### PR TITLE
Add 3D scatter test for cmap update

### DIFF
--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -492,6 +492,28 @@ def test_polycollection_close():
     ax.set_ylim3d(0, 4)
 
 
+@check_figures_equal(extensions=["png"])
+def test_scalarmap_change_cmap(fig_test, fig_ref):
+    # Ensure that changing the colormap of a 3D scatter after draw updates the colors.
+
+    x, y, z = np.array(list(itertools.product(
+        np.arange(0, 5, 1),
+        np.arange(0, 5, 1),
+        np.arange(0, 5, 1)
+    ))).T
+    c = x + y
+
+    # test
+    ax_test = fig_test.add_subplot(111, projection='3d')
+    sc_test = ax_test.scatter(x, y, z, c=c, s=40, cmap='jet')
+    fig_test.canvas.draw()
+    sc_test.set_cmap('viridis')
+
+    # ref
+    ax_ref = fig_ref.add_subplot(111, projection='3d')
+    ax_ref.scatter(x, y, z, c=c, s=40, cmap='viridis')
+
+
 @image_comparison(['regularpolycollection_rotate.png'], remove_text=True)
 def test_regularpolycollection_rotate():
     xx, yy = np.mgrid[:10, :10]


### PR DESCRIPTION
## PR summary

This PR adds a new test to verify that changing the colormap of a 3D scatter plot (`Axes3D.scatter`) after drawing the figure properly updates the face colors.

### Why is this change necessary?
There was previously no test ensuring that colormap updates on 3D scatter plots are reflected after a figure draw. This test ensures consistency with 2D behavior and guards against regressions.

### What problem does it solve?
Confirms that calling `set_cmap()` after drawing does in fact update the plotted colors in 3D, which has historically been a bug but seems to be fixed.

### What is the reasoning for this implementation?
The test draws a 3D scatter plot with an initial colormap (`'jet'`), forces a draw, changes the colormap to `'viridis'`, and compares it against a reference plot created directly with `'viridis'`.

This ensures the update mechanism behaves correctly post-render.

### Minimal example
```python
sc = ax.scatter(x, y, z, c=values, cmap='jet')
fig.canvas.draw()
sc.set_cmap('viridis')
```

Closes #18931

---

## PR checklist

* [x] "closes #18931" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
* [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
* [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
* [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
* [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
