### PR TITLE
Run subprocess-starting tests without pytest-xdist

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -337,9 +337,18 @@ jobs:
           if [[ "${{ matrix.python-version }}" == '3.13t' ]]; then
             export PYTHON_GIL=0
           fi
-          pytest -rfEsXR -n auto \
-            --maxfail=50 --timeout=300 --durations=25 \
-            --cov-report=xml --cov=lib --log-level=DEBUG --color=yes
+          FLAGS=(
+            -rfEsXR
+            --maxfail=50
+            --timeout=300
+            --durations=25
+            --cov-report=xml
+            --cov=lib
+            --log-level=DEBUG
+            --color=yes
+          )
+          pytest "${FLAGS[@]}" -m 'not subprocess' -n auto
+          pytest "${FLAGS[@]}" -m subprocess --cov-append
 
       - name: Cleanup non-failed image files
         if: failure()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -120,9 +120,18 @@ stages:
 
               echo "##vso[task.setvariable variable=VS_COVERAGE_TOOL]$TOOL"
 
-              PYTHONFAULTHANDLER=1 pytest -rfEsXR -n 2 \
-                  --maxfail=50 --timeout=300 --durations=25 \
-                  --junitxml=junit/test-results.xml --cov-report=xml --cov=lib
+              FLAGS=(
+                -rfEsXR
+                --maxfail=50
+                --timeout=300
+                --durations=25
+                --cov-report=xml
+                --cov=lib
+              )
+              PYTHONFAULTHANDLER=1 pytest "${FLAGS[@]}" -m 'not subprocess' -n 2 \
+                  --junitxml=junit/test-results-1.xml
+              PYTHONFAULTHANDLER=1 pytest "${FLAGS[@]}" -m subprocess \
+                  --junitxml=junit/test-results-2.xml --cov-append
 
               if [[ $VS_VER == 2022 ]]; then
                 "$TOOL" shutdown $SESSION_ID
@@ -153,7 +162,8 @@ stages:
 
           - task: PublishTestResults@2
             inputs:
-              testResultsFiles: '**/test-results.xml'
+              mergeTestResults: true
+              testResultsFiles: '**/test-results*.xml'
               testRunTitle: 'Python $(python.version)'
             condition: succeededOrFailed()
 

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -15,6 +15,7 @@ def pytest_configure(config):
         ("markers", "backend: Set alternate Matplotlib backend temporarily."),
         ("markers", "baseline_images: Compare output against references."),
         ("markers", "pytz: Tests that require pytz to be installed."),
+        ("markers", "subprocess: Tests that start a subprocess."),
         ("filterwarnings", "error"),
         ("filterwarnings",
          "ignore:.*The py23 module has been deprecated:DeprecationWarning"),

--- a/lib/matplotlib/tests/test_backend_inline.py
+++ b/lib/matplotlib/tests/test_backend_inline.py
@@ -10,6 +10,7 @@ nbformat = pytest.importorskip('nbformat')
 pytest.importorskip('nbconvert')
 pytest.importorskip('ipykernel')
 pytest.importorskip('matplotlib_inline')
+pytestmark = pytest.mark.subprocess
 
 
 def test_ipynb():

--- a/lib/matplotlib/tests/test_backend_nbagg.py
+++ b/lib/matplotlib/tests/test_backend_nbagg.py
@@ -9,6 +9,7 @@ from matplotlib.testing import subprocess_run_for_testing
 nbformat = pytest.importorskip('nbformat')
 pytest.importorskip('nbconvert')
 pytest.importorskip('ipykernel')
+pytestmark = pytest.mark.subprocess
 
 # From https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
 

--- a/lib/matplotlib/tests/test_backend_webagg.py
+++ b/lib/matplotlib/tests/test_backend_webagg.py
@@ -6,6 +6,7 @@ import matplotlib.backends.backend_webagg_core
 from matplotlib.testing import subprocess_run_for_testing
 
 
+@pytest.mark.subprocess
 @pytest.mark.parametrize("backend", ["webagg", "nbagg"])
 def test_webagg_fallback(backend):
     pytest.importorskip("tornado")

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -22,6 +22,9 @@ from matplotlib.backend_tools import ToolToggleBase
 from matplotlib.testing import subprocess_run_helper as _run_helper, is_ci_environment
 
 
+pytestmark = pytest.mark.subprocess
+
+
 class _WaitForStringPopen(subprocess.Popen):
     """
     A Popen that passes flags that allow triggering KeyboardInterrupt.

--- a/lib/matplotlib/tests/test_basic.py
+++ b/lib/matplotlib/tests/test_basic.py
@@ -5,6 +5,8 @@ import textwrap
 
 from matplotlib.testing import subprocess_run_for_testing
 
+import pytest
+
 
 def test_simple():
     assert 1 + 1 == 2
@@ -28,6 +30,7 @@ def test_override_builtins():
     assert overridden <= ok_to_override
 
 
+@pytest.mark.subprocess
 def test_lazy_imports():
     source = textwrap.dedent("""
     import sys

--- a/lib/matplotlib/tests/test_determinism.py
+++ b/lib/matplotlib/tests/test_determinism.py
@@ -21,6 +21,8 @@ import matplotlib.testing.compare
 from matplotlib.text import TextPath
 from matplotlib.transforms import IdentityTransform
 
+pytestmark = pytest.mark.subprocess
+
 
 def _save_figure(objects='mhip', fmt="pdf", usetex=False):
     mpl.use(fmt)

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -289,6 +289,7 @@ def test_fontcache_thread_safe():
     subprocess_run_helper(_test_threading, timeout=10)
 
 
+@pytest.mark.subprocess
 def test_lockfilefailure(tmp_path):
     # The logic here:
     # 1. get a temp directory from pytest

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -19,6 +19,7 @@ def test_parse_to_version_info(version_str, version_tuple):
     assert matplotlib._parse_to_version_info(version_str) == version_tuple
 
 
+@pytest.mark.subprocess
 @pytest.mark.skipif(sys.platform == "win32",
                     reason="chmod() doesn't work as is on Windows")
 @pytest.mark.skipif(sys.platform != "win32" and os.geteuid() == 0,
@@ -37,6 +38,7 @@ def test_tmpconfigdir_warning(tmp_path):
         os.chmod(tmp_path, mode)
 
 
+@pytest.mark.subprocess
 def test_importable_with_no_home(tmp_path):
     subprocess_run_for_testing(
         [sys.executable, "-c",

--- a/lib/matplotlib/tests/test_preprocess_data.py
+++ b/lib/matplotlib/tests/test_preprocess_data.py
@@ -245,6 +245,7 @@ def test_docstring_addition():
                          funcy.__doc__)
 
 
+@pytest.mark.subprocess
 def test_data_parameter_replacement():
     """
     Test that the docstring contains the correct *data* parameter stub

--- a/lib/matplotlib/tests/test_pyplot.py
+++ b/lib/matplotlib/tests/test_pyplot.py
@@ -12,6 +12,7 @@ from matplotlib.testing import subprocess_run_for_testing
 from matplotlib import pyplot as plt
 
 
+@pytest.mark.subprocess
 def test_pyplot_up_to_date(tmp_path):
     pytest.importorskip("black")
 

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -528,6 +528,7 @@ def test_rcparams_reset_after_fail():
         assert mpl.rcParams['text.usetex'] is False
 
 
+@pytest.mark.subprocess
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
 def test_backend_fallback_headless_invalid_backend(tmp_path):
     env = {**os.environ,
@@ -545,6 +546,7 @@ def test_backend_fallback_headless_invalid_backend(tmp_path):
             env=env, check=True, stderr=subprocess.DEVNULL)
 
 
+@pytest.mark.subprocess
 @pytest.mark.skipif(sys.platform != "linux", reason="Linux only")
 def test_backend_fallback_headless_auto_backend(tmp_path):
     # specify a headless mpl environment, but request a graphical (tk) backend
@@ -567,6 +569,7 @@ def test_backend_fallback_headless_auto_backend(tmp_path):
     assert backend.strip().lower() == "agg"
 
 
+@pytest.mark.subprocess
 @pytest.mark.skipif(
     sys.platform == "linux" and not _c_internal_utils.xdisplay_is_valid(),
     reason="headless")

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -16,6 +16,7 @@ pytest.importorskip('sphinx', minversion='4.1.3')
 tinypages = Path(__file__).parent / 'data/tinypages'
 
 
+@pytest.mark.subprocess
 def build_sphinx_html(source_dir, doctree_dir, html_dir, extra_args=None):
     # Build the pages with warnings turned into errors
     extra_args = [] if extra_args is None else extra_args

--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -63,6 +63,7 @@ def test_unicode_characters():
         fig.canvas.draw()
 
 
+@pytest.mark.subprocess
 @needs_usetex
 def test_openin_any_paranoid():
     completed = subprocess_run_for_testing(


### PR DESCRIPTION
I suspect that we are running out of process IDs, or the scheduler
is not letting all subprocesses execute, leading to timeouts in
tests that start subprocesses when there are other tests executing.
This happens often with Python 3.14 tests for some reason.
