### PR TITLE
[MNT] Use Literal for `level` parameter in `set_loglevel` (#30257)

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -283,9 +283,7 @@ def _ensure_handler():
     return handler
 
 
-def set_loglevel(
-    level: Literal["notset", "debug", "info", "warning", "error", "critical"]
-):
+def set_loglevel(level):
     """
     Configure Matplotlib's logging levels.
 

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -137,7 +137,6 @@ __all__ = [
 
 import atexit
 from collections import namedtuple
-from typing import Literal
 from collections.abc import MutableMapping
 import contextlib
 import functools

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -137,6 +137,7 @@ __all__ = [
 
 import atexit
 from collections import namedtuple
+from typing import Literal
 from collections.abc import MutableMapping
 import contextlib
 import functools
@@ -153,6 +154,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+
 
 from packaging.version import parse as parse_version
 
@@ -281,7 +283,9 @@ def _ensure_handler():
     return handler
 
 
-def set_loglevel(level):
+def set_loglevel(
+    level: Literal["notset", "debug", "info", "warning", "error", "critical"]
+):
     """
     Configure Matplotlib's logging levels.
 
@@ -309,7 +313,6 @@ def set_loglevel(level):
     The first time this function is called, an additional handler is attached
     to Matplotlib's root handler; this handler is reused every time and this
     function simply manipulates the logger and handler's level.
-
     """
     _log.setLevel(level.upper())
     _ensure_handler().setLevel(level.upper())


### PR DESCRIPTION
## Summary

This PR replaces the `str` type annotation with `typing.Literal` for the `level` parameter in `matplotlib.set_loglevel`. This improves static type checking and IDE autocompletion for common log levels.

## Changes
- Introduced `Literal` type for accepted log level values: `"notset"`, `"debug"`, `"info"`, `"warning"`, `"error"`, `"critical"`
- Helps clarify valid values to users and tooling without changing runtime behavior

## Notes
- No logic has been changed
- No tests were added since this is strictly a typing improvement

Closes #30257