### PR TITLE
FIX: Ensure Locators on RadialAxis are always correctly wrapped

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -680,19 +680,20 @@ class RadialAxis(maxis.YAxis):
         self.sticky_edges.y.append(0)
 
     def _wrap_locator_formatter(self):
-        self.set_major_locator(RadialLocator(self.get_major_locator(),
-                                             self.axes))
-        self.isDefault_majloc = True
+        if not isinstance(self.get_major_locator(), RadialLocator):
+            is_default = self.isDefault_majloc
+            super().set_major_locator(
+                RadialLocator(self.get_major_locator(), self.axes))
+            self.isDefault_majloc = is_default
+
+    def set_major_locator(self, locator):
+        super().set_major_locator(locator)
+        self._wrap_locator_formatter()
 
     def clear(self):
         # docstring inherited
         super().clear()
         self.set_ticks_position('none')
-        self._wrap_locator_formatter()
-
-    def _set_scale(self, value, **kwargs):
-        super()._set_scale(value, **kwargs)
-        self._wrap_locator_formatter()
 
 
 def _is_full_circle_deg(thetamin, thetamax):
@@ -1242,19 +1243,11 @@ class PolarAxes(Axes):
         """
         self._r_label_position.clear().translate(np.deg2rad(value), 0.0)
 
-    def set_yscale(self, *args, **kwargs):
-        super().set_yscale(*args, **kwargs)
-        self.yaxis.set_major_locator(
-            self.RadialLocator(self.yaxis.get_major_locator(), self))
-
     def set_rscale(self, *args, **kwargs):
         return Axes.set_yscale(self, *args, **kwargs)
 
     def set_rticks(self, *args, **kwargs):
-        result = Axes.set_yticks(self, *args, **kwargs)
-        self.yaxis.set_major_locator(
-            self.RadialLocator(self.yaxis.get_major_locator(), self))
-        return result
+        return Axes.set_yticks(self, *args, **kwargs)
 
     def set_thetagrids(self, angles, labels=None, fmt=None, **kwargs):
         """

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -3,8 +3,10 @@ from numpy.testing import assert_allclose
 import pytest
 
 import matplotlib as mpl
+from matplotlib.projections.polar import RadialLocator
 from matplotlib import pyplot as plt
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
+import matplotlib.ticker as mticker
 
 
 @image_comparison(['polar_axes.png'], style='default', tol=0.012)
@@ -526,3 +528,43 @@ def test_radial_limits_behavior():
     # negative data also autoscales to negative limits
     ax.plot([1, 2], [-1, -2])
     assert ax.get_ylim() == (-2, 2)
+
+
+def test_radial_locator_wrapping():
+    # Check that the locator is always wrapped inside a RadialLocator
+    # and that RaidialAxis.isDefault_majloc is set correctly.
+    fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    assert ax.yaxis.isDefault_majloc
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+
+    # set an explicit locator
+    locator = mticker.MaxNLocator(3)
+    ax.yaxis.set_major_locator(locator)
+    assert not ax.yaxis.isDefault_majloc
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+    assert ax.yaxis.get_major_locator().base is locator
+
+    ax.clear()  # reset to the default locator
+    assert ax.yaxis.isDefault_majloc
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+
+    ax.set_rticks([0, 1, 2, 3])  # implicitly sets a FixedLocator
+    assert not ax.yaxis.isDefault_majloc  # because of the fixed ticks
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+    assert isinstance(ax.yaxis.get_major_locator().base, mticker.FixedLocator)
+
+    ax.clear()
+
+    ax.set_rgrids([0, 1, 2, 3])  # implicitly sets a FixedLocator
+    assert not ax.yaxis.isDefault_majloc  # because of the fixed ticks
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+    assert isinstance(ax.yaxis.get_major_locator().base, mticker.FixedLocator)
+
+    ax.clear()
+
+    ax.set_yscale("log")  # implicitly sets a LogLocator
+    # Note that the LogLocator is still considered the default locator
+    # for the log scale
+    assert ax.yaxis.isDefault_majloc
+    assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
+    assert isinstance(ax.yaxis.get_major_locator().base, mticker.LogLocator)


### PR DESCRIPTION
All the wrapping logic is now done whenever a new locator is set in RadialAxis.

Closes #30164 and rearchitects #29798.
