### PR TITLE
TST: Fix runtime error checking NaN input to format_cursor_data

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2228,6 +2228,9 @@ def _g_sig_digits(value, delta):
     Return the number of significant digits to %g-format *value*, assuming that
     it is known with an error of *delta*.
     """
+    # For inf or nan, the precision doesn't matter.
+    if not math.isfinite(value):
+        return 0
     if delta == 0:
         if value == 0:
             # if both value and delta are 0, np.spacing below returns 5e-324
@@ -2241,11 +2244,10 @@ def _g_sig_digits(value, delta):
     # digits before the decimal point (floor(log10(45.67)) + 1 = 2): the total
     # is 4 significant digits.  A value of 0 contributes 1 "digit" before the
     # decimal point.
-    # For inf or nan, the precision doesn't matter.
     return max(
         0,
         (math.floor(math.log10(abs(value))) + 1 if value else 1)
-        - math.floor(math.log10(delta))) if math.isfinite(value) else 0
+        - math.floor(math.log10(delta)))
 
 
 def _unikey_or_keysym_to_mplkey(unikey, keysym):


### PR DESCRIPTION
## PR summary

This seems to have changed in NumPy 2.3.0, only on Windows, but there's no reason to not catch this in the test always.

## PR checklist
- [x] "closes #30152" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines