### PR TITLE
DOC: expand polar example

### DIFF
--- a/galleries/examples/pie_and_polar_charts/polar_demo.py
+++ b/galleries/examples/pie_and_polar_charts/polar_demo.py
@@ -52,6 +52,8 @@ plt.show()
 #    - `matplotlib.projections.polar`
 #    - `matplotlib.projections.polar.PolarAxes`
 #    - `matplotlib.projections.polar.PolarAxes.set_rticks`
+#    - `matplotlib.projections.polar.PolarAxes.set_rmin`
+#    - `matplotlib.projections.polar.PolarAxes.set_rorigin`
 #    - `matplotlib.projections.polar.PolarAxes.set_rmax`
 #    - `matplotlib.projections.polar.PolarAxes.set_rlabel_position`
 #

--- a/galleries/examples/pie_and_polar_charts/polar_demo.py
+++ b/galleries/examples/pie_and_polar_charts/polar_demo.py
@@ -30,15 +30,15 @@ ax.set_title("A line plot on a polar axis", va='bottom')
 ax = axs[1]
 ax.plot(theta, r)
 ax.set_rmax(2)
-ax.set_rmin(1)  # change the radial axis to only go from 1 to 2
-ax.set_rorigin(0)  # Set the origin of the radial axis to 0.
+ax.set_rmin(1)  # Change the radial axis to only go from 1 to 2
+ax.set_rorigin(0)  # Set the origin of the radial axis to 0
 ax.set_thetamin(0)
 ax.set_thetamax(225)
 ax.set_rticks([1, 1.5, 2])  # Fewer radial ticks
 ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
 
 ax.grid(True)
-ax.set_title("Same plot, but axis starts at r=1, and ends at theta=225", va='bottom')
+ax.set_title("Same plot, but with reduced axis limits", va='bottom')
 plt.show()
 
 # %%

--- a/galleries/examples/pie_and_polar_charts/polar_demo.py
+++ b/galleries/examples/pie_and_polar_charts/polar_demo.py
@@ -4,6 +4,11 @@ Polar plot
 ==========
 
 Demo of a line plot on a polar axis.
+
+The second plot shows the same data, but with the radial axis starting at r=1
+and the angular axis starting at 0 degrees and ending at 225 degrees. Setting
+the origin of the radial axis to 0 allows the radial ticks to be placed at the
+same location as the first plot.
 """
 import matplotlib.pyplot as plt
 import numpy as np
@@ -11,14 +16,29 @@ import numpy as np
 r = np.arange(0, 2, 0.01)
 theta = 2 * np.pi * r
 
-fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+fig, axs = plt.subplots(2, 1, figsize=(5, 8), subplot_kw={'projection': 'polar'},
+                        layout='constrained')
+ax = axs[0]
 ax.plot(theta, r)
 ax.set_rmax(2)
-ax.set_rticks([0.5, 1, 1.5, 2])  # Less radial ticks
+ax.set_rticks([0.5, 1, 1.5, 2])  # Fewer radial ticks
 ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
 ax.grid(True)
 
 ax.set_title("A line plot on a polar axis", va='bottom')
+
+ax = axs[1]
+ax.plot(theta, r)
+ax.set_rmax(2)
+ax.set_rmin(1)  # change the radial axis to only go from 1 to 2
+ax.set_rorigin(0)  # Set the origin of the radial axis to 0.
+ax.set_thetamin(0)
+ax.set_thetamax(225)
+ax.set_rticks([1, 1.5, 2])  # Fewer radial ticks
+ax.set_rlabel_position(-22.5)  # Move radial labels away from plotted line
+
+ax.grid(True)
+ax.set_title("Same plot, but axis starts at r=1, and ends at theta=225", va='bottom')
 plt.show()
 
 # %%


### PR DESCRIPTION
This marginally expands the polar example to include examples of setting the limits, and using `rorigin`.  