### PR TITLE
Check that stem input is 1D

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3436,6 +3436,9 @@ or pandas.DataFrame
         else:  # horizontal
             heads, locs = self._process_unit_info([("x", heads), ("y", locs)])
 
+        heads = cbook._check_1d(heads)
+        locs = cbook._check_1d(locs)
+
         # resolve line format
         if linefmt is None:
             linefmt = args[0] if len(args) > 0 else "C0-"

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4744,6 +4744,11 @@ def test_stem_args():
     _assert_equal(ax.stem(y, linefmt='r--'), expected=([0, 1, 2], y))
     _assert_equal(ax.stem(y, 'r--'), expected=([0, 1, 2], y))
 
+    with pytest.raises(ValueError):
+        ax.stem([[y]])
+    with pytest.raises(ValueError):
+        ax.stem([[x]], y)
+
 
 def test_stem_markerfmt():
     """Test that stem(..., markerfmt=...) produces the intended markers."""


### PR DESCRIPTION
## PR summary

This also has the side-effect of casting torch Tensors to NumPy arrays, which fixes #30216. Since `stem` is made up of `plot` and `[hv]lines` whic already do this cast, this just moves it up one level which prevents doing it twice.

We don't have any testing with torch directly, so I didn't add any of that sort.

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines