### PR TITLE
BLD: Remove FreeType from Agg backend extension

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -37,7 +37,7 @@ extension_data = {
       '_backend_agg.cpp',
       '_backend_agg_wrapper.cpp',
     ),
-    'dependencies': [agg_dep, freetype_dep, pybind11_dep],
+    'dependencies': [agg_dep, pybind11_dep],
   },
   '_c_internal_utils': {
     'subdir': 'matplotlib',


### PR DESCRIPTION
## PR summary

I'm not sure why this was added originally, but it seems unnecessary. Fortunately, the waste was probably avoided by LTO.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines