### PR TITLE
DOC: expand petroff10 example to include 6- and 8- styles

### DIFF
--- a/galleries/examples/style_sheets/petroff10.py
+++ b/galleries/examples/style_sheets/petroff10.py
@@ -1,13 +1,13 @@
 """
-=====================
-Petroff10 style sheet
-=====================
+====================
+Petroff style sheets
+====================
 
-This example demonstrates the "petroff10" style, which implements the 10-color
-sequence developed by Matthew A. Petroff [1]_ for accessible data visualization.
-The style balances aesthetics with accessibility considerations, making it
-suitable for various types of plots while ensuring readability and distinction
-between data series.
+This example demonstrates the "petroffN" styles, which implement the 6-, 8- and
+10-color sequences developed by Matthew A. Petroff [1]_ for accessible data
+visualization.  The styles balance aesthetics with accessibility considerations,
+making them suitable for various types of plots while ensuring readability and
+distinction between data series.
 
 .. [1] https://arxiv.org/abs/2107.02270
 
@@ -35,9 +35,15 @@ def image_and_patch_example(ax):
     c = plt.Circle((5, 5), radius=5, label='patch')
     ax.add_patch(c)
 
-plt.style.use('petroff10')
-fig, (ax1, ax2) = plt.subplots(ncols=2, figsize=(12, 5))
-fig.suptitle("'petroff10' style sheet")
-colored_lines_example(ax1)
-image_and_patch_example(ax2)
+
+fig = plt.figure(figsize=(6.4, 9.6), layout='compressed')
+sfigs = fig.subfigures(nrows=3)
+
+for style, sfig in zip(['petroff6', 'petroff8', 'petroff10'], sfigs):
+    sfig.suptitle(f"'{style}' style sheet")
+    with plt.style.context(style):
+        ax1, ax2 = sfig.subplots(ncols=2)
+        colored_lines_example(ax1)
+        image_and_patch_example(ax2)
+
 plt.show()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Follows #30065


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
