### PR TITLE
Add Matplotlib Journey online course to external resources

### DIFF
--- a/doc/users/resources/index.rst
+++ b/doc/users/resources/index.rst
@@ -82,6 +82,10 @@ Tutorials
   <https://github.com/stefmolin/python-data-viz-workshop>`_
   by Stefanie Molin
 
+* `Matplotlib Journey: Interactive Online Course
+  <https://www.matplotlib-journey.com/>`_
+  by Yan Holtz and Joseph Barbier
+
 =========
 Galleries
 =========


### PR DESCRIPTION
## PR summary

Following discussions with @tacaswell and @story645, I have added [Matplotlib Journey](https://www.matplotlib-journey.com/), an online course on matplotlib, in the external resources.

Please let me know if any changes need to be made (for example, to make it clear that this is a paying resource).


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

