### PR TITLE
Remove get_bbox_header

### DIFF
--- a/doc/api/next_api_changes/removals/xxxxxx-DS.rst
+++ b/doc/api/next_api_changes/removals/xxxxxx-DS.rst
@@ -1,0 +1,4 @@
+``backend_ps.get_bbox_header``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+... is removed, as it is considered an internal helper.

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1362,15 +1362,6 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         pstoeps(tmpfile)
 
 
-@_api.deprecated("3.9")
-def get_bbox_header(lbrt, rotated=False):
-    """
-    Return a postscript header string for the given bbox lbrt=(l, b, r, t).
-    Optionally, return rotate command.
-    """
-    return _get_bbox_header(lbrt), (_get_rotate_command(lbrt) if rotated else "")
-
-
 def _get_bbox_header(lbrt):
     """Return a PostScript header string for bounding box *lbrt*=(l, b, r, t)."""
     l, b, r, t = lbrt


### PR DESCRIPTION
Deprecated in 3.9, so time to remove.