### PR TITLE
Move cibuildwheel configuration to pyproject.toml

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -4,6 +4,7 @@
       - any-glob-to-any-file:
           - '.github/workflows/cibuildwheel.yml'
           - '.github/workflows/wasm.yml'
+          - 'pyproject.toml'
 "CI: Run cygwin":
   - changed-files:
       - any-glob-to-any-file: ['.github/workflows/cygwin.yml']

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -97,31 +97,6 @@ jobs:
     permissions:
       contents: read
     runs-on: ${{ matrix.os }}
-    env:
-      CIBW_BEFORE_BUILD: >-
-        rm -rf {package}/build
-      CIBW_BEFORE_BUILD_WINDOWS: >-
-        pip install delvewheel &&
-        rm -rf {package}/build
-      CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: >-
-        delvewheel repair -w {dest_dir} {wheel}
-      CIBW_AFTER_BUILD: >-
-        twine check {wheel} &&
-        python {package}/ci/check_wheel_licenses.py {wheel}
-      # On Windows, we explicitly request MSVC compilers (as GitHub Action runners have
-      # MinGW on PATH that would be picked otherwise), switch to a static build for
-      # runtimes, but use dynamic linking for `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`,
-      # and the UCRT. This avoids requiring specific versions of `MSVCP140.dll`, while
-      # keeping shared state with the rest of the Python process/extensions.
-      CIBW_CONFIG_SETTINGS_WINDOWS: >-
-        setup-args="--vsenv"
-        setup-args="-Db_vscrt=mt"
-        setup-args="-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']"
-      CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-      CIBW_SKIP: "*-musllinux_aarch64"
-      CIBW_TEST_COMMAND: >-
-        python {package}/ci/check_version_number.py
-      MACOSX_DEPLOYMENT_TARGET: "10.12"
     strategy:
       matrix:
         include:
@@ -155,17 +130,14 @@ jobs:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}
         env:
           CIBW_BUILD: "cp314-* cp314t-*"
-          CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
 
       - name: Build wheels for CPython 3.13
         uses: pypa/cibuildwheel@8d2b08b68458a16aeb24b64e68a09ab1c8e82084  # v3.4.1
         with:
           package-dir: dist/${{ needs.build_sdist.outputs.SDIST_NAME }}
         env:
-          CIBW_BUILD: "cp313-* cp313t-*"
-          CIBW_ENABLE: cpython-freethreading
+          CIBW_BUILD: "cp313-*"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
 
       - name: Build wheels for CPython 3.12

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -400,6 +400,21 @@ addopts = [
     "--import-mode=importlib",
 ]
 
+[tool.cibuildwheel]
+enable = ["cpython-freethreading"]
+skip = "*-musllinux_aarch64"
+manylinux-x86_64-image = "manylinux2014"
+
+before-build = "rm -rf {package}/build"
+test-command = [
+    # "python {package}/ci/check_wheel_licenses.py {wheel}",
+    "python {package}/ci/check_version_number.py",
+]
+test-environment = "PIP_PREFER_BINARY=true"
+
+[tool.cibuildwheel.macos.environment]
+MACOSX_DEPLOYMENT_TARGET = "10.12"
+
 [tool.cibuildwheel.pyodide]
 test-requires = "pytest"
 test-command = [
@@ -422,3 +437,26 @@ test-command = [
 CFLAGS = "-fexceptions"
 CXXFLAGS = "-fexceptions"
 LDFLAGS = "-fexceptions"
+
+[tool.cibuildwheel.windows]
+before-build = [
+    "pip install delvewheel",
+    "rm -rf {package}/build",
+]
+repair-wheel-command = "delvewheel repair -w {dest_dir} {wheel}"
+
+[tool.cibuildwheel.windows.config-settings]
+# On Windows, we explicitly request MSVC compilers (as GitHub Action runners have
+# MinGW on PATH that would be picked otherwise), switch to a static build for
+# runtimes, but use dynamic linking for `VCRUNTIME140.dll`, `VCRUNTIME140_1.dll`,
+# and the UCRT. This avoids requiring specific versions of `MSVCP140.dll`, while
+# keeping shared state with the rest of the Python process/extensions.
+setup-args = [
+    "--vsenv",
+    "-Db_vscrt=mt",
+    "-Dcpp_link_args=['ucrt.lib','vcruntime.lib','/nodefaultlib:libucrt.lib','/nodefaultlib:libvcruntime.lib']",
+]
+
+[[tool.cibuildwheel.overrides]]
+select = "cp314*"
+manylinux-x86_64-image = "manylinux_2_28"


### PR DESCRIPTION
## PR summary

This allows developers to test out the build locally. With this, I was able to fix the test command by setting `PIP_PREFER_BINARY` to avoid re-building Pillow, which accidentally dropped manylinux2014 wheels in the latest release: https://github.com/python-pillow/Pillow/issues/9057

Note also that we previously set `CIBW_AFTER_BUILD`, but this doesn't seem to be a valid setting. Thus I have dropped the `twine check`, which only tests the `README` rendering and so checking the sdist is sufficient. Additionally, I have commented out the license check, as we cannot do multiple licenses with meson-python without PEP639 (#28982).

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines