### PR TITLE
Fix typo in backend_ps.py comment: change 'and them scale them' to 'and then scale them'

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -406,7 +406,7 @@ class RendererPS(_backend_pdf_ps.RendererPDFPSBase):
     def __init__(self, width, height, pswriter, imagedpi=72):
         # Although postscript itself is dpi independent, we need to inform the
         # image code about a requested dpi to generate high resolution images
-        # and them scale them before embedding them.
+        # and then scale them before embedding them.
         super().__init__(width, height)
         self._pswriter = pswriter
         if mpl.rcParams['text.usetex']:


### PR DESCRIPTION
**Why is this change necessary?**  
The previous comment contained a grammatical error ("them" instead of "then"), which could cause confusion for readers.  

**What problem does it solve?**  
It improves the clarity and correctness of the documentation in the code.  

**What is the reasoning for this implementation?**  
This is a simple, documentation-only change that does not affect any code functionality.
