### PR TITLE
Upgrade to Visual Studio 2022 in appveyor.yml

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ skip_commits:
 
 clone_depth: 50
 
-image: Visual Studio 2019
+image: Visual Studio 2022
 
 environment:
 


### PR DESCRIPTION
Let's see if this resolves the build error

--------

Previous description:

Call vcvars batch file in appveyor.yml

As per https://www.appveyor.com/docs/lang/cpp/

Recent Appveyor builds including #30232 and #30236 are failing with

<details><summary>log lines for <code> pip install -v --no-build-isolation --editable .[dev] </code></summary>

```
pip install -v --no-build-isolation --editable .[dev]
Using pip 25.1.1 from C:\Users\appveyor\AppData\Roaming\mamba\envs\mpl-dev\Lib\site-packages\pip (python 3.11)
Obtaining file:///C:/projects/matplotlib
  Checking if build backend supports build_editable: started
  Running command Checking if build backend supports build_editable
  Checking if build backend supports build_editable: finished with status 'done'
  Preparing editable metadata (pyproject.toml): started
  Running command Preparing editable metadata (pyproject.toml)
  + meson setup C:\projects\matplotlib C:\projects\matplotlib\build\cp311 -Dbuildtype=release -Db_ndebug=if-release -Db_vscrt=md --native-file=C:\projects\matplotlib\build\cp311\meson-python-native-file.ini
  The Meson build system
  Version: 1.8.2
  Source dir: C:\projects\matplotlib
  Build dir: C:\projects\matplotlib\build\cp311
  Build type: native build
  Program python found: YES 3.11.13 3.11.13
  Project name: matplotlib
  Project version: 3.11.0.dev1494+g211d94a8
  ..\..\meson.build:1:0: ERROR: Unknown compiler(s): [['cl.exe']]
  The following exception(s) were encountered:
  Running `cl.exe /?` gave "[WinError 2] The system cannot find the file specified"
  A full log can be found at C:\projects\matplotlib\build\cp311\meson-logs\meson-log.txt
  error: subprocess-exited-with-error
  
  × Preparing editable metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> See above for output.
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
  full command: 'C:\Users\appveyor\AppData\Roaming\mamba\envs\mpl-dev\python.exe' 'C:\Users\appveyor\AppData\Roaming\mamba\envs\mpl-dev\Lib\site-packages\pip\_vendor\pyproject_hooks\_in_process\_in_process.py' prepare_metadata_for_build_editable 'C:\Users\appveyor\AppData\Local\Temp\1\tmpls4kfivo'
  cwd: C:\projects\matplotlib
  Preparing editable metadata (pyproject.toml): finished with status 'error'
error: metadata-generation-failed
× Encountered error while generating package metadata.
╰─> See above for output.
note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
Command exited with code 1
```

</details>

This build at least gets past that command.