### PR TITLE
Don't expose private styles in style.available

### DIFF
--- a/lib/matplotlib/style/__init__.py
+++ b/lib/matplotlib/style/__init__.py
@@ -6,7 +6,8 @@ Core functions and attributes for the matplotlib style library:
 ``context``
     Context manager to use a style sheet temporarily.
 ``available``
-    List available style sheets.
+    List available style sheets. Underscore-prefixed names are considered private and
+    not listed, though may still be accessed directly from ``library``.
 ``library``
     A dictionary of style names and matplotlib settings.
 """
@@ -245,8 +246,8 @@ available = []
 def reload_library():
     """Reload the style library."""
     library.clear()
-    library.update(_update_user_library(_base_library))
-    available[:] = sorted(library.keys())
+    library.update(_update_user_library(_base_library.copy()))
+    available[:] = sorted(name for name in library if not name.startswith('_'))
 
 
 reload_library()

--- a/lib/matplotlib/tests/test_style.py
+++ b/lib/matplotlib/tests/test_style.py
@@ -21,6 +21,7 @@ def temp_style(style_name, settings=None):
     if not settings:
         settings = DUMMY_SETTINGS
     temp_file = f'{style_name}.mplstyle'
+    orig_library_paths = style.USER_LIBRARY_PATHS
     try:
         with TemporaryDirectory() as tmpdir:
             # Write style settings to file in the tmpdir.
@@ -32,6 +33,7 @@ def temp_style(style_name, settings=None):
             style.reload_library()
             yield
     finally:
+        style.USER_LIBRARY_PATHS = orig_library_paths
         style.reload_library()
 
 
@@ -46,8 +48,17 @@ def test_invalid_rc_warning_includes_filename(caplog):
 
 
 def test_available():
-    with temp_style('_test_', DUMMY_SETTINGS):
-        assert '_test_' in style.available
+    # Private name should not be listed in available but still usable.
+    assert '_classic_test_patch' not in style.available
+    assert '_classic_test_patch' in style.library
+
+    with temp_style('_test_', DUMMY_SETTINGS), temp_style('dummy', DUMMY_SETTINGS):
+        assert 'dummy' in style.available
+        assert 'dummy' in style.library
+        assert '_test_' not in style.available
+        assert '_test_' in style.library
+    assert 'dummy' not in style.available
+    assert '_test_' not in style.available
 
 
 def test_use():


### PR DESCRIPTION
## PR summary

They remain in `style.library`, because that's how we look them up, but this prevents them being exposed as something someone might use.

Also, fix `reload_library`, which was accidentally modifying the original base library information each time.

Fixes itprojects/MasVisGtk#13

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines