### PR TITLE
FIX: fix submerged margins algorithm being applied twice

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -521,11 +521,13 @@ def match_submerged_margins(layoutgrids, fig):
     See test_constrained_layout::test_constrained_layout12 for an example.
     """
 
+    axsdone = []
     for sfig in fig.subfigs:
-        match_submerged_margins(layoutgrids, sfig)
+        axsdone += match_submerged_margins(layoutgrids, sfig)
 
     axs = [a for a in fig.get_axes()
-           if a.get_subplotspec() is not None and a.get_in_layout()]
+           if (a.get_subplotspec() is not None and a.get_in_layout() and
+               a not in axsdone)]
 
     for ax1 in axs:
         ss1 = ax1.get_subplotspec()
@@ -591,6 +593,8 @@ def match_submerged_margins(layoutgrids, fig):
                 lg1.edit_margin_min('top', maxsubt, cell=i)
             for i in ss1.rowspan[:-1]:
                 lg1.edit_margin_min('bottom', maxsubb, cell=i)
+
+    return axs
 
 
 def get_cb_parent_spans(cbax):


### PR DESCRIPTION
Closes #30076

If a figure had subfigures, the submerged margin algorithm (that tries to deal with margins that are not shared across all axes) would get applied to _all_ axes in the figure, including any that had already been taken care of in a subfigure.  This lead to the erroneous behaviour described in #30076.  

New version does not apply the algorithm if the axes has already been dealt with in a subfigure. 

```python
import matplotlib.pyplot as plt

def test(layout, labelled=False):
    ll = labelled
    fig = plt.figure(figsize=(4, 9), layout=layout)
    fig.suptitle(f'Labelled = {not labelled}', fontsize='small')
    figures = fig.subfigures(4, 1)
    for f in figures.flatten():
        gs = f.add_gridspec(2, 2)
        for i in range(2):
            ax = f.add_subplot(gs[i, 0])
            ax.plot()
            if not labelled:
                ax.set_xlabel('BOOO', fontsize='large')
                labelled = True
        f.add_subplot(gs[:, 1]).plot()
    fig.savefig(f'fig_{not ll}.png')
test("constrained")
#test("constrained", labelled=True)
plt.show()
```

now yields:
![fig_True](https://github.com/user-attachments/assets/4786a799-6b2d-4b27-9457-962446c9de86)

Test just makes sure that the appropriate subplots are the same height now. The test fails on main.