### PR TITLE
BUG: Include python-including headers first in src/ft2font.{cpp,h}

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -1,5 +1,8 @@
 /* -*- mode: c++; c-basic-offset: 4 -*- */
 
+#include "ft2font.h"
+#include "mplutils.h"
+
 #include <algorithm>
 #include <cstdio>
 #include <iterator>
@@ -8,9 +11,6 @@
 #include <stdexcept>
 #include <string>
 #include <vector>
-
-#include "ft2font.h"
-#include "mplutils.h"
 
 #ifndef M_PI
 #define M_PI 3.14159265358979323846264338328

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -6,6 +6,9 @@
 #ifndef MPL_FT2FONT_H
 #define MPL_FT2FONT_H
 
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
 #include <set>
 #include <string>
 #include <string_view>
@@ -22,8 +25,6 @@ extern "C" {
 #include FT_TRUETYPE_TABLES_H
 }
 
-#include <pybind11/pybind11.h>
-#include <pybind11/numpy.h>
 namespace py = pybind11;
 
 // By definition, FT_FIXED as 2 16bit values stored in a single long.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Python.h defines several visibility macros on my platform.  If system headers are included before Python.h, they will define the visibility macros to default values, causing compilation errors due to the conflicting definitions.
These changes allow matplotlib to compile into a wheel on my platform (Cygwin).

I moved the groups that looked like headers that included Python.h before all other include statements in the file.

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
