### PR TITLE
Time out in _get_executable_info

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -400,12 +400,15 @@ def _get_executable_info(name):
         try:
             output = subprocess.check_output(
                 args, stderr=subprocess.STDOUT,
-                text=True, errors="replace")
+                text=True, errors="replace", timeout=30)
         except subprocess.CalledProcessError as _cpe:
             if ignore_exit_code:
                 output = _cpe.output
             else:
                 raise ExecutableNotFoundError(str(_cpe)) from _cpe
+        except subprocess.TimeoutExpired as _te:
+            msg = f"Timed out running {cbook._pformat_subprocess(args)}"
+            raise ExecutableNotFoundError(msg) from _te
         except OSError as _ose:
             raise ExecutableNotFoundError(str(_ose)) from _ose
         match = re.search(regex, output)

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -1,6 +1,7 @@
 import os
 import subprocess
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -80,3 +81,16 @@ def test_importable_with__OO():
         [sys.executable, "-OO", "-c", program],
         env={**os.environ, "MPLBACKEND": ""}, check=True
         )
+
+
+@patch('matplotlib.subprocess.check_output')
+def test_get_executable_info_timeout(mock_check_output):
+    """
+    Test that _get_executable_info raises ExecutableNotFoundError if the
+    command times out.
+    """
+
+    mock_check_output.side_effect = subprocess.TimeoutExpired(cmd=['mock'], timeout=30)
+
+    with pytest.raises(matplotlib.ExecutableNotFoundError, match='Timed out'):
+        matplotlib._get_executable_info.__wrapped__('inkscape')


### PR DESCRIPTION
Time out after 30 seconds. This is used for version queries which
should be very fast, so a 30-second delay would be unusual.

GitHub Actions test runs have been hanging trying to get the
inkscape version when using Python 3.14:

https://github.com/matplotlib/matplotlib/actions/runs/16043158943/job/45268507848#step:13:836

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
