### PR TITLE
Fix OffsetBox custom picker

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -1504,7 +1504,9 @@ class DraggableBase:
     @staticmethod
     def _picker(artist, mouseevent):
         # A custom picker to prevent dragging on mouse scroll events
-        return (artist.contains(mouseevent) and mouseevent.name != "scroll_event"), {}
+        if mouseevent.name == "scroll_event":
+            return False, {}
+        return artist.contains(mouseevent)
 
     # A property, not an attribute, to maintain picklability.
     canvas = property(lambda self: self.ref_artist.get_figure(root=True).canvas)

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -460,3 +460,13 @@ def test_draggable_in_subfigure():
     fig.canvas.draw()  # Texts are non-pickable until the first draw.
     MouseEvent("button_press_event", fig.canvas, 1, 1)._process()
     assert ann._draggable.got_artist
+    # Stop dragging the annotation.
+    MouseEvent("button_release_event", fig.canvas, 1, 1)._process()
+    assert not ann._draggable.got_artist
+    # A scroll event should not initiate a drag.
+    MouseEvent("scroll_event", fig.canvas, 1, 1)._process()
+    assert not ann._draggable.got_artist
+    # An event outside the annotation should not initiate a drag.
+    bbox = ann.get_window_extent()
+    MouseEvent("button_press_event", fig.canvas, bbox.x1+2, bbox.y1+2)._process()
+    assert not ann._draggable.got_artist


### PR DESCRIPTION
## PR summary

As with the custom picker, `Artist.contains` returns a boolean and a dictionary in a tuple. This non-empty tuple is always true, so the custom picker would always return True for any non-scroll event. It would also lose the related dictionary.

This broke `mplcursors` tests.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines