### PR TITLE
Fix _is_tensorflow_array.

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2331,42 +2331,56 @@ def _picklable_class_constructor(mixin_class, fmt, attr_name, base_class):
 
 
 def _is_torch_array(x):
-    """Check if 'x' is a PyTorch Tensor."""
+    """Return whether *x* is a PyTorch Tensor."""
     try:
-        # we're intentionally not attempting to import torch. If somebody
-        # has created a torch array, torch should already be in sys.modules
-        return isinstance(x, sys.modules['torch'].Tensor)
-    except Exception:  # TypeError, KeyError, AttributeError, maybe others?
-        # we're attempting to access attributes on imported modules which
-        # may have arbitrary user code, so we deliberately catch all exceptions
-        return False
+        # We're intentionally not attempting to import torch. If somebody
+        # has created a torch array, torch should already be in sys.modules.
+        tp = sys.modules.get("torch").Tensor
+    except AttributeError:
+        return False  # Module not imported or a nonstandard module with no Tensor attr.
+    return (isinstance(tp, type)  # Just in case it's a very nonstandard module.
+            and isinstance(x, tp))
 
 
 def _is_jax_array(x):
-    """Check if 'x' is a JAX Array."""
+    """Return whether *x* is a JAX Array."""
     try:
-        # we're intentionally not attempting to import jax. If somebody
-        # has created a jax array, jax should already be in sys.modules
-        return isinstance(x, sys.modules['jax'].Array)
-    except Exception:  # TypeError, KeyError, AttributeError, maybe others?
-        # we're attempting to access attributes on imported modules which
-        # may have arbitrary user code, so we deliberately catch all exceptions
-        return False
+        # We're intentionally not attempting to import jax. If somebody
+        # has created a jax array, jax should already be in sys.modules.
+        tp = sys.modules.get("jax").Array
+    except AttributeError:
+        return False  # Module not imported or a nonstandard module with no Array attr.
+    return (isinstance(tp, type)  # Just in case it's a very nonstandard module.
+            and isinstance(x, tp))
+
+
+def _is_pandas_dataframe(x):
+    """Check if *x* is a Pandas DataFrame."""
+    try:
+        # We're intentionally not attempting to import Pandas. If somebody
+        # has created a Pandas DataFrame, Pandas should already be in sys.modules.
+        tp = sys.modules.get("pandas").DataFrame
+    except AttributeError:
+        return False  # Module not imported or a nonstandard module with no Array attr.
+    return (isinstance(tp, type)  # Just in case it's a very nonstandard module.
+            and isinstance(x, tp))
 
 
 def _is_tensorflow_array(x):
-    """Check if 'x' is a TensorFlow Tensor or Variable."""
+    """Return whether *x* is a TensorFlow Tensor or Variable."""
     try:
-        # we're intentionally not attempting to import TensorFlow. If somebody
-        # has created a TensorFlow array, TensorFlow should already be in sys.modules
-        # we use `is_tensor` to not depend on the class structure of TensorFlow
-        # arrays, as `tf.Variables` are not instances of `tf.Tensor`
-        # (they both convert the same way)
-        return isinstance(x, sys.modules['tensorflow'].is_tensor(x))
-    except Exception:  # TypeError, KeyError, AttributeError, maybe others?
-        # we're attempting to access attributes on imported modules which
-        # may have arbitrary user code, so we deliberately catch all exceptions
+        # We're intentionally not attempting to import TensorFlow. If somebody
+        # has created a TensorFlow array, TensorFlow should already be in
+        # sys.modules we use `is_tensor` to not depend on the class structure
+        # of TensorFlow arrays, as `tf.Variables` are not instances of
+        # `tf.Tensor` (they both convert the same way).
+        is_tensor = sys.modules.get("tensorflow").is_tensor
+    except AttributeError:
         return False
+    try:
+        return is_tensor(x)
+    except Exception:
+        return False  # Just in case it's a very nonstandard module.
 
 
 def _unpack_to_numpy(x):
@@ -2421,15 +2435,3 @@ def _auto_format_str(fmt, value):
         return fmt % (value,)
     except (TypeError, ValueError):
         return fmt.format(value)
-
-
-def _is_pandas_dataframe(x):
-    """Check if 'x' is a Pandas DataFrame."""
-    try:
-        # we're intentionally not attempting to import Pandas. If somebody
-        # has created a Pandas DataFrame, Pandas should already be in sys.modules
-        return isinstance(x, sys.modules['pandas'].DataFrame)
-    except Exception:  # TypeError, KeyError, AttributeError, maybe others?
-        # we're attempting to access attributes on imported modules which
-        # may have arbitrary user code, so we deliberately catch all exceptions
-        return False

--- a/lib/matplotlib/tests/test_cbook.py
+++ b/lib/matplotlib/tests/test_cbook.py
@@ -1000,6 +1000,7 @@ def test_unpack_to_numpy_from_torch():
     torch_tensor = torch.Tensor(data)
 
     result = cbook._unpack_to_numpy(torch_tensor)
+    assert isinstance(result, np.ndarray)
     # compare results, do not check for identity: the latter would fail
     # if not mocked, and the implementation does not guarantee it
     # is the same Python object, just the same values.
@@ -1028,6 +1029,7 @@ def test_unpack_to_numpy_from_jax():
     jax_array = jax.Array(data)
 
     result = cbook._unpack_to_numpy(jax_array)
+    assert isinstance(result, np.ndarray)
     # compare results, do not check for identity: the latter would fail
     # if not mocked, and the implementation does not guarantee it
     # is the same Python object, just the same values.
@@ -1057,6 +1059,7 @@ def test_unpack_to_numpy_from_tensorflow():
     tf_tensor = tensorflow.Tensor(data)
 
     result = cbook._unpack_to_numpy(tf_tensor)
+    assert isinstance(result, np.ndarray)
     # compare results, do not check for identity: the latter would fail
     # if not mocked, and the implementation does not guarantee it
     # is the same Python object, just the same values.


### PR DESCRIPTION
The previous implementation was clearly wrong (the isinstance check would raise TypeError as the second argument would be a bool), but the tests didn't catch that because the bug led to _is_tensorflow_array returning False, then _unpack_to_numpy returning the original input, and then assert_array_equal implicitly converting `result` by calling `__array__` on it.  Fix the test by explicitly checking that `result` is indeed a numpy array, and also fix _is_tensorflow_array with more restrictive exception catching (also applied to _is_torch_array, _is_jax_array, and _is_pandas_dataframe, while we're at it).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
