### PR TITLE
[Example] Add workaround for tick_top and sharex compatibility (#30219)

### DIFF
--- a/examples/statistics/errorbar_tick_top_fix.py
+++ b/examples/statistics/errorbar_tick_top_fix.py
@@ -1,0 +1,43 @@
+import matplotlib.pyplot as plt
+
+# Create a 2x2 grid of subplots with shared x and y axes
+fig, axes = plt.subplots(
+    nrows=2, ncols=2,
+    sharex=True, sharey=True
+)
+
+# Flatten the 2D array of axes for easier iteration
+axes = axes.flatten()
+
+for i, ax in enumerate(axes):
+    # Plot a basic scatter plot
+    ax.scatter(x=[0, 1, 5, 3], y=[0, 1, 2, 4])
+
+    # Apply ticks and labels to the top of the axes only for the top row
+    if i < 2:
+        ax.tick_params(
+            axis='x',
+            top=True,           # Show ticks on top
+            labeltop=True,      # Show labels on top
+            bottom=False,       # Hide bottom ticks
+            labelbottom=False,  # Hide bottom labels
+            rotation=55         # Rotate the tick labels for better visibility
+        )
+    else:
+        # Hide all x-axis ticks/labels for the bottom row
+        ax.tick_params(
+            axis='x',
+            top=False,
+            labeltop=False,
+            bottom=False,
+            labelbottom=False
+        )
+
+    # Automatically hide tick labels that are not on the edge of the figure
+    ax.label_outer()
+
+# Adjust layout to prevent overlap between subplots and labels
+plt.tight_layout()
+
+# Display the plot
+plt.show()


### PR DESCRIPTION
Closes #30219

This PR adds a new example script under `examples/statistics/` that demonstrates a practical workaround for using `tick_top()` with `sharex=True` in a subplot grid.

### Background
When using shared x-axes, `tick_top()` does not restore tick labels on the top row because shared axes suppress labels on all but the bottom subplot by default. This results in unintuitive behaviour for users expecting top ticks on the uppermost axes.

### What This Example Shows
This example:
- Uses `tick_params(top=True, labeltop=True, bottom=False, labelbottom=False)` on the top row,
- Suppresses bottom ticks and labels to avoid overlap,
- Applies `ax.label_outer()` to hide redundant ticks in the interior,
- Demonstrates clean placement of x-axis labels on top for shared subplots.

This provides a clean, idiomatic alternative for achieving the intended visual layout.

### Tested
- Verified locally using an editable Matplotlib install.
- Pre-commit hooks (ruff, codespell, etc.) all pass for this file.