### PR TITLE
CI: try running the precommit hooks on GHA

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -6,6 +6,20 @@ permissions:
   contents: read
 
 jobs:
+  pre-commit:
+    name: precommit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55  # v5.5.0
+        with:
+          python-version: "3.x"
+      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+        with:
+          extra_args: --hook-stage manual --all-files
+
   ruff:
     name: ruff
     runs-on: ubuntu-latest


### PR DESCRIPTION
I think it is a security risk that we have given precommit.ci a token with write access to the main repo.

If this works as expected we will get all the upsides of the current setup (see a report of precommit in CI) with none of the downsides (un-trusted entity has write permissions). 