### PR TITLE
Reduce pause time in interactive timer test

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -649,12 +649,9 @@ def _impl_test_interactive_timers():
     # milliseconds, which the mac framework interprets as singleshot.
     # We only want singleshot if we specify that ourselves, otherwise we want
     # a repeating timer
-    import os
     from unittest.mock import Mock
     import matplotlib.pyplot as plt
-    # increase pause duration on CI to let things spin up
-    # particularly relevant for gtk3cairo
-    pause_time = 2 if os.getenv("CI") else 0.5
+    pause_time = 0.5
     fig = plt.figure()
     plt.pause(pause_time)
     timer = fig.canvas.new_timer(0.1)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Since the Appveyor run is timing out, I went hunting for some low hanging fruit to speed up the tests. From the slower tests, this seemed like an obvious target as each run of the test is taking ~10 seconds. This seems to work fine.

Since gtk3cairo is disabled in this test, the comment doesn't seem relevant any more.



## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
