### PR TITLE
[Doc]: fix bug in release notes for matplotlib v3.5.0 and v3.7.0

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.5.0/deprecations.rst
@@ -282,7 +282,7 @@ Miscellaneous deprecations
 - The *format* parameter of ``dviread.find_tex_file`` is deprecated (with no
   replacement).
 - ``FancyArrowPatch.get_path_in_displaycoord`` and
-  ``ConnectionPath.get_path_in_displaycoord`` are deprecated. The path in
+  ``ConnectionPatch.get_path_in_displaycoord`` are deprecated. The path in
   display coordinates can still be obtained, as for other patches, using
   ``patch.get_transform().transform_path(patch.get_path())``.
 - The ``font_manager.win32InstalledFonts`` and

--- a/doc/api/prev_api_changes/api_changes_3.7.0/removals.rst
+++ b/doc/api/prev_api_changes/api_changes_3.7.0/removals.rst
@@ -323,7 +323,7 @@ Miscellaneous removals
 - The *format* parameter of ``dviread.find_tex_file`` is removed (with no
   replacement).
 - ``FancyArrowPatch.get_path_in_displaycoord`` and
-  ``ConnectionPath.get_path_in_displaycoord`` are removed. The path in
+  ``ConnectionPatch.get_path_in_displaycoord`` are removed. The path in
   display coordinates can still be obtained, as for other patches, using
   ``patch.get_transform().transform_path(patch.get_path())``.
 - The ``font_manager.win32InstalledFonts`` and


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

Reference Issue #30211 

There is a typo in the release notes for matplotlib v3.5.0 and v3.7.0.

The item in this [link](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.5.0.html#miscellaneous-deprecations):

> `FancyArrowPatch.get_path_in_displaycoord` and `ConnectionPath.get_path_in_displaycoord` are deprecated. ...

`ConnectionPath` should be `ConnectionPatch`. There is no such a class as `ConnectionPath`.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
