### PR TITLE
Adjust logic in RcParams to allow for inheritance

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -799,13 +799,13 @@ class RcParams(MutableMapping, dict):
 
         """
         pattern_re = re.compile(pattern)
-        return RcParams((key, value)
-                        for key, value in self.items()
-                        if pattern_re.search(key))
+        return self.__class__(
+            (key, value) for key, value in self.items() if pattern_re.search(key)
+        )
 
     def copy(self):
         """Copy this RcParams instance."""
-        rccopy = RcParams()
+        rccopy = self.__class__()
         for k in self:  # Skip deprecations and revalidation.
             rccopy._set(k, self._get(k))
         return rccopy


### PR DESCRIPTION
We over at [UltraPlot](https://github.com/Ultraplot/ultraplot) ran into an issue where I wanted to derrive our RcClass directly from matplotlib's RcParams. However, in the source I noticed there are two places where the class hardcodes the class itself. This PR addresses this issue by making that initialization tied to the class type, opening up the potential for direct inheritance without needing to override these methods.