### PR TITLE
js: Fix externally-controlled format strings

### DIFF
--- a/lib/matplotlib/backends/web_backend/js/mpl.js
+++ b/lib/matplotlib/backends/web_backend/js/mpl.js
@@ -575,7 +575,8 @@ mpl.figure.prototype._make_on_message_function = function (fig) {
             var callback = fig['handle_' + msg_type];
         } catch (e) {
             console.log(
-                "No handler for the '" + msg_type + "' message type: ",
+                "No handler for the '%s' message type: ",
+                msg_type,
                 msg
             );
             return;
@@ -583,11 +584,12 @@ mpl.figure.prototype._make_on_message_function = function (fig) {
 
         if (callback) {
             try {
-                // console.log("Handling '" + msg_type + "' message: ", msg);
+                // console.log("Handling '%s' message: ", msg_type, msg);
                 callback(fig, msg);
             } catch (e) {
                 console.log(
-                    "Exception inside the 'handler_" + msg_type + "' callback:",
+                    "Exception inside the 'handler_%s' callback:",
+                    msg_type,
                     e,
                     e.stack,
                     msg


### PR DESCRIPTION
## PR summary

CodeQL is now complaining about these. This should be okay since we only talk to ourselves, but better to be safe about it.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines