### PR TITLE
DOC: Clarify that types in docstrings do not use formal type annotation syntax

### DIFF
--- a/doc/devel/document.rst
+++ b/doc/devel/document.rst
@@ -537,6 +537,10 @@ understandable by humans. If the possible types are too complex use a
 simplification for the type description and explain the type more
 precisely in the text.
 
+We do not use formal type annotation syntax for type descriptions in
+docstrings; e.g. we use ``list of str`` rather than  ``list[str]``; we
+use ``int or str`` rather than ``int | str`` or ``Union[int, str]``.
+
 Generally, the `numpydoc docstring guide`_ conventions apply. The following
 rules expand on them where the numpydoc conventions are not specific.
 


### PR DESCRIPTION
Historically, our type descriptions are "human readable" and no formal type specifiers - as is propagated by numpydoc.
This PR makes this explicit because we get more and more PRs where people write out types. For consistency, I want to stick to the current pattern for now. 