### PR TITLE
Throw exception when alpha is out of bounds

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -949,7 +949,7 @@ class Colormap:
         if not isinstance(alpha, Real):
             raise TypeError(f"'alpha' must be numeric or None, not {type(alpha)}")
         if not 0 <= alpha <= 1:
-            ValueError("'alpha' must be between 0 and 1, inclusive")
+            raise ValueError("'alpha' must be between 0 and 1, inclusive")
         new_cm = self.copy()
         if not new_cm._isinit:
             new_cm._init()


### PR DESCRIPTION
## PR summary
This small PR ensures that a `ValueError` is raised when the 'alpha' parameter is outside the valid range `[0, 1]`. This prevents silent failures and enforces proper input validation.