### PR TITLE
Copy-edit the docstring of AuxTransformBox.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -201,7 +201,7 @@ def _get_aligned_offsets(yspans, height, align="baseline"):
 
 class OffsetBox(martist.Artist):
     """
-    The OffsetBox is a simple container artist.
+    A simple container artist.
 
     The child artists are meant to be drawn at a relative position to its
     parent.
@@ -826,17 +826,18 @@ class TextArea(OffsetBox):
 
 class AuxTransformBox(OffsetBox):
     """
-    Offset Box with the aux_transform. Its children will be
-    transformed with the aux_transform first then will be
-    offsetted. The absolute coordinate of the aux_transform is meaning
-    as it will be automatically adjust so that the left-lower corner
-    of the bounding box of children will be set to (0, 0) before the
-    offset transform.
+    An OffsetBox with an auxiliary transform.
 
-    It is similar to drawing area, except that the extent of the box
-    is not predetermined but calculated from the window extent of its
-    children. Furthermore, the extent of the children will be
-    calculated in the transformed coordinate.
+    All child artists are first transformed with *aux_transform*, then
+    translated with an offset (the same for all children) so the bounding
+    box of the children matches the drawn box.  (In other words, adding an
+    arbitrary translation to *aux_transform* has no effect as it will be
+    cancelled out by the later offsetting.)
+
+    `AuxTransformBox` is similar to `.DrawingArea`, except that the extent of
+    the box is not predetermined but calculated from the window extent of its
+    children, and the extent of the children will be calculated in the
+    transformed coordinate.
     """
     def __init__(self, aux_transform):
         self.aux_transform = aux_transform
@@ -853,10 +854,7 @@ class AuxTransformBox(OffsetBox):
         self.stale = True
 
     def get_transform(self):
-        """
-        Return the :class:`~matplotlib.transforms.Transform` applied
-        to the children
-        """
+        """Return the `.Transform` applied to the children."""
         return (self.aux_transform
                 + self.ref_offset_transform
                 + self.offset_transform)
@@ -908,7 +906,7 @@ class AuxTransformBox(OffsetBox):
 
 class AnchoredOffsetbox(OffsetBox):
     """
-    An offset box placed according to location *loc*.
+    An OffsetBox placed according to location *loc*.
 
     AnchoredOffsetbox has a single child.  When multiple children are needed,
     use an extra OffsetBox to enclose them.  By default, the offset box is


### PR DESCRIPTION
It can likely be made even clearer; here I tried to just repeat what was written but with a clearer style.

Some minor additional edits are included as well.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
