### PR TITLE
Remove meson-python pinning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,7 @@ requires-python = ">=3.11"
 [project.optional-dependencies]
 # Should be a copy of the build dependencies below.
 dev = [
-    "meson-python>=0.13.1,<0.17.0",
+    "meson-python>=0.13.1,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
     "setuptools_scm>=7",
     # Not required by us but setuptools_scm without a version, cso _if_
@@ -70,7 +70,9 @@ dev = [
 build-backend = "mesonpy"
 # Also keep in sync with optional dependencies above.
 requires = [
-    "meson-python>=0.13.1,<0.17.0",
+    # meson-python 0.17.x breaks symlinks in sdists. You can remove this pin if
+    # you really need it and aren't using an sdist.
+    "meson-python>=0.13.1,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
     "setuptools_scm>=7",
 ]


### PR DESCRIPTION
## PR summary

Version 0.18 should restore handling of symlinks:
https://github.com/mesonbuild/meson-python/pull/728

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines