### PR TITLE
Scale an image to the axes edges regardless of whether it is being plotted with a nonaffine transform or an affine transform

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1641,6 +1641,17 @@ def test__resample_valid_output():
         resample(np.zeros((9, 9)), out)
 
 
+@pytest.fixture
+def nonaffine_identity_transform():
+    class NonAffineIdentityTransform(Transform):
+        input_dims = 2
+        output_dims = 2
+
+        def inverted(self):
+            return self
+    return NonAffineIdentityTransform()
+
+
 @pytest.mark.parametrize("data, interpolation, expected",
     [(np.array([[0.1, 0.3, 0.2]]), mimage.NEAREST,
       np.array([[0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2]])),
@@ -1649,7 +1660,7 @@ def test__resample_valid_output():
                  0.28476562, 0.2546875, 0.22460938, 0.20002441, 0.20002441]])),
     ]
 )
-def test_resample_nonaffine(data, interpolation, expected):
+def test_resample_nonaffine(data, interpolation, expected, nonaffine_identity_transform):
     # Test that equivalent affine and nonaffine transforms resample the same
 
     # Create a simple affine transform for scaling the input array
@@ -1661,18 +1672,25 @@ def test_resample_nonaffine(data, interpolation, expected):
 
     # Create a nonaffine version of the same transform
     # by compositing with a nonaffine identity transform
-    class NonAffineIdentityTransform(Transform):
-        input_dims = 2
-        output_dims = 2
-
-        def inverted(self):
-           return self
-    nonaffine_transform = NonAffineIdentityTransform() + affine_transform
+    nonaffine_transform = nonaffine_identity_transform + affine_transform
 
     nonaffine_result = np.empty_like(expected)
     mimage.resample(data, nonaffine_result, nonaffine_transform,
                     interpolation=interpolation)
     assert_allclose(nonaffine_result, expected, atol=5e-3)
+
+
+@check_figures_equal()
+def test_nonaffine_scaling_to_axes_edges(fig_test, fig_ref, nonaffine_identity_transform):
+    # Test that plotting an image with equivalent affine and nonaffine
+    # transforms is scaled the same to the axes edges
+    data = np.arange(16).reshape((4, 4)) % 3
+
+    ax = fig_test.subplots()
+    ax.imshow(data, transform=nonaffine_identity_transform + ax.transData)
+
+    ax = fig_ref.subplots()
+    ax.imshow(data)
 
 
 def test_axesimage_get_shape():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

This PR fixes a difference between plotting an image with a nonaffine transform versus with an affine transform.  When plotting with an affine transform, the transform for rendering gets an additional transform step to scale the image to the axes edges in the situation where the axes bbox is not a whole number of pixels.  However, when plotting with a nonaffine transform, this additional scaling step is skipped, and instead the fractional pixel at the end is clipped off.  I can't think of any reason why this difference is desirable, so this PR removes the different handling of a nonaffine transform versus an affine transform.

Here's an example image before this PR and generating script.  Note that the image plotted using the nonaffine transform has a obvious gap to the axis on the right edge due to the fractional pixel.  The discrepancy on the top edge is not quite as obvious.
![Figure_1](https://github.com/user-attachments/assets/15b1e7b7-fad2-4e8d-820e-d14ae01a7aad)
```python
import numpy as np

import matplotlib.pyplot as plt
from matplotlib.transforms import Transform

# Create a nonaffine identity transform
class NonAffineIdentityTransform(Transform):
    input_dims = 2
    output_dims = 2

    def inverted(self):
       return self
nonaffine_transform = NonAffineIdentityTransform()

data = np.arange(16).reshape((4, 4)) % 3

fig, axs = plt.subplots(2, figsize=(6, 3), dpi=100)

# Choose axes bboxs with with fractional pixels
axs[0].set_position([0.1, 0.3, 200.75 / fig.bbox.width, 200.75 / fig.bbox.height])
axs[1].set_position([0.6, 0.3, 200.75 / fig.bbox.width, 200.75 / fig.bbox.height])

im0 = axs[0].imshow(data)
im1 = axs[1].imshow(data, transform=nonaffine_transform + axs[1].transData)

axs[0].spines[:].set_ls((0, (5, 5)))
axs[1].spines[:].set_ls((0, (5, 5)))

axs[0].set_title("Affine")
axs[1].set_title("Nonaffine")

plt.show()
```


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
