### PR TITLE
Make path extension a bit safer

### DIFF
--- a/src/_path.h
+++ b/src/_path.h
@@ -43,7 +43,8 @@ struct XY
 
 typedef std::vector<XY> Polygon;
 
-void _finalize_polygon(std::vector<Polygon> &result, int closed_only)
+inline void
+_finalize_polygon(std::vector<Polygon> &result, bool closed_only)
 {
     if (result.size() == 0) {
         return;
@@ -691,12 +692,12 @@ clip_path_to_rect(PathIterator &path, agg::rect_d &rect, bool inside, std::vecto
 
         // Empty polygons aren't very useful, so skip them
         if (polygon1.size()) {
-            _finalize_polygon(results, 1);
+            _finalize_polygon(results, true);
             results.push_back(polygon1);
         }
     } while (code != agg::path_cmd_stop);
 
-    _finalize_polygon(results, 1);
+    _finalize_polygon(results, true);
 }
 
 template <class VerticesArray, class ResultArray>
@@ -956,7 +957,7 @@ void convert_path_to_polygons(PathIterator &path,
                               agg::trans_affine &trans,
                               double width,
                               double height,
-                              int closed_only,
+                              bool closed_only,
                               std::vector<Polygon> &result)
 {
     typedef agg::conv_transform<mpl::PathIterator> transformed_path_t;
@@ -980,7 +981,7 @@ void convert_path_to_polygons(PathIterator &path,
 
     while ((code = curve.vertex(&x, &y)) != agg::path_cmd_stop) {
         if ((code & agg::path_cmd_end_poly) == agg::path_cmd_end_poly) {
-            _finalize_polygon(result, 1);
+            _finalize_polygon(result, true);
             polygon = &result.emplace_back();
         } else {
             if (code == agg::path_cmd_move_to) {

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -68,15 +68,15 @@ Py_get_path_collection_extents(agg::trans_affine master_transform,
 
     py::ssize_t dims[] = { 2, 2 };
     py::array_t<double> extents(dims);
-    *extents.mutable_data(0, 0) = e.x0;
-    *extents.mutable_data(0, 1) = e.y0;
-    *extents.mutable_data(1, 0) = e.x1;
-    *extents.mutable_data(1, 1) = e.y1;
+    *extents.mutable_data(0, 0) = e.start.x;
+    *extents.mutable_data(0, 1) = e.start.y;
+    *extents.mutable_data(1, 0) = e.end.x;
+    *extents.mutable_data(1, 1) = e.end.y;
 
     py::ssize_t minposdims[] = { 2 };
     py::array_t<double> minpos(minposdims);
-    *minpos.mutable_data(0) = e.xm;
-    *minpos.mutable_data(1) = e.ym;
+    *minpos.mutable_data(0) = e.minpos.x;
+    *minpos.mutable_data(1) = e.minpos.y;
 
     return py::make_tuple(extents, minpos);
 }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -109,9 +109,7 @@ Py_path_in_path(mpl::PathIterator a, agg::trans_affine atrans,
 static py::list
 Py_clip_path_to_rect(mpl::PathIterator path, agg::rect_d rect, bool inside)
 {
-    std::vector<Polygon> result;
-
-    clip_path_to_rect(path, rect, inside, result);
+    auto result = clip_path_to_rect(path, rect, inside);
 
     return convert_polygon_vector(result);
 }

--- a/src/_path_wrapper.cpp
+++ b/src/_path_wrapper.cpp
@@ -252,15 +252,10 @@ static py::object
 Py_convert_to_string(mpl::PathIterator path, agg::trans_affine trans,
                      agg::rect_d cliprect, std::optional<bool> simplify,
                      SketchParams sketch, int precision,
-                     std::array<std::string, 5> codes_obj, bool postfix)
+                     const std::array<std::string, 5> &codes, bool postfix)
 {
-    char *codes[5];
     std::string buffer;
     bool status;
-
-    for (auto i = 0; i < 5; ++i) {
-        codes[i] = const_cast<char *>(codes_obj[i].c_str());
-    }
 
     if (!simplify.has_value()) {
         simplify = path.should_simplify();


### PR DESCRIPTION
## PR summary

By replacing double pointers by `std::array` and returned tuples. AFAICT, this doesn't have any effect on code size, but ensures that several places are checked at compile time. And for now, we already know these to be correct, but this would prevent any future problems if some sizes change.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines