### PR TITLE
Clean up AFM code

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -24,7 +24,6 @@ import numpy as np
 
 import matplotlib as mpl
 from matplotlib import _api, cbook, _path, _text_helpers
-from matplotlib._afm import AFM
 from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
 from matplotlib.cbook import is_writable_file_like, file_requires_unicode
@@ -787,7 +786,7 @@ grestore
                     width = font.get_width_from_char_name(name)
                 except KeyError:
                     name = 'question'
-                    width = font.get_width_char('?')
+                    width = font.get_width_char(ord('?'))
                 kern = font.get_kern_dist_from_name(last_name, name)
                 last_name = name
                 thisx += kern * scale
@@ -835,9 +834,7 @@ grestore
                 lastfont = font.postscript_name, fontsize
                 self._pswriter.write(
                     f"/{font.postscript_name} {fontsize} selectfont\n")
-            glyph_name = (
-                font.get_name_char(chr(num)) if isinstance(font, AFM) else
-                font.get_glyph_name(font.get_char_index(num)))
+            glyph_name = font.get_glyph_name(font.get_char_index(num))
             self._pswriter.write(
                 f"{ox:g} {oy:g} moveto\n"
                 f"/{glyph_name} glyphshow\n")

--- a/lib/matplotlib/tests/test_afm.py
+++ b/lib/matplotlib/tests/test_afm.py
@@ -135,3 +135,11 @@ def test_malformed_header(afm_data, caplog):
         _afm._parse_header(fh)
 
     assert len(caplog.records) == 1
+
+
+def test_afm_kerning():
+    fn = fm.findfont("Helvetica", fontext="afm")
+    with open(fn, 'rb') as fh:
+        afm = _afm.AFM(fh)
+    assert afm.get_kern_dist_from_name('A', 'V') == -70.0
+    assert afm.get_kern_dist_from_name('V', 'A') == -80.0

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -208,13 +208,6 @@ def test_antialiasing():
     mpl.rcParams['text.antialiased'] = False  # Should not affect existing text.
 
 
-def test_afm_kerning():
-    fn = mpl.font_manager.findfont("Helvetica", fontext="afm")
-    with open(fn, 'rb') as fh:
-        afm = mpl._afm.AFM(fh)
-    assert afm.string_width_height('VAVAVAVAVAVA') == (7174.0, 718)
-
-
 @image_comparison(['text_contains.png'])
 def test_contains():
     fig = plt.figure()


### PR DESCRIPTION
## PR summary

Since AFM is now private (though for some reason still in the docs), we can delete unused methods without deprecation.

Additionally, add `AFM.get_glyph_name` so that the PostScript mathtext code doesn't need to special case AFM files.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines