### PR TITLE
Tweak docstrings of get_window_extent/get_tightbbox.

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -321,13 +321,12 @@ class Artist:
 
     def get_window_extent(self, renderer=None):
         """
-        Get the artist's bounding box in display space.
+        Get the artist's bounding box in display space, ignoring clipping.
 
         The bounding box's width and height are non-negative.
 
-        Subclasses should override for inclusion in the bounding box
-        "tight" calculation. Default is to return an empty bounding
-        box at 0, 0.
+        Subclasses should override for inclusion in the bounding box "tight"
+        calculation.  Default is to return an empty bounding box at 0, 0.
 
         .. warning::
 
@@ -341,28 +340,40 @@ class Artist:
           screen render incorrectly when saved to file.
 
           To get accurate results you may need to manually call
-          `matplotlib.figure.Figure.savefig` or
-          `matplotlib.figure.Figure.draw_without_rendering` to have Matplotlib
-          compute the rendered size.
+          `~.Figure.savefig` or `~.Figure.draw_without_rendering` to have
+          Matplotlib compute the rendered size.
 
+        Parameters
+        ----------
+        renderer : `~matplotlib.backend_bases.RendererBase`, optional
+            Renderer used to draw the figure (i.e. ``fig.canvas.get_renderer()``).
+
+        See Also
+        --------
+        `~.Artist.get_tightbbox` :
+            Get the artist bounding box, taking clipping into account.
         """
         return Bbox([[0, 0], [0, 0]])
 
     def get_tightbbox(self, renderer=None):
         """
-        Like `.Artist.get_window_extent`, but includes any clipping.
+        Get the artist's bounding box in display space, taking clipping into account.
 
         Parameters
         ----------
-        renderer : `~matplotlib.backend_bases.RendererBase` subclass, optional
-            renderer that will be used to draw the figures (i.e.
-            ``fig.canvas.get_renderer()``)
+        renderer : `~matplotlib.backend_bases.RendererBase`, optional
+            Renderer used to draw the figure (i.e. ``fig.canvas.get_renderer()``).
 
         Returns
         -------
         `.Bbox` or None
-            The enclosing bounding box (in figure pixel coordinates).
-            Returns None if clipping results in no intersection.
+            The enclosing bounding box (in figure pixel coordinates), or None
+            if clipping results in no intersection.
+
+        See Also
+        --------
+        `~.Artist.get_window_extent` :
+            Get the artist bounding box, ignoring clipping.
         """
         bbox = self.get_window_extent(renderer)
         if self.get_clip_on():


### PR DESCRIPTION
Make the difference between the two methods clearer (only the latter takes clipping into account).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
