### PR TITLE
merge up 3.10.3

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -119,7 +119,6 @@ stages:
               VS_VER=2022
 
               echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
-
               PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 2 \
                   --maxfail=50 --timeout=300 --durations=25 \
                   --junitxml=junit/test-results.xml --cov-report=xml --cov=lib

--- a/doc/_static/mpl.css
+++ b/doc/_static/mpl.css
@@ -220,3 +220,15 @@ div.wide-table table th.stub {
 .sidebar-cheatsheets > img {
     width: 100%;
 }
+
+.sidebar-cheatsheets {
+    margin-bottom: 3em;
+}
+
+.sidebar-cheatsheets > h3 {
+    margin-top: 0;
+}
+
+.sidebar-cheatsheets > img {
+    width: 100%;
+}

--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.10 (stable)",
-        "version": "3.10.1",
+        "version": "3.10.3",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },

--- a/doc/users/github_stats.rst
+++ b/doc/users/github_stats.rst
@@ -1,174 +1,147 @@
 .. _github-stats:
 
-GitHub statistics for 3.10.1 (Feb 27, 2025)
+GitHub statistics for 3.10.3 (May 08, 2025)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/02/27
+GitHub statistics for 2025/02/27 (tag: v3.10.1) - 2025/05/08
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 14 issues and merged 107 pull requests.
-The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/98?closed=1>`__
+We closed 16 issues and merged 78 pull requests.
+The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/101?closed=1>`__
 
-The following 28 authors contributed 241 commits.
+The following 28 authors contributed 128 commits.
 
-* Anselm Hahn
+* Alexandra Khoo
 * Antony Lee
-* Ben Greiner
-* Chaoyi Hu
-* Christine P. Chai
-* dependabot[bot]
+* Carlos Ramos Carreño
+* David Lowry-Duda
+* David Stansby
+* DerWeh
 * Elliott Sales de Andrade
-* G.D. McBain
-* Greg Lucas
+* guillermodotn
 * hannah
-* hu-xiaonan
-* Khushi_29
-* Khushikela29
-* KIU Shueng Chuan
-* Kyle Martin
+* Hassan Kibirige
+* Ian Thomas
+* James Addison
+* Jody Klymak
 * Kyle Sunden
-* Lumberbot (aka Jack)
-* Manthan Nagvekar
-* musvaage
-* Nathan G. Wiseman
+* Marten H. van Kerkwijk
+* Marten Henric van Kerkwijk
+* martincornejo
+* Mateusz Sokół
+* Nicolai Weitkemper
 * Oscar Gustafsson
-* Owl
+* Praful Gulani
+* prafulgulani555
+* Qian Zhang
+* Raphael Erik Hviding
 * Ruth Comer
-* saikarna913
-* Scott Shambaugh
 * Thomas A Caswell
 * Tim Hoffmann
-* Trygve Magnus Ræder
+* Weh Andreas
 
 GitHub issues and pull requests:
 
-Pull Requests (107):
+Pull Requests (78):
 
-* :ghpull:`29682`: Backport PR #29680 on branch v3.10.x (DOC: fix the bug of examples\event_handling)
-* :ghpull:`29683`: Backport PR #29670 on branch v3.10.x (DOC: change marginal scatter plot to subplot_mosaic)
-* :ghpull:`29680`: DOC: fix the bug of examples\event_handling
-* :ghpull:`29676`: Backport PR #29666 on branch v3.10.x (DOC: Revising the Figure Legend Demo Example)
-* :ghpull:`29675`: Backport PR #29662 on branch v3.10.x (DOC: Move Colorbar parameters to __init__)
-* :ghpull:`29662`: DOC: Move Colorbar parameters to __init__
-* :ghpull:`29668`: Backport PR #29667 on branch v3.10.x (DOC: remove redundant gridspec from example)
-* :ghpull:`29664`: Backport PR #29642 on branch v3.10.x (DOC: Add docstrings to get_usetex and set_usetex in ticker.py)
-* :ghpull:`29663`: Backport PR #29075 on branch v3.10.x (Add xaxis and yaxis attributes to Axes docs)
-* :ghpull:`29642`: DOC: Add docstrings to get_usetex and set_usetex in ticker.py
-* :ghpull:`29661`: Backport PR #29652 on branch v3.10.x (Reorder kwonly kwargs in Colorbar & related docs.)
-* :ghpull:`29652`: Reorder kwonly kwargs in Colorbar & related docs.
-* :ghpull:`29075`: Add xaxis and yaxis attributes to Axes docs
-* :ghpull:`29656`: Backport PR #28437 on branch v3.10.x (Respect array alpha with interpolation_stage='rgba' in _Imagebase::_make_image)
-* :ghpull:`29448`: Backport PR #29362 on branch v3.10.0-doc (TYP: semantics of enums in stub files changed)
-* :ghpull:`28437`: Respect array alpha with interpolation_stage='rgba' in _Imagebase::_make_image
-* :ghpull:`29651`: Backport PR #29650 on branch v3.10.x (Copy-edit "interactive figures & async programming" guide.)
-* :ghpull:`29650`: Copy-edit "interactive figures & async programming" guide.
-* :ghpull:`29633`: Backport PR #29631 on branch v3.10.x (Add inline notebook to test data)
-* :ghpull:`29631`: Add inline notebook to test data
-* :ghpull:`29627`: Backport PR #29617 on branch v3.10.x (DOC: Add docstrings to matplotlib.cbook.GrouperView)
-* :ghpull:`29617`: DOC: Add docstrings to matplotlib.cbook.GrouperView
-* :ghpull:`29625`: Backport PR #29622 on branch v3.10.x (DOC: Move "Infinite lines" example from section "pyplot" to "Lines, bars and markers)
-* :ghpull:`29623`: Backport PR #29621 on branch v3.10.x (DOC: Cleanup text rotation in data coordinates example)
-* :ghpull:`29619`: Backport PR #29616 on branch v3.10.x (FIX: Fix unit example so that we can unpin numpy<2.1)
-* :ghpull:`29616`: FIX: Fix unit example so that we can unpin numpy<2.1
-* :ghpull:`29611`: Backport PR #29608 on branch v3.10.x (Remove md5 usage to prevent issues on FIPS enabled systems (closes #29603))
-* :ghpull:`29608`: Remove md5 usage to prevent issues on FIPS enabled systems (closes #29603)
-* :ghpull:`29609`: Backport PR #29607 on branch v3.10.x (Correct doc for axvline arg x which sets x not y)
-* :ghpull:`29604`: Backport PR #29601 on branch v3.10.x (DOC: Duplicate categorical values are mapped to the same position)
-* :ghpull:`29598`: Backport PR #29597 on branch v3.10.x (Fix typo in deprecation notes for 3.10.0)
-* :ghpull:`29591`: Backport PR #29585 on branch v3.10.x (DOC: Document that tight_layout may not converge)
-* :ghpull:`29585`: DOC: Document that tight_layout may not converge
-* :ghpull:`29587`: Backport PR #25801 on branch v3.10.x (Remove some examples from Userdemo)
-* :ghpull:`29577`: Backport PR #29576 on branch v3.10.x (Remove documentation for no-longer existent ContourSet attributes.)
-* :ghpull:`29576`: Remove documentation for no-longer existent ContourSet attributes.
-* :ghpull:`29530`: Bump the actions group with 5 updates
-* :ghpull:`29564`: Backport PR #29563 on branch v3.10.x (DOC: add color sequences reference example)
-* :ghpull:`29563`: DOC: add color sequences reference example
-* :ghpull:`29557`: Backport PR #29518: TST: Increase tolerance on more arches
-* :ghpull:`29555`: Backport PR #29546 on branch v3.10.x (FIX: pyplot.matshow figure handling)
-* :ghpull:`29546`: FIX: pyplot.matshow figure handling
-* :ghpull:`29518`: TST: Increase tolerance on more arches
-* :ghpull:`29547`: Backport PR #29543 on branch v3.10.x (DOC: Minor improvement on broken_barh())
-* :ghpull:`29538`: Backport PR #29536 on branch v3.10.x (Fix typo in solarized example plot.)
-* :ghpull:`29531`: Backport PR #29520 on branch v3.10.x (FIX: Correct variable name from _frame to _frames in PillowWriter class)
-* :ghpull:`29520`: FIX: Correct variable name from _frame to _frames in PillowWriter class
-* :ghpull:`29521`: Backport PR #29509 on branch v3.10.x (MNT: Discourage arrow())
-* :ghpull:`29509`: MNT: Discourage arrow()
-* :ghpull:`29514`: Backport PR #29511 on branch v3.10.x (DOC: Document the behavior of bar() for categorical x data)
-* :ghpull:`29513`: Backport PR #29471 on branch v3.10.x (Fix subplot docs)
-* :ghpull:`29511`: DOC: Document the behavior of bar() for categorical x data
-* :ghpull:`29471`: Fix subplot docs
-* :ghpull:`29500`: Backport PR #29478 on branch v3.10.x (DOC: Added blurb for colorizer objects in what's new for 3.10)
-* :ghpull:`29498`: Backport PR #29488 on branch v3.10.x (DOC: Update broken_barh example)
-* :ghpull:`29490`: Backport PR #29476 on branch v3.10.x (ci: Enable native ARM builders for wheels)
-* :ghpull:`29476`: ci: Enable native ARM builders for wheels
-* :ghpull:`29462`: Backport PR #29404 on branch v3.10.x (DOC: scales - built in options and custom scale usefulness)
-* :ghpull:`29459`: Backport PR #29456 on branch v3.10.x (DOC: Fix type descriptions in fill_between docstring)
-* :ghpull:`29404`: DOC: scales - built in options and custom scale usefulness
-* :ghpull:`29458`: Backport PR #29457 on branch v3.10.x (DOC: Use float instead for scalar for type descriptions in docstrings)
-* :ghpull:`29456`: DOC: Fix type descriptions in fill_between docstring
-* :ghpull:`29457`: DOC: Use float instead for scalar for type descriptions in docstrings
-* :ghpull:`29452`: Backport PR #29411 on branch v3.10.x (fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization)
-* :ghpull:`29411`: fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization
-* :ghpull:`29451`: Backport PR #29449 on branch v3.10.x (ci: Install libnotify4 on all Ubuntu)
-* :ghpull:`29449`: ci: Install libnotify4 on all Ubuntu
-* :ghpull:`29444`: Backport PR #29442 on branch v3.10.x (DOC: put section headings in 3.10 what's new)
-* :ghpull:`29436`: Backport PR #29407 on branch v3.10.x (DOC: Improve log scale example)
-* :ghpull:`29432`: Backport PR #29431 on branch v3.10.x (ft2font: Split named instance count from style flags)
-* :ghpull:`29431`: ft2font: Split named instance count from style flags
-* :ghpull:`29423`: Backport PR #29130 on branch v3.10.x (Raise warning if both c and facecolors are used in scatter plot (... and related improvements in the test suite).)
-* :ghpull:`29420`: Backport PR #29406 on branch v3.10.x (DOC: Update scales overview)
-* :ghpull:`29417`: Backport PR #29409 on branch v3.10.x (Fixed test case(test_axes.py) failing on ppc64le)
-* :ghpull:`29416`: Backport PR #29382 on branch v3.10.x (Fix title position for polar plots)
-* :ghpull:`29382`: Fix title position for polar plots
-* :ghpull:`29412`: Backport PR #29363 on branch v3.10.x (FIX: Add version gate to GTK4 calls when necessary)
-* :ghpull:`29409`: Fixed test case(test_axes.py) failing on ppc64le
-* :ghpull:`29363`: FIX: Add version gate to GTK4 calls when necessary
-* :ghpull:`29408`: Backport PR #29401 on branch v3.10.x (FIX: add errorbars with ``add_container``)
-* :ghpull:`29401`: FIX: add errorbars with ``add_container``
-* :ghpull:`29130`: Raise warning if both c and facecolors are used in scatter plot (... and related improvements in the test suite).
-* :ghpull:`29390`: Backport PR #29389 on branch v3.10.x (DOC: Minor improvements on VPacker, HPacker, PaddedBox docs)
-* :ghpull:`29389`: DOC: Minor improvements on VPacker, HPacker, PaddedBox docs
-* :ghpull:`29371`: Backport PR #29353 on branch v3.10.x (DOC: Improve module docs of matplotlib.scale)
-* :ghpull:`29361`: Backport PR #29355 on branch v3.10.x (Add QtCore.Slot() decorations to FigureCanvasQT)
-* :ghpull:`29369`: Backport PR #29362 on branch v3.10.x (TYP: semantics of enums in stub files changed)
-* :ghpull:`29353`: DOC: Improve module docs of matplotlib.scale
-* :ghpull:`29362`: TYP: semantics of enums in stub files changed
-* :ghpull:`29365`: Backport PR #29364 on branch v3.10.x (fix typo)
-* :ghpull:`29366`: Backport PR #29347 on branch v3.10.x (DOC: Explain parameters linthresh and linscale of symlog scale)
-* :ghpull:`29364`: fix typo
-* :ghpull:`29355`: Add QtCore.Slot() decorations to FigureCanvasQT
-* :ghpull:`29351`: Backport PR #29348 on branch v3.10.x (DOC: Cleanup scales examples)
-* :ghpull:`29336`: Backport PR #29328 on branch v3.10.x (Bump github/codeql-action from 3.27.6 to 3.27.9 in the actions group)
-* :ghpull:`29328`: Bump github/codeql-action from 3.27.6 to 3.27.9 in the actions group
-* :ghpull:`29330`: Backport PR #29321 on branch v3.10.x (DOC: List min. Python version for Matplotlib 3.10)
-* :ghpull:`29324`: Backport PR #29258 on branch v3.10.x (Adding font Size as default parameter)
-* :ghpull:`29326`: Backport PR #29323 on branch v3.10.x (DOC: Don't put quotes around coordinate system names)
-* :ghpull:`29323`: DOC: Don't put quotes around coordinate system names
-* :ghpull:`29258`: Adding font Size as default parameter
-* :ghpull:`29320`: Backport PR #29317 on branch v3.10.x (FIX: pass renderer through ``_auto_legend_data``)
-* :ghpull:`29317`: FIX: pass renderer through ``_auto_legend_data``
-* :ghpull:`29315`: Backport PR #29314 on branch v3.10.x (DOC: fix footnote in choosing colormaps guide)
-* :ghpull:`29309`: Backport PR #29308 on branch v3.10.x (Update cibuildwheel workflow)
-* :ghpull:`29310`: Backport PR #29292 on branch v3.10.x (Update dependencies.rst)
-* :ghpull:`29308`: Update cibuildwheel workflow
+* :ghpull:`30018`: Backport PR #29907 on branch v3.10.x (Ensure text metric calculation always uses the text cache)
+* :ghpull:`30010`: Backport PR #29992 on v3.10.x: Update pinned oldest win image on azure
+* :ghpull:`29992`: Update pinned oldest win image on azure
+* :ghpull:`29867`: Backport PR #29827 on branch v3.10.x (TST: Remove unnecessary test images)
+* :ghpull:`30002`: Backport PR #29673 on branch v3.10.x (DOC: document the issues with overlaying new mpl on old mpl)
+* :ghpull:`29673`: DOC: document the issues with overlaying new mpl on old mpl
+* :ghpull:`29999`: Backport PR #29997 on branch v3.10.x (BLD: Ensure meson.build has the right version of Python)
+* :ghpull:`29997`: BLD: Ensure meson.build has the right version of Python
+* :ghpull:`29996`: Backport PR #29995 on branch v3.10.x (Fix typo: missing singlequote in unrecognized backend exception)
+* :ghpull:`29995`: Fix typo: missing singlequote in unrecognized backend exception
+* :ghpull:`29990`: Backport PR #29789 on branch v3.10.x (Improve layout of cheatsheets in sidebar)
+* :ghpull:`29987`: Backport PR #29370 on branch v3.10.x (DOC: Improve NonUniformImage docs)
+* :ghpull:`29370`: DOC: Improve NonUniformImage docs
+* :ghpull:`29983`: Backport PR #29975 on branch v3.10.x (DOC: correct signature for animation update function in rain example)
+* :ghpull:`29974`: Backport PR #29970 on branch v3.10.x (TST: Make refcount tests more resilient to Python changes)
+* :ghpull:`29975`: DOC: correct signature for animation update function in rain example
+* :ghpull:`29980`: Backport PR #29979 on branch v3.10.x (Fix typos: horizonatal -> horizontal)
+* :ghpull:`29979`: Fix typos: horizonatal -> horizontal
+* :ghpull:`29970`: TST: Make refcount tests more resilient to Python changes
+* :ghpull:`29969`: Backport PR #29965 on branch v3.10.x (Document Axes.spines)
+* :ghpull:`29965`: Document Axes.spines
+* :ghpull:`29949`: Backport PR #29796 on branch v3.10.x: ci: rotate soon-to-be-unsupported GitHub Actions ubuntu-20.04 runner out of roster
+* :ghpull:`29901`: Backport PR #29872 on branch v3.10.x (TST: Use placeholders for text in layout tests)
+* :ghpull:`29933`: Backport PR #29931 on branch v3.10.x (Allow Python native sequences in Matplotlib ``imsave()``.)
+* :ghpull:`29943`: Fix doc build on 3.10.x
+* :ghpull:`29940`: Backport PR #29919 on branch v3.10.x (Handle MOVETO's, CLOSEPOLY's and empty paths in Path.interpolated)
+* :ghpull:`29919`: Handle MOVETO's, CLOSEPOLY's and empty paths in Path.interpolated
+* :ghpull:`29908`: TST: Use text placeholders for empty legends
+* :ghpull:`29931`: Allow Python native sequences in Matplotlib ``imsave()``.
+* :ghpull:`29932`: Backport PR #29920 on branch v3.10.x (Allow ``None`` in set_prop_cycle (in type hints))
+* :ghpull:`29920`: Allow ``None`` in set_prop_cycle (in type hints)
+* :ghpull:`29927`: Backport PR #29897 on branch v3.10.x (BUG: ensure that errorbar does not error on masked negative errors.)
+* :ghpull:`29930`: Backport PR #29929 on branch v3.10.x (Correct rightparen typo)
+* :ghpull:`29929`: Correct rightparen typo
+* :ghpull:`29897`: BUG: ensure that errorbar does not error on masked negative errors.
+* :ghpull:`29907`: Ensure text metric calculation always uses the text cache
+* :ghpull:`29902`: Backport PR #29899 on branch v3.10.x ([doc] minimally document what basic units is doing)
+* :ghpull:`29900`: Backport PR #29896 on branch v3.10.x (Change ``.T`` to ``.transpose()`` in ``_reshape_2D``)
+* :ghpull:`29872`: TST: Use placeholders for text in layout tests
+* :ghpull:`29896`: Change ``.T`` to ``.transpose()`` in ``_reshape_2D``
+* :ghpull:`29888`: Backport PR #29803 on branch v3.10.x (DOC: Improve FancyArrowPatch docstring)
+* :ghpull:`29880`: Backport PR #29853 on branch v3.10.x (Update lib/matplotlib/stackplot.py)
+* :ghpull:`29853`: Update lib/matplotlib/stackplot.py
+* :ghpull:`29868`: Backport PR #29834 on branch v3.10.x (TST: pin flake8)
+* :ghpull:`29827`: TST: Remove unnecessary test images
+* :ghpull:`29861`: Backport PR #29773 on branch v3.10.x (DOC: Improve interactive figures guide / Blocking input)
+* :ghpull:`29859`: Backport PR #29545 on branch v3.10.x (DOC: correctly specify return type of ``figaspect``)
+* :ghpull:`29545`: DOC: correctly specify return type of ``figaspect``
+* :ghpull:`29858`: Backport PR #29842 on branch v3.10.x (Don't drag draggables on scroll events)
+* :ghpull:`29842`: Don't drag draggables on scroll events
+* :ghpull:`29848`: Backport PR #29839 on branch v3.10.x (Improve docs regarding plt.close().)
+* :ghpull:`29839`: Improve docs regarding plt.close().
+* :ghpull:`29818`: Backport PR #29801 on branch v3.10.x (DOC: Slightly further improve arrowstyle demo)
+* :ghpull:`29814`: Backport PR #29552 on branch v3.10.x (Bug Fix: Normalize kwargs for Histogram)
+* :ghpull:`29792`: Backport PR #29770 on branch v3.10.x (MNT: Move test for old ipython behavior to minver tests)
+* :ghpull:`29750`: Backport PR #29748 on branch v3.10.x (Fix PyGObject version pinning in macOS tests)
+* :ghpull:`29754`: Backport PR #29721 on branch v3.10.x (FIX: pyplot auto-backend detection case-sensitivity fixup)
+* :ghpull:`29786`: Backport PR #29755 on branch v3.10.x (DOC: Simplify annotation arrow style reference)
+* :ghpull:`29784`: Backport PR #29781 on branch v3.10.x (Fix escaping of nulls and "0" in default filenames.)
+* :ghpull:`29781`: Fix escaping of nulls and "0" in default filenames.
+* :ghpull:`29771`: Backport PR #29752 on branch v3.10.x (DOC: Add install instructions for pixi and uv)
+* :ghpull:`29768`: Backport PR #29767 on branch v3.10.x (Add description to logit_demo.py script)
+* :ghpull:`29721`: FIX: pyplot auto-backend detection case-sensitivity fixup
+* :ghpull:`29737`: Backport PR #29734 on branch v3.10.x (ci: MacOS 14: temporarily upper-bound the 'PyGObject' Python package version)
+* :ghpull:`29735`: Backport PR #29719 on branch v3.10.x (Fix passing singleton sequence-type styles to hist)
+* :ghpull:`29719`: Fix passing singleton sequence-type styles to hist
+* :ghpull:`29730`: Backport PR #29724 on branch v3.10.x (Fix SubplotSpec.get_gridspec type hint)
+* :ghpull:`29724`: Fix SubplotSpec.get_gridspec type hint
+* :ghpull:`29727`: Backport PR #29726 on branch v3.10.x (Add reference tag to Hatch style reference)
+* :ghpull:`29709`: Backport PR #29708 on branch v3.10.x (MNT: correct version in plotting method deprecation warnings)
+* :ghpull:`29708`: MNT: correct version in plotting method deprecation warnings
+* :ghpull:`29692`: Backport PR #29689 on branch v3.10.x (Fix alt and caption handling in Sphinx directives)
+* :ghpull:`29693`: Backport PR #29590 on branch v3.10.x (Blocked set_clim() callbacks to prevent inconsistent state (#29522))
+* :ghpull:`29590`: Blocked set_clim() callbacks to prevent inconsistent state (#29522)
+* :ghpull:`29689`: Fix alt and caption handling in Sphinx directives
+* :ghpull:`29691`: Backport PR #29584 on branch v3.10.x (DOC: Recommend constrained_layout over tight_layout)
+* :ghpull:`29584`: DOC: Recommend constrained_layout over tight_layout
+* :ghpull:`29552`: Bug Fix: Normalize kwargs for Histogram
 
-Issues (14):
+Issues (16):
 
-* :ghissue:`28382`: [Bug]: interpolation_stage="rgba" does not respect array-alpha
-* :ghissue:`28780`: Doc build fails with numpy>=2.1.0
-* :ghissue:`29603`: [Bug]: Setting ``text.usetex=True`` in ``pyplot.rcParams`` Raises FIPS Compliance Errors
-* :ghissue:`29575`: [Doc]: QuadContourSet does not contain a collections attribute like stated in the manual
-* :ghissue:`29519`: [Bug]:  'PillowWriter' object has no attribute '_frame' shouldn't be  '_frames'?
-* :ghissue:`29507`: [Bug]: Duplicating the labels in the ``height``/``width`` argument in ``barh()``/``bar`` leads to undrawn bars
-* :ghissue:`29447`: [Doc]: ``subplot`` behavior is not same as the doc reads in 3.10(stable)
-* :ghissue:`29410`: [Bug]: Modifying Axes' position also alters the original Bbox object used for initialization
-* :ghissue:`29396`: [Bug]: Style flag errors trying to save figures as PDF with font Inter
-* :ghissue:`29381`: [Bug]: title position incorrect for polar plot
-* :ghissue:`29350`: [Bug]: Matplotlib causes segmentation fault when hovering mouse over graph
-* :ghissue:`25274`: [Bug]: .remove() on ErrorbarContainer object does not remove the corresponding item from the legend
-* :ghissue:`29202`: [Bug]: ``fontsize`` in tables not working
-* :ghissue:`29301`: [Bug]: Blank EPS output with legend and annotate
+* :ghissue:`29183`: [Bug]: I give an RGB image to imsave but I don't have the right color map!
+* :ghissue:`29797`: [MNT]: Flaky Windows_py31x tests on Azure Pipelines
+* :ghissue:`26827`: [Bug]: ImportError when using Matplotlib v3.8.0 in Python package tests
+* :ghissue:`29964`: [Doc]: object description for "spines"of matplot.axes.Axes not found
+* :ghissue:`29917`: [Bug]: Contour plots using mollweide-projection
+* :ghissue:`29540`: [Bug]: matshow(..., fignum=...) broken
+* :ghissue:`29142`: [MNT]: Draggable legend gets stuck on cursor after scroll event
+* :ghissue:`29857`: [Bug]: Unexpected behavior of the line style specifiers in the histogram method
+* :ghissue:`29766`: [MNT]: ci: ubuntu-20.04 GitHub Actions runner will soon be unmaintained
+* :ghissue:`29812`: [MNT]: Backport request for #29552 to 3.10.x
+* :ghissue:`29779`: [Bug]: get_default_filename removes '0' from file name instead of '\0' from window title
+* :ghissue:`29713`: [Bug]: Matplotlib selects TkAgg backend on LXC containers
+* :ghissue:`29717`: [Bug]: Using a linestyle tuple with a histogram crashes with matplotlib 3.10
+* :ghissue:`29522`: [Bug]: Image color limits not correctly updated with set_clim() IFF color bar present AND new norm.vmin > old norm.vmax
+* :ghissue:`17339`: Clarify that constrained_layout and tight_layout conflict with each other
+* :ghissue:`28884`: [ENH]: Expand ``hist()`` signature to support aliases and plural kwargs
 
 
 Previous GitHub statistics

--- a/doc/users/prev_whats_new/github_stats_3.10.1.rst
+++ b/doc/users/prev_whats_new/github_stats_3.10.1.rst
@@ -1,0 +1,171 @@
+.. _github-stats-3_10_1:
+
+GitHub statistics for 3.10.1 (Feb 27, 2025)
+===========================================
+
+GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/02/27
+
+These lists are automatically generated, and may be incomplete or contain duplicates.
+
+We closed 14 issues and merged 107 pull requests.
+The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/98?closed=1>`__
+
+The following 28 authors contributed 241 commits.
+
+* Anselm Hahn
+* Antony Lee
+* Ben Greiner
+* Chaoyi Hu
+* Christine P. Chai
+* dependabot[bot]
+* Elliott Sales de Andrade
+* G.D. McBain
+* Greg Lucas
+* hannah
+* hu-xiaonan
+* Khushi_29
+* Khushikela29
+* KIU Shueng Chuan
+* Kyle Martin
+* Kyle Sunden
+* Lumberbot (aka Jack)
+* Manthan Nagvekar
+* musvaage
+* Nathan G. Wiseman
+* Oscar Gustafsson
+* Owl
+* Ruth Comer
+* saikarna913
+* Scott Shambaugh
+* Thomas A Caswell
+* Tim Hoffmann
+* Trygve Magnus Ræder
+
+GitHub issues and pull requests:
+
+Pull Requests (107):
+
+* :ghpull:`29682`: Backport PR #29680 on branch v3.10.x (DOC: fix the bug of examples\event_handling)
+* :ghpull:`29683`: Backport PR #29670 on branch v3.10.x (DOC: change marginal scatter plot to subplot_mosaic)
+* :ghpull:`29680`: DOC: fix the bug of examples\event_handling
+* :ghpull:`29676`: Backport PR #29666 on branch v3.10.x (DOC: Revising the Figure Legend Demo Example)
+* :ghpull:`29675`: Backport PR #29662 on branch v3.10.x (DOC: Move Colorbar parameters to __init__)
+* :ghpull:`29662`: DOC: Move Colorbar parameters to __init__
+* :ghpull:`29668`: Backport PR #29667 on branch v3.10.x (DOC: remove redundant gridspec from example)
+* :ghpull:`29664`: Backport PR #29642 on branch v3.10.x (DOC: Add docstrings to get_usetex and set_usetex in ticker.py)
+* :ghpull:`29663`: Backport PR #29075 on branch v3.10.x (Add xaxis and yaxis attributes to Axes docs)
+* :ghpull:`29642`: DOC: Add docstrings to get_usetex and set_usetex in ticker.py
+* :ghpull:`29661`: Backport PR #29652 on branch v3.10.x (Reorder kwonly kwargs in Colorbar & related docs.)
+* :ghpull:`29652`: Reorder kwonly kwargs in Colorbar & related docs.
+* :ghpull:`29075`: Add xaxis and yaxis attributes to Axes docs
+* :ghpull:`29656`: Backport PR #28437 on branch v3.10.x (Respect array alpha with interpolation_stage='rgba' in _Imagebase::_make_image)
+* :ghpull:`29448`: Backport PR #29362 on branch v3.10.0-doc (TYP: semantics of enums in stub files changed)
+* :ghpull:`28437`: Respect array alpha with interpolation_stage='rgba' in _Imagebase::_make_image
+* :ghpull:`29651`: Backport PR #29650 on branch v3.10.x (Copy-edit "interactive figures & async programming" guide.)
+* :ghpull:`29650`: Copy-edit "interactive figures & async programming" guide.
+* :ghpull:`29633`: Backport PR #29631 on branch v3.10.x (Add inline notebook to test data)
+* :ghpull:`29631`: Add inline notebook to test data
+* :ghpull:`29627`: Backport PR #29617 on branch v3.10.x (DOC: Add docstrings to matplotlib.cbook.GrouperView)
+* :ghpull:`29617`: DOC: Add docstrings to matplotlib.cbook.GrouperView
+* :ghpull:`29625`: Backport PR #29622 on branch v3.10.x (DOC: Move "Infinite lines" example from section "pyplot" to "Lines, bars and markers)
+* :ghpull:`29623`: Backport PR #29621 on branch v3.10.x (DOC: Cleanup text rotation in data coordinates example)
+* :ghpull:`29619`: Backport PR #29616 on branch v3.10.x (FIX: Fix unit example so that we can unpin numpy<2.1)
+* :ghpull:`29616`: FIX: Fix unit example so that we can unpin numpy<2.1
+* :ghpull:`29611`: Backport PR #29608 on branch v3.10.x (Remove md5 usage to prevent issues on FIPS enabled systems (closes #29603))
+* :ghpull:`29608`: Remove md5 usage to prevent issues on FIPS enabled systems (closes #29603)
+* :ghpull:`29609`: Backport PR #29607 on branch v3.10.x (Correct doc for axvline arg x which sets x not y)
+* :ghpull:`29604`: Backport PR #29601 on branch v3.10.x (DOC: Duplicate categorical values are mapped to the same position)
+* :ghpull:`29598`: Backport PR #29597 on branch v3.10.x (Fix typo in deprecation notes for 3.10.0)
+* :ghpull:`29591`: Backport PR #29585 on branch v3.10.x (DOC: Document that tight_layout may not converge)
+* :ghpull:`29585`: DOC: Document that tight_layout may not converge
+* :ghpull:`29587`: Backport PR #25801 on branch v3.10.x (Remove some examples from Userdemo)
+* :ghpull:`29577`: Backport PR #29576 on branch v3.10.x (Remove documentation for no-longer existent ContourSet attributes.)
+* :ghpull:`29576`: Remove documentation for no-longer existent ContourSet attributes.
+* :ghpull:`29530`: Bump the actions group with 5 updates
+* :ghpull:`29564`: Backport PR #29563 on branch v3.10.x (DOC: add color sequences reference example)
+* :ghpull:`29563`: DOC: add color sequences reference example
+* :ghpull:`29557`: Backport PR #29518: TST: Increase tolerance on more arches
+* :ghpull:`29555`: Backport PR #29546 on branch v3.10.x (FIX: pyplot.matshow figure handling)
+* :ghpull:`29546`: FIX: pyplot.matshow figure handling
+* :ghpull:`29518`: TST: Increase tolerance on more arches
+* :ghpull:`29547`: Backport PR #29543 on branch v3.10.x (DOC: Minor improvement on broken_barh())
+* :ghpull:`29538`: Backport PR #29536 on branch v3.10.x (Fix typo in solarized example plot.)
+* :ghpull:`29531`: Backport PR #29520 on branch v3.10.x (FIX: Correct variable name from _frame to _frames in PillowWriter class)
+* :ghpull:`29520`: FIX: Correct variable name from _frame to _frames in PillowWriter class
+* :ghpull:`29521`: Backport PR #29509 on branch v3.10.x (MNT: Discourage arrow())
+* :ghpull:`29509`: MNT: Discourage arrow()
+* :ghpull:`29514`: Backport PR #29511 on branch v3.10.x (DOC: Document the behavior of bar() for categorical x data)
+* :ghpull:`29513`: Backport PR #29471 on branch v3.10.x (Fix subplot docs)
+* :ghpull:`29511`: DOC: Document the behavior of bar() for categorical x data
+* :ghpull:`29471`: Fix subplot docs
+* :ghpull:`29500`: Backport PR #29478 on branch v3.10.x (DOC: Added blurb for colorizer objects in what's new for 3.10)
+* :ghpull:`29498`: Backport PR #29488 on branch v3.10.x (DOC: Update broken_barh example)
+* :ghpull:`29490`: Backport PR #29476 on branch v3.10.x (ci: Enable native ARM builders for wheels)
+* :ghpull:`29476`: ci: Enable native ARM builders for wheels
+* :ghpull:`29462`: Backport PR #29404 on branch v3.10.x (DOC: scales - built in options and custom scale usefulness)
+* :ghpull:`29459`: Backport PR #29456 on branch v3.10.x (DOC: Fix type descriptions in fill_between docstring)
+* :ghpull:`29404`: DOC: scales - built in options and custom scale usefulness
+* :ghpull:`29458`: Backport PR #29457 on branch v3.10.x (DOC: Use float instead for scalar for type descriptions in docstrings)
+* :ghpull:`29456`: DOC: Fix type descriptions in fill_between docstring
+* :ghpull:`29457`: DOC: Use float instead for scalar for type descriptions in docstrings
+* :ghpull:`29452`: Backport PR #29411 on branch v3.10.x (fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization)
+* :ghpull:`29411`: fix #29410 Modifying Axes' position also alters the original Bbox object used for initialization
+* :ghpull:`29451`: Backport PR #29449 on branch v3.10.x (ci: Install libnotify4 on all Ubuntu)
+* :ghpull:`29449`: ci: Install libnotify4 on all Ubuntu
+* :ghpull:`29444`: Backport PR #29442 on branch v3.10.x (DOC: put section headings in 3.10 what's new)
+* :ghpull:`29436`: Backport PR #29407 on branch v3.10.x (DOC: Improve log scale example)
+* :ghpull:`29432`: Backport PR #29431 on branch v3.10.x (ft2font: Split named instance count from style flags)
+* :ghpull:`29431`: ft2font: Split named instance count from style flags
+* :ghpull:`29423`: Backport PR #29130 on branch v3.10.x (Raise warning if both c and facecolors are used in scatter plot (... and related improvements in the test suite).)
+* :ghpull:`29420`: Backport PR #29406 on branch v3.10.x (DOC: Update scales overview)
+* :ghpull:`29417`: Backport PR #29409 on branch v3.10.x (Fixed test case(test_axes.py) failing on ppc64le)
+* :ghpull:`29416`: Backport PR #29382 on branch v3.10.x (Fix title position for polar plots)
+* :ghpull:`29382`: Fix title position for polar plots
+* :ghpull:`29412`: Backport PR #29363 on branch v3.10.x (FIX: Add version gate to GTK4 calls when necessary)
+* :ghpull:`29409`: Fixed test case(test_axes.py) failing on ppc64le
+* :ghpull:`29363`: FIX: Add version gate to GTK4 calls when necessary
+* :ghpull:`29408`: Backport PR #29401 on branch v3.10.x (FIX: add errorbars with ``add_container``)
+* :ghpull:`29401`: FIX: add errorbars with ``add_container``
+* :ghpull:`29130`: Raise warning if both c and facecolors are used in scatter plot (... and related improvements in the test suite).
+* :ghpull:`29390`: Backport PR #29389 on branch v3.10.x (DOC: Minor improvements on VPacker, HPacker, PaddedBox docs)
+* :ghpull:`29389`: DOC: Minor improvements on VPacker, HPacker, PaddedBox docs
+* :ghpull:`29371`: Backport PR #29353 on branch v3.10.x (DOC: Improve module docs of matplotlib.scale)
+* :ghpull:`29361`: Backport PR #29355 on branch v3.10.x (Add QtCore.Slot() decorations to FigureCanvasQT)
+* :ghpull:`29369`: Backport PR #29362 on branch v3.10.x (TYP: semantics of enums in stub files changed)
+* :ghpull:`29353`: DOC: Improve module docs of matplotlib.scale
+* :ghpull:`29362`: TYP: semantics of enums in stub files changed
+* :ghpull:`29365`: Backport PR #29364 on branch v3.10.x (fix typo)
+* :ghpull:`29366`: Backport PR #29347 on branch v3.10.x (DOC: Explain parameters linthresh and linscale of symlog scale)
+* :ghpull:`29364`: fix typo
+* :ghpull:`29355`: Add QtCore.Slot() decorations to FigureCanvasQT
+* :ghpull:`29351`: Backport PR #29348 on branch v3.10.x (DOC: Cleanup scales examples)
+* :ghpull:`29336`: Backport PR #29328 on branch v3.10.x (Bump github/codeql-action from 3.27.6 to 3.27.9 in the actions group)
+* :ghpull:`29328`: Bump github/codeql-action from 3.27.6 to 3.27.9 in the actions group
+* :ghpull:`29330`: Backport PR #29321 on branch v3.10.x (DOC: List min. Python version for Matplotlib 3.10)
+* :ghpull:`29324`: Backport PR #29258 on branch v3.10.x (Adding font Size as default parameter)
+* :ghpull:`29326`: Backport PR #29323 on branch v3.10.x (DOC: Don't put quotes around coordinate system names)
+* :ghpull:`29323`: DOC: Don't put quotes around coordinate system names
+* :ghpull:`29258`: Adding font Size as default parameter
+* :ghpull:`29320`: Backport PR #29317 on branch v3.10.x (FIX: pass renderer through ``_auto_legend_data``)
+* :ghpull:`29317`: FIX: pass renderer through ``_auto_legend_data``
+* :ghpull:`29315`: Backport PR #29314 on branch v3.10.x (DOC: fix footnote in choosing colormaps guide)
+* :ghpull:`29309`: Backport PR #29308 on branch v3.10.x (Update cibuildwheel workflow)
+* :ghpull:`29310`: Backport PR #29292 on branch v3.10.x (Update dependencies.rst)
+* :ghpull:`29308`: Update cibuildwheel workflow
+
+Issues (14):
+
+* :ghissue:`28382`: [Bug]: interpolation_stage="rgba" does not respect array-alpha
+* :ghissue:`28780`: Doc build fails with numpy>=2.1.0
+* :ghissue:`29603`: [Bug]: Setting ``text.usetex=True`` in ``pyplot.rcParams`` Raises FIPS Compliance Errors
+* :ghissue:`29575`: [Doc]: QuadContourSet does not contain a collections attribute like stated in the manual
+* :ghissue:`29519`: [Bug]:  'PillowWriter' object has no attribute '_frame' shouldn't be  '_frames'?
+* :ghissue:`29507`: [Bug]: Duplicating the labels in the ``height``/``width`` argument in ``barh()``/``bar`` leads to undrawn bars
+* :ghissue:`29447`: [Doc]: ``subplot`` behavior is not same as the doc reads in 3.10(stable)
+* :ghissue:`29410`: [Bug]: Modifying Axes' position also alters the original Bbox object used for initialization
+* :ghissue:`29396`: [Bug]: Style flag errors trying to save figures as PDF with font Inter
+* :ghissue:`29381`: [Bug]: title position incorrect for polar plot
+* :ghissue:`29350`: [Bug]: Matplotlib causes segmentation fault when hovering mouse over graph
+* :ghissue:`25274`: [Bug]: .remove() on ErrorbarContainer object does not remove the corresponding item from the legend
+* :ghissue:`29202`: [Bug]: ``fontsize`` in tables not working
+* :ghissue:`29301`: [Bug]: Blank EPS output with legend and annotate

--- a/doc/users/release_notes.rst
+++ b/doc/users/release_notes.rst
@@ -22,6 +22,7 @@ Version 3.10
     ../api/prev_api_changes/api_changes_3.10.0.rst
     github_stats.rst
     prev_whats_new/github_stats_3.10.0.rst
+    prev_whats_new/github_stats_3.10.1.rst
 
 Version 3.9
 ^^^^^^^^^^^

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -75,7 +75,7 @@ def test_repr():
         "label='label', title={'center': 'title'}, xlabel='x', ylabel='y'>")
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_label_loc_vertical(fig_test, fig_ref):
     ax = fig_test.subplots()
     sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
@@ -94,7 +94,7 @@ def test_label_loc_vertical(fig_test, fig_ref):
     cbar.set_label("Z Label", y=1, ha='right')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_label_loc_horizontal(fig_test, fig_ref):
     ax = fig_test.subplots()
     sc = ax.scatter([1, 2], [1, 2], c=[1, 2], label='scatter')
@@ -113,7 +113,7 @@ def test_label_loc_horizontal(fig_test, fig_ref):
     cbar.set_label("Z Label", x=0, ha='left')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_label_loc_rc(fig_test, fig_ref):
     with matplotlib.rc_context({"xaxis.labellocation": "right",
                                 "yaxis.labellocation": "top"}):
@@ -2250,7 +2250,7 @@ def test_bar_pandas_indexed(pd):
 
 
 @mpl.style.context('default')
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_bar_hatches(fig_test, fig_ref):
     ax_test = fig_test.subplots()
     ax_ref = fig_ref.subplots()
@@ -3299,7 +3299,7 @@ def test_stackplot_baseline():
     axs[1, 1].stackplot(range(100), d.T, baseline='weighted_wiggle')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_stackplot_hatching(fig_ref, fig_test):
     x = np.linspace(0, 10, 10)
     y1 = 1.0 * x
@@ -3468,7 +3468,7 @@ def test_bxp_customwhisker():
         whiskerprops=dict(linestyle='-', color='m', lw=3)))
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_boxplot_median_bound_by_box(fig_test, fig_ref):
     data = np.arange(3)
     medianprops_test = {"linewidth": 12}
@@ -4276,7 +4276,7 @@ def test_errorbar_colorcycle():
     assert mcolors.to_rgba(ln1.get_color()) == mcolors.to_rgba('C2')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_errorbar_cycle_ecolor(fig_test, fig_ref):
     x = np.arange(0.1, 4, 0.5)
     y = [np.exp(-x+n) for n in range(4)]
@@ -4475,7 +4475,7 @@ def test_xerr_yerr_not_none():
         ax.errorbar(x=[0], y=[0], yerr=[[None], [1]])
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_errorbar_every(fig_test, fig_ref):
     x = np.linspace(0, 1, 15)
     y = x * (1-x)
@@ -5322,7 +5322,7 @@ def test_eb_line_zorder():
     ax.set_title("errorbar zorder test")
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_axline_loglog(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(0.1, 10), ylim=(1e-3, 1))
@@ -5335,7 +5335,7 @@ def test_axline_loglog(fig_test, fig_ref):
     ax.loglog([1, 10], [1e-3, 1e-2], c="k")
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_axline(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
@@ -5358,7 +5358,7 @@ def test_axline(fig_test, fig_ref):
     ax.axvline(-0.5, color='C5')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_axline_transaxes(fig_test, fig_ref):
     ax = fig_test.subplots()
     ax.set(xlim=(-1, 1), ylim=(-1, 1))
@@ -5375,7 +5375,7 @@ def test_axline_transaxes(fig_test, fig_ref):
     ax.plot([0, 0], [-1, 1], color='C3')
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_axline_transaxes_panzoom(fig_test, fig_ref):
     # test that it is robust against pan/zoom and
     # figure resize after plotting
@@ -6431,7 +6431,7 @@ def test_normalize_kwarg_pie():
     assert abs(t2[0][-1].theta2 - 360.) > 1e-3
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_pie_hatch_single(fig_test, fig_ref):
     x = [0.3, 0.3, 0.1]
     hatch = '+'
@@ -6440,7 +6440,7 @@ def test_pie_hatch_single(fig_test, fig_ref):
     [w.set_hatch(hatch) for w in wedges]
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_pie_hatch_multi(fig_test, fig_ref):
     x = [0.3, 0.3, 0.1]
     hatch = ['/', '+', '.']
@@ -9516,7 +9516,7 @@ def test_boxplot_tick_labels():
 
 
 @needs_usetex
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_latex_pie_percent(fig_test, fig_ref):
 
     data = [20, 10, 70]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1676,7 +1676,7 @@ def test_scalarmappable_norm_update():
     assert sm.stale
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_norm_update_figs(fig_test, fig_ref):
     ax_ref = fig_ref.add_subplot()
     ax_test = fig_test.add_subplot()

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -122,7 +122,7 @@ def test_imshow_zoom(fig_test, fig_ref):
     ax.set_ylim([10, 20])
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_imshow_pil(fig_test, fig_ref):
     style.use("default")
     png_path = Path(__file__).parent / "baseline_images/pngsuite/basn3p04.png"
@@ -1384,7 +1384,7 @@ def test_huge_range_log(fig_test, fig_ref, x):
               interpolation='nearest', cmap=cmap)
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_spy_box(fig_test, fig_ref):
     # setting up reference and test
     ax_test = fig_test.subplots(1, 3)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1262,7 +1262,7 @@ def test_legend_markers_from_line2d():
     assert labels == new_labels
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_ncol_ncols(fig_test, fig_ref):
     # Test that both ncol and ncols work
     strings = ["a", "b", "c", "d", "e", "f"]

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -252,7 +252,7 @@ def test_is_sorted_and_has_non_nan():
     plt.plot([np.nan] * n, range(n))
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_step_markers(fig_test, fig_ref):
     fig_test.subplots().step([0, 1], "-o")
     fig_ref.subplots().plot([0, 0, 1], [0, 1, 1], "-o", markevery=[0, 2])
@@ -342,7 +342,7 @@ def test_striped_lines(text_placeholders):
     ax.legend(handlelength=5)
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_odd_dashes(fig_test, fig_ref):
     fig_test.add_subplot().plot([1, 2], dashes=[1, 2, 3])
     fig_ref.add_subplot().plot([1, 2], dashes=[1, 2, 3, 1, 2, 3])
@@ -374,7 +374,7 @@ def test_picking():
     assert_array_equal(indices['ind'], [0])
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_input_copy(fig_test, fig_ref):
 
     t = np.arange(0, 6, 2)

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -412,7 +412,7 @@ def test_textarea_properties():
     assert ta.get_multilinebaseline()
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_textarea_set_text(fig_test, fig_ref):
     ax_ref = fig_ref.add_subplot()
     text0 = AnchoredText("Foo", "upper left")

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -98,7 +98,7 @@ def test_polar_twice():
     assert len(fig.axes) == 1, 'More than one polar Axes created.'
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_polar_wrap(fig_test, fig_ref):
     ax = fig_test.add_subplot(projection="polar")
     ax.plot(np.deg2rad([179, -179]), [0.2, 0.1])
@@ -108,7 +108,7 @@ def test_polar_wrap(fig_test, fig_ref):
     ax.plot(np.deg2rad([2, 358]), [0.2, 0.1])
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_polar_units_1(fig_test, fig_ref):
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -123,7 +123,7 @@ def test_polar_units_1(fig_test, fig_ref):
     ax.set(xlabel="deg")
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_polar_units_2(fig_test, fig_ref):
     import matplotlib.testing.jpl_units as units
     units.register()

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -15,7 +15,7 @@ import io
 import pytest
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_log_scales(fig_test, fig_ref):
     ax_test = fig_test.add_subplot(122, yscale='log', xscale='symlog')
     ax_test.axvline(24.1)

--- a/lib/matplotlib/tests/test_triangulation.py
+++ b/lib/matplotlib/tests/test_triangulation.py
@@ -1321,7 +1321,7 @@ def test_tricontourset_reuse():
     assert tcs3._contour_generator == tcs1._contour_generator
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_triplot_with_ls(fig_test, fig_ref):
     x = [0, 2, 1]
     y = [0, 0, 1]

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1536,7 +1536,7 @@ def test_polygon_selector_set_props_handle_props(ax, draw_bounding_box):
         assert artist.get_alpha() == 0.3
 
 
-@check_figures_equal()
+@check_figures_equal(extensions=['png'])
 def test_rect_visibility(fig_test, fig_ref):
     # Check that requesting an invisible selector makes it invisible
     ax_test = fig_test.subplots()


### PR DESCRIPTION
- Backport PR #29584: DOC: Recommend constrained_layout over tight_layout
- Backport PR #29689: Fix alt and caption handling in Sphinx directives
- Backport PR #29590: Blocked set_clim() callbacks to prevent inconsistent state (#29522)
- Backport PR #29708: MNT: correct version in plotting method deprecation warnings
- Backport PR #29726: Add reference tag to Hatch style reference
- Backport PR #29724: Fix SubplotSpec.get_gridspec type hint
- Backport PR #29719: Fix passing singleton sequence-type styles to hist
- Backport PR #29734: ci: MacOS 14: temporarily upper-bound the 'PyGObject' Python package version
- Backport PR #29748: Fix PyGObject version pinning in macOS tests
- Backport PR #29721: FIX: pyplot auto-backend detection case-sensitivity fixup
- Backport PR #29767: Add description to logit_demo.py script
- Backport PR #29752: DOC: Add install instructions for pixi and uv
- Backport PR #29781: Fix escaping of nulls and "0" in default filenames.
- Backport PR #29755: DOC: Simplify annotation arrow style reference
- Backport PR #29770: MNT: Move test for old ipython behavior to minver tests
- Backport PR #29552: Bug Fix: Normalize kwargs for Histogram
- Backport PR #29801: DOC: Slightly further improve arrowstyle demo
- Backport PR #29839: Improve docs regarding plt.close().
- Backport PR #29842: Don't drag draggables on scroll events
- Backport PR #29545: DOC: correctly specify return type of `figaspect`
- Backport PR #29773: DOC: Improve interactive figures guide / Blocking input
- Backport PR #29834: TST: pin flake8
- Backport PR #29853: Update lib/matplotlib/stackplot.py
- Backport PR #29803: DOC: Improve FancyArrowPatch docstring
- Backport PR #29896: Change `.T` to `.transpose()` in `_reshape_2D`
- Backport PR #29899: [doc] minimally document what basic units is doing
- Backport PR #29897: BUG: ensure that errorbar does not error on masked negative errors.
- Backport PR #29929: Correct rightparen typo
- Backport PR #29920: Allow `None` in set_prop_cycle (in type hints)
- Backport PR #29931: Allow Python native sequences in Matplotlib `imsave()`.
- Backport PR #29919: Handle MOVETO's, CLOSEPOLY's and empty paths in Path.interpolated
- Fix broken links in interactive guide
- STY: placate lint
- Backport PR #29872: TST: Use placeholders for text in layout tests
- Backport PR #29796: ci: rotate soon-to-be-unsupported GitHub Actions ubuntu-20.04 runner out of roster
- Backport PR #29827: TST: Remove unnecessary test images
- Backport PR #29965: Document Axes.spines
- Backport PR #29970: TST: Make refcount tests more resilient to Python changes
- Backport PR #29979: Fix typos: horizonatal -> horizontal
- Backport PR #29975: DOC: correct signature for animation update function in rain example
- Backport PR #29370: DOC: Improve NonUniformImage docs
- Backport PR #29789: Improve layout of cheatsheets in sidebar
- Backport PR #29995: Fix typo: missing singlequote in unrecognized backend exception
- Backport PR #29997: BLD: Ensure meson.build has the right version of Python
- Backport PR #29673: DOC: document the issues with overlaying new mpl on old mpl
- Backport PR #29992 on v3.10.x: Update pinned oldest win image on azure
- Backport PR #29907: Ensure text metric calculation always uses the text cache
- REL prep 3.10.3
- REL: v3.10.3
- Bump from v3.10.3 tag

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
