### PR TITLE
Fix: Add [global] to pybind11 in dev requirements for Windows compati…

### DIFF
--- a/requirements/dev/build-requirements.txt
+++ b/requirements/dev/build-requirements.txt
@@ -1,3 +1,3 @@
-pybind11>=2.13.2,!=2.13.3
+pybind11[global]>=2.13.2,!=2.13.3
 meson-python
 setuptools-scm


### PR DESCRIPTION
## PR summary
When installing `matplotlib` in editable mode on Windows, the build fails with the error:

`fatal error C1083: Cannot open include file: 'pybind11/pybind11.h': No such file or directory`

This issue arises because the standard `pybind11` installation does not place headers in a globally accessible location. By specifying `pybind11[global]`, the headers are installed in a location where build tools like Meson can find them, resolving the compilation error.

**Summary of changes:**  
- Update `requirements/dev.txt` to require `pybind11[global]` instead of just `pybind11`.

**References:**  
See [pybind11 documentation on global installation](https://pybind11.readthedocs.io/en/stable/installing.html#global-installation).

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to link the related issue
- [N/A] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines