### PR TITLE
Polar log scale: fix inner patch boundary and spine location

### DIFF
--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -817,6 +817,10 @@ class PolarAxes(Axes):
         self.xaxis = ThetaAxis(self, clear=False)
         self.yaxis = RadialAxis(self, clear=False)
         self.spines['polar'].register_axis(self.yaxis)
+        inner_spine = self.spines.get('inner', None)
+        if inner_spine is not None:
+            # Subclasses may not have inner spine.
+            inner_spine.register_axis(self.yaxis)
 
     def _set_lim_and_transforms(self):
         # A view limit where the minimum radius can be locked if the user
@@ -961,7 +965,9 @@ class PolarAxes(Axes):
         thetamin, thetamax = np.rad2deg(self._realViewLim.intervalx)
         if thetamin > thetamax:
             thetamin, thetamax = thetamax, thetamin
-        rmin, rmax = ((self._realViewLim.intervaly - self.get_rorigin()) *
+        rscale_tr = self.yaxis.get_transform()
+        rmin, rmax = ((rscale_tr.transform(self._realViewLim.intervaly) -
+                       rscale_tr.transform(self.get_rorigin())) *
                       self.get_rsign())
         if isinstance(self.patch, mpatches.Wedge):
             # Backwards-compatibility: Any subclassed Axes might override the

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -265,11 +265,17 @@ class Spine(mpatches.Patch):
                 self._path = mpath.Path.arc(np.rad2deg(low), np.rad2deg(high))
 
                 if self.spine_type == 'bottom':
-                    rmin, rmax = self.axes.viewLim.intervaly
+                    if self.axis is None:
+                        tr = mtransforms.IdentityTransform()
+                    else:
+                        tr = self.axis.get_transform()
+                    rmin, rmax = tr.transform(self.axes.viewLim.intervaly)
                     try:
                         rorigin = self.axes.get_rorigin()
                     except AttributeError:
                         rorigin = rmin
+                    else:
+                        rorigin = tr.transform(rorigin)
                     scaled_diameter = (rmin - rorigin) / (rmax - rorigin)
                     self._height = scaled_diameter
                     self._width = scaled_diameter

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -482,6 +482,26 @@ def test_polar_log():
     ax.plot(np.linspace(0, 2 * np.pi, n), np.logspace(0, 2, n))
 
 
+@check_figures_equal()
+def test_polar_log_rorigin(fig_ref, fig_test):
+    # Test that equivalent linear and log radial settings give the same axes patch
+    # and spines.
+    ax_ref = fig_ref.add_subplot(projection='polar', facecolor='red')
+    ax_ref.set_rlim(0, 2)
+    ax_ref.set_rorigin(-3)
+    ax_ref.set_rticks(np.linspace(0, 2, 5))
+
+    ax_test = fig_test.add_subplot(projection='polar', facecolor='red')
+    ax_test.set_rscale('log')
+    ax_test.set_rlim(1, 100)
+    ax_test.set_rorigin(10**-3)
+    ax_test.set_rticks(np.logspace(0, 2, 5))
+
+    for ax in ax_ref, ax_test:
+        # Radial tick labels should be the only difference, so turn them off.
+        ax.tick_params(labelleft=False)
+
+
 def test_polar_neg_theta_lims():
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -154,3 +154,15 @@ def test_spines_black_axes():
     ax.set_xticks([])
     ax.set_yticks([])
     ax.set_facecolor((0, 0, 0))
+
+
+def test_arc_spine_inner_no_axis():
+    # Backcompat: smoke test that inner arc spine does not need a registered
+    # axis in order to be drawn
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="polar")
+    inner_spine = ax.spines["inner"]
+    inner_spine.register_axis(None)
+    assert ax.spines["inner"].axis is None
+
+    fig.draw_without_rendering()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Fixes #30179.  The inner patch and spine positions are calculated in linear space, so we need to apply the scale's transform to min, max and origin.

The code from the OP now gives
![image](https://github.com/user-attachments/assets/f08d1e5b-3cc6-417f-b731-ff1e103fa7de)

The code from https://github.com/matplotlib/matplotlib/issues/30179#issuecomment-2990366910 now gives
![image](https://github.com/user-attachments/assets/5fdb7c69-feb9-450d-bce3-9545100265dd)

The test image looks like
![test_polar_log_rorigin png -expected](https://github.com/user-attachments/assets/95387fb6-41a2-4ec3-94a4-2ea49bcbf4ac)

I note there is an existing PR at #30185, but it appears to me unlikely to progress.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
