### PR TITLE
Add type hints for matplotlib.dates module

### DIFF
--- a/lib/matplotlib/dates.pyi
+++ b/lib/matplotlib/dates.pyi
@@ -8,7 +8,6 @@ from .projections.polar import _AxisWrapper
 from .ticker import _DummyAxis, Formatter, Locator
 from .units import AxisInfo, ConversionInterface
 
-
 # --- Global Functions ---
 
 def _get_tzinfo(tz: str | datetime.tzinfo | None = ...) -> datetime.tzinfo: ...


### PR DESCRIPTION
## PR Summary

This pull request introduces comprehensive type hint stubs (`.pyi` files) for the `matplotlib.dates` module.

**Why this change is necessary:**
By providing explicit type information, this enhancement significantly improves static type checking capabilities for `matplotlib.dates`. Developers using tools like MyPy, Pyright, or Ruff can now catch potential type-related errors earlier in the development cycle, leading to more robust and maintainable code.

**Problem solved:**
This PR addresses the current lack of precise type information for `matplotlib.dates` classes and functions during static analysis. It makes the module's API more explicit and easier for automated type-checking tools to understand and validate.

**Implementation reasoning:**
The implementation involves adding `.pyi` files that define the types for the core classes and functions within `matplotlib.dates.py`. This change directly contributes to Matplotlib's ongoing initiative to expand and improve type hinting coverage across its codebase, fostering better developer experience and code quality.

Closes #29994 

## PR Checklist
- [x] "closes #29994" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
    - *Note: For type stub additions, "tested" typically means running `mypy` or similar type checkers to ensure no errors are introduced.*

## Test Result
mypy, ruff and Pyright with the new `dates.pyi`
<img width="1003" alt="Screenshot 2025-06-01 at 4 22 20 AM" src="https://github.com/user-attachments/assets/91c5dd1a-fa2c-4941-8c9a-26e6bd1712ee" />
