### PR TITLE
Update version switcher for 3.10.3

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.10 (stable)",
-        "version": "3.10.1",
+        "version": "3.10.3",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },


### PR DESCRIPTION
Closes #30046.

Note: There is no need for backporting. See the updated description at #30048.