### PR TITLE
Remove cutout for missing font file in PdfFile._embedTeXFont.

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1021,18 +1021,6 @@ class PdfFile:
                     0, *map(Name, dviread._parse_enc(fontinfo.encodingfile))],
             }
 
-        # If no file is specified, stop short
-        if fontinfo.fontfile is None:
-            _log.warning(
-                "Because of TeX configuration (pdftex.map, see updmap option "
-                "pdftexDownloadBase14) the font %s is not embedded. This is "
-                "deprecated as of PDF 1.5 and it may cause the consumer "
-                "application to show something that was not intended.",
-                fontinfo.basefont)
-            fontdict['BaseFont'] = Name(fontinfo.basefont)
-            self.writeObject(fontdictObject, fontdict)
-            return fontdictObject
-
         # We have a font file to embed - read it in and apply any effects
         t1font = _type1font.Type1Font(fontinfo.fontfile)
         if fontinfo.effects:


### PR DESCRIPTION
If fontfile is None, an error would already have been raised earlier in dviFontName (which explicitly checks for this case).

(The cutout in _embedTeXFont was introduced first, in ed0066f (2009), but support for that case appears to have been broken a bit later and the check in dviFontName was then introduced in 4fcc0e7 (2016) where it simply improved the clarity of the exception ultimately raised. -- attn @jkseppan, who wrote both commits?)

Noted in relation to #29807.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
