### PR TITLE
Update font-related documentation

### DIFF
--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -90,7 +90,7 @@ files, particularly with fonts with many glyphs such as those that support CJK
 
 The solution to this problem is to subset the fonts used in the document and
 only embed the glyphs actually used.  This gets both vector text and small
-files sizes.  Computing the subset of the font required and writing the new
+files sizes.  Computing the font subset and writing the new
 (reduced) font are both complex problems and thus Matplotlib relies in most cases
 on `fontTools <https://fonttools.readthedocs.io/en/latest/>`__.
 

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -53,7 +53,7 @@ which are explained later in the guide):
 .. note::
 
    Adobe disabled__ support for authoring with Type 1 fonts in January 2023.
-   Matplotlib uses Type 1 fonts for compatibility with TeX: when the usetex
+   Matplotlib uses Type 1 fonts for compatibility with TeX; when the usetex
    feature is used with the PDF backend, Matplotlib reads the fonts used by
    the TeX engine, which are usually Type 1.
 

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -36,7 +36,7 @@ which are explained later in the guide):
   | introduced by Adobe      | terms of introduction      | used commonly today,       |
   |                          |                            | introduced by Apple        |
   +--------------------------+----------------------------+----------------------------+
-  | Restricted subset of     | Full PostScript language,  | Includes a virtual machine  |
+  | Restricted subset of     | Full PostScript language,  | Includes a virtual machine |
   | PostScript, charstrings  | allows embedding arbitrary | that can execute code!     |
   | are in bytecode          | code (in theory, even      |                            |
   |                          | render fractals when       |                            |
@@ -88,11 +88,12 @@ pixelated.  However, embedding full fonts in the file can lead to large output
 files, particularly with fonts with many glyphs such as those that support CJK
 (Chinese/Japanese/Korean).
 
-The solution to this problem is to subset the fonts used in the document and
-only embed the glyphs actually used.  This gets both vector text and small
-files sizes.  Computing the font subset and writing the new
-(reduced) font are both complex problems and thus Matplotlib relies in most cases
-on `fontTools <https://fonttools.readthedocs.io/en/latest/>`__.
+To keep the output size reasonable while using vector fonts,
+Matplotlib embeds only the glyphs that are actually used in the document.
+This is known as font subsetting.
+Computing the font subset and writing the reduced font are both complex problems,
+which Matplotlib solves in most cases by using the
+`fontTools <https://fonttools.readthedocs.io/en/latest/>`__ library.
 
 Core Fonts
 ^^^^^^^^^^

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -42,9 +42,9 @@ which are explained later in the guide):
   |                          | render fractals when       |                            |
   |                          | rasterizing!)              |                            |
   +--------------------------+----------------------------+----------------------------+
-  | Supports font | Does not support font hinting| Supports font hinting (virtual |
-  | hinting                  |                            | machine processes the      |
-  |                          |                            | "hints")                   |
+  | Supports font            | Does not support font      | Supports font hinting      |
+  | hinting                  | hinting                    | (virtual machine processes |
+  |                          |                            | the "hints")               |
   +--------------------------+----------------------------+----------------------------+
   | Subsetted by code in     | Subsetted via external module                           |
   | `matplotlib._type1font`  | `fontTools <https://github.com/fonttools/fonttools>`__  |

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -36,7 +36,7 @@ which are explained later in the guide):
   | introduced by Adobe      | terms of introduction      | used commonly today,       |
   |                          |                            | introduced by Apple        |
   +--------------------------+----------------------------+----------------------------+
-  | Restricted subset of     | Full PostScript language,  | Include a virtual machine  |
+  | Restricted subset of     | Full PostScript language,  | Includes a virtual machine  |
   | PostScript, charstrings  | allows embedding arbitrary | that can execute code!     |
   | are in bytecode          | code (in theory, even      |                            |
   |                          | render fractals when       |                            |

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -27,30 +27,35 @@ different platforms supporting different types of fonts.  In practice,
 Matplotlib supports three font specifications (in addition to pdf 'core fonts',
 which are explained later in the guide):
 
-.. list-table:: Type of Fonts
-   :header-rows: 1
+.. table:: Type of Fonts
 
-   * - Type 1 (PDF)
-     - Type 3 (PDF/PS)
-     - TrueType (PDF)
-   * - One of the oldest types, introduced by Adobe
-     - Similar to Type 1 in terms of introduction
-     - Newer than previous types, used commonly today, introduced by Apple
-   * - Restricted subset of PostScript, charstrings are in bytecode
-     - Full PostScript language, allows embedding arbitrary code
-       (in theory, even render fractals when rasterizing!)
-     - Include a virtual machine that can execute code!
-   * - These fonts support font hinting
-     - Do not support font hinting
-     - Hinting supported (virtual machine processes the "hints")
-   * - Non-subsetted through Matplotlib
-     - Subsetted via external module ttconv
-     - Subsetted via external module
-       `fontTools <https://github.com/fonttools/fonttools>`__
+  +--------------------------+----------------------------+----------------------------+
+  | Type 1 (PDF with usetex) | Type 3 (PDF/PS)            | TrueType (PDF)             |
+  +==========================+============================+============================+
+  | One of the oldest types, | Similar to Type 1 in       | Newer than previous types, |
+  | introduced by Adobe      | terms of introduction      | used commonly today,       |
+  |                          |                            | introduced by Apple        |
+  +--------------------------+----------------------------+----------------------------+
+  | Restricted subset of     | Full PostScript language,  | Include a virtual machine  |
+  | PostScript, charstrings  | allows embedding arbitrary | that can execute code!     |
+  | are in bytecode          | code (in theory, even      |                            |
+  |                          | render fractals when       |                            |
+  |                          | rasterizing!)              |                            |
+  +--------------------------+----------------------------+----------------------------+
+  | These fonts support font | Do not support font hinting| Hinting supported (virtual |
+  | hinting                  |                            | machine processes the      |
+  |                          |                            | "hints")                   |
+  +--------------------------+----------------------------+----------------------------+
+  | Subsetted by code in     | Subsetted via external module                           |
+  | `matplotlib._type1font`  | `fontTools <https://github.com/fonttools/fonttools>`__  |
+  +--------------------------+----------------------------+----------------------------+
 
 .. note::
 
    Adobe disabled__ support for authoring with Type 1 fonts in January 2023.
+   Matplotlib uses Type 1 fonts for compatibility with TeX: when the usetex
+   feature is used with the PDF backend, Matplotlib reads the fonts used by
+   the TeX engine, which are usually Type 1.
 
    __ https://helpx.adobe.com/fonts/kb/postscript-type-1-fonts-end-of-support.html
 
@@ -86,11 +91,8 @@ files, particularly with fonts with many glyphs such as those that support CJK
 The solution to this problem is to subset the fonts used in the document and
 only embed the glyphs actually used.  This gets both vector text and small
 files sizes.  Computing the subset of the font required and writing the new
-(reduced) font are both complex problem and thus Matplotlib relies on
-`fontTools <https://fonttools.readthedocs.io/en/latest/>`__ and a vendored fork
-of ttconv.
-
-Currently Type 3, Type 42, and TrueType fonts are subsetted.  Type 1 fonts are not.
+(reduced) font are both complex problems and thus Matplotlib relies in most cases
+on `fontTools <https://fonttools.readthedocs.io/en/latest/>`__.
 
 Core Fonts
 ^^^^^^^^^^

--- a/galleries/users_explain/text/fonts.py
+++ b/galleries/users_explain/text/fonts.py
@@ -42,7 +42,7 @@ which are explained later in the guide):
   |                          | render fractals when       |                            |
   |                          | rasterizing!)              |                            |
   +--------------------------+----------------------------+----------------------------+
-  | These fonts support font | Do not support font hinting| Hinting supported (virtual |
+  | Supports font | Does not support font hinting| Supports font hinting (virtual |
   | hinting                  |                            | machine processes the      |
   |                          |                            | "hints")                   |
   +--------------------------+----------------------------+----------------------------+


### PR DESCRIPTION
We now subset Type-1 fonts and no longer have a copy of ttconv.

Make the font comparison table a grid table so we can use a colspan
cell.

Clarify that Type-1 fonts get used only in the usetex/pdf combination.
