### PR TITLE
Simplify some Sphinx tests

### DIFF
--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -21,9 +21,13 @@ def build_sphinx_html(source_dir, doctree_dir, html_dir, extra_args=None):
     extra_args = [] if extra_args is None else extra_args
     cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
            '-d', str(doctree_dir), str(source_dir), str(html_dir), *extra_args]
+    # On CI, gcov emits warnings (due to agg headers being included with the
+    # same name in multiple extension modules -- but we don't care about their
+    # coverage anyways); hide them using GCOV_ERROR_FILE.
     proc = subprocess_run_for_testing(
         cmd, capture_output=True, text=True,
-        env={**os.environ, "MPLBACKEND": ""})
+        env={**os.environ, "MPLBACKEND": "", "GCOV_ERROR_FILE": os.devnull}
+    )
     out = proc.stdout
     err = proc.stderr
 
@@ -40,18 +44,6 @@ def test_tinypages(tmp_path):
     html_dir = tmp_path / '_build' / 'html'
     img_dir = html_dir / '_images'
     doctree_dir = tmp_path / 'doctrees'
-    # Build the pages with warnings turned into errors
-    cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
-           '-d', str(doctree_dir), str(tinypages), str(html_dir)]
-    # On CI, gcov emits warnings (due to agg headers being included with the
-    # same name in multiple extension modules -- but we don't care about their
-    # coverage anyways); hide them using GCOV_ERROR_FILE.
-    proc = subprocess_run_for_testing(
-        cmd, capture_output=True, text=True,
-        env={**os.environ, "MPLBACKEND": "", "GCOV_ERROR_FILE": os.devnull}
-    )
-    out = proc.stdout
-    err = proc.stderr
 
     # Build the pages with warnings turned into errors
     build_sphinx_html(tmp_path, doctree_dir, html_dir)
@@ -185,13 +177,12 @@ def test_show_source_link_false(tmp_path, plot_html_show_source_link):
 
 
 def test_srcset_version(tmp_path):
-    shutil.copytree(tinypages, tmp_path, dirs_exist_ok=True)
     html_dir = tmp_path / '_build' / 'html'
     img_dir = html_dir / '_images'
     doctree_dir = tmp_path / 'doctrees'
 
-    build_sphinx_html(tmp_path, doctree_dir, html_dir, extra_args=[
-        '-D', 'plot_srcset=2x'])
+    build_sphinx_html(tinypages, doctree_dir, html_dir,
+                      extra_args=['-D', 'plot_srcset=2x'])
 
     def plot_file(num, suff=''):
         return img_dir / f'some_plots-{num}{suff}.png'


### PR DESCRIPTION
## PR summary

Just a couple things I noticed in #30061:

- `test_tinypages` unnecessarily calls `sphinx-build` twice.
- `test_srcset_versions` doesn't need an extra copy of the source files, as it doesn't modify anything.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines