### PR TITLE
[TYP] Add more literals to MarkerType

### DIFF
--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -51,7 +51,7 @@ ColourType: TypeAlias = ColorType
 
 LineStyleType: TypeAlias = (
     Literal["-", "solid", "--", "dashed", "-.", "dashdot", ":", "dotted",
-    "", "none", " ", "None"] |
+            "", "none", " ", "None"] |
     tuple[float, Sequence[float]]
 )
 """
@@ -60,7 +60,7 @@ See :doc:`/gallery/lines_bars_and_markers/linestyles`.
 """
 
 DrawStyleType: TypeAlias = Literal["default", "steps", "steps-pre", "steps-mid",
-"steps-post"]
+                                   "steps-post"]
 """See :doc:`/gallery/lines_bars_and_markers/step_demo`."""
 
 MarkEveryType: TypeAlias = (

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -76,8 +76,8 @@ MarkerType: TypeAlias = (
         "1", "2", "3", "4", "8", "s", "p",
         "P", "*", "h", "H", "+", "x", "X",
         "D", "d", "|", "_", "none", " ",
-        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
-    ] | list[tuple[int, int]] | tuple[int, Literal[1, 2, 3], int]
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+    ] | list[tuple[int, int]] | tuple[int, Literal[0, 1, 2], int]
 )
 """
 Marker specification. See :doc:`/gallery/lines_bars_and_markers/marker_reference`.

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -1,5 +1,3 @@
-from builtins import list
-
 """
 Typing support for Matplotlib
 
@@ -12,6 +10,7 @@ downstream libraries.
     The ``typing`` module and type stub files are considered provisional and may change
     at any time without a deprecation period.
 """
+from builtins import list
 from collections.abc import Hashable, Sequence
 import pathlib
 from typing import Any, Callable, Literal, TypeAlias, TypeVar, Union

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -1,3 +1,5 @@
+from builtins import list
+
 """
 Typing support for Matplotlib
 
@@ -49,7 +51,7 @@ ColourType: TypeAlias = ColorType
 
 LineStyleType: TypeAlias = (
     Literal["-", "solid", "--", "dashed", "-.", "dashdot", ":", "dotted",
-            "", "none", " ", "None"] |
+    "", "none", " ", "None"] |
     tuple[float, Sequence[float]]
 )
 """
@@ -58,7 +60,7 @@ See :doc:`/gallery/lines_bars_and_markers/linestyles`.
 """
 
 DrawStyleType: TypeAlias = Literal["default", "steps", "steps-pre", "steps-mid",
-                                   "steps-post"]
+"steps-post"]
 """See :doc:`/gallery/lines_bars_and_markers/step_demo`."""
 
 MarkEveryType: TypeAlias = (
@@ -69,7 +71,16 @@ MarkEveryType: TypeAlias = (
 )
 """See :doc:`/gallery/lines_bars_and_markers/markevery_demo`."""
 
-MarkerType: TypeAlias = str | path.Path | MarkerStyle
+MarkerType: TypeAlias = (
+    path.Path | MarkerStyle | str |  # str required for "$...$" marker
+    Literal[
+        ".", ",", "o", "v", "^", "<", ">",
+        "1", "2", "3", "4", "8", "s", "p",
+        "P", "*", "h", "H", "+", "x", "X",
+        "D", "d", "|", "_", "none", " ",
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11
+    ] | list[tuple[int, int]] | tuple[int, Literal[1, 2, 3], int]
+)
 """
 Marker specification. See :doc:`/gallery/lines_bars_and_markers/marker_reference`.
 """

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -10,7 +10,6 @@ downstream libraries.
     The ``typing`` module and type stub files are considered provisional and may change
     at any time without a deprecation period.
 """
-from builtins import list
 from collections.abc import Hashable, Sequence
 import pathlib
 from typing import Any, Callable, Literal, TypeAlias, TypeVar, Union


### PR DESCRIPTION
## PR summary
This PR update the `MarkerType`

- Add `Literal` for accepted `str` and `int` values
- Add `list` for accept [`verts`](https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers:~:text=verts,the%20unit%20cell.)
- Add `tuple` for accept [regular polygon, star-like and asterisk](https://matplotlib.org/stable/api/markers_api.html#module-matplotlib.markers:~:text=(numsides%2C%200%2C%20angle),asterisk%20with%20numsides%20sides%2C%20rotated%20by%20angle.)


## PR checklist
- [ ] #30257
