### PR TITLE
Fix mlab fallback for 32-bit systems

### DIFF
--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -212,16 +212,8 @@ def detrend_linear(y):
 
 
 def _stride_windows(x, n, noverlap=0):
-    x = np.asarray(x)
-
     _api.check_isinstance(Integral, n=n, noverlap=noverlap)
-    if not (1 <= n <= x.size and n < noverlap):
-        raise ValueError(f'n ({n}) and noverlap ({noverlap}) must be positive integers '
-                         f'with n < noverlap and n <= x.size ({x.size})')
-
-    if n == 1 and noverlap == 0:
-        return x[np.newaxis]
-
+    x = np.asarray(x)
     step = n - noverlap
     shape = (n, (x.shape[-1]-noverlap)//step)
     strides = (x.strides[0], step*x.strides[0])
@@ -257,7 +249,7 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
     if NFFT is None:
         NFFT = 256
 
-    if noverlap >= NFFT:
+    if not (0 <= noverlap < NFFT):
         raise ValueError('noverlap must be less than NFFT')
 
     if mode is None or mode == 'default':

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -1,3 +1,5 @@
+import sys
+
 from numpy.testing import (assert_allclose, assert_almost_equal,
                            assert_array_equal, assert_array_almost_equal_nulp)
 import numpy as np
@@ -429,7 +431,16 @@ class TestSpectral:
         assert spec.shape[0] == freqs.shape[0]
         assert spec.shape[1] == getattr(self, f"t_{case}").shape[0]
 
-    def test_csd(self):
+    @pytest.mark.parametrize('bitsize', [
+        pytest.param(None, id='default'),
+        pytest.param(32,
+                     marks=pytest.mark.skipif(sys.maxsize <= 2**32,
+                                              reason='System is already 32-bit'),
+                     id='32-bit')
+    ])
+    def test_csd(self, bitsize, monkeypatch):
+        if bitsize is not None:
+            monkeypatch.setattr(sys, 'maxsize', 2**bitsize)
         freqs = self.freqs_density
         spec, fsp = mlab.csd(x=self.y, y=self.y+1,
                              NFFT=self.NFFT_density,


### PR DESCRIPTION
## PR summary

Unfortunately, I applied the change from
https://github.com/matplotlib/matplotlib/pull/29115#discussion_r2189746839 directly without noticing the typo, or running full tests.

So fix the swapped condition, and add a test (for `csd` only, which should be enough since everything goes though `_spectral_helper`.) This test should work on 64-bit systems as well, but I also double-checked on WASM.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines