### PR TITLE
ci: Fix image preload with multiple conflicts

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -107,8 +107,8 @@ jobs:
                       lib/matplotlib/tests/baseline_images \
                       lib/mpl_toolkits/*/tests/baseline_images)
           if [ -n "${conflicts}" ]; then
-            git checkout --ours -- "${conflicts}"
-            git add -- "${conflicts}"
+            git checkout --ours -- ${conflicts}
+            git add -- ${conflicts}
           fi
           # If committing fails, there were conflicts other than the baseline images,
           # which should not be allowed to happen, and should fail the build.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -79,8 +79,8 @@ stages:
                           lib/matplotlib/tests/baseline_images \
                           lib/mpl_toolkits/*/tests/baseline_images)
               if [ -n "${conflicts}" ]; then
-                git checkout --ours -- "${conflicts}"
-                git add -- "${conflicts}"
+                git checkout --ours -- ${conflicts}
+                git add -- ${conflicts}
               fi
               # If committing fails, there were conflicts other than the baseline images,
               # which should not be allowed to happen, and should fail the build.

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -219,9 +219,6 @@ def _stride_windows(x, n, noverlap=0):
         raise ValueError(f'n ({n}) and noverlap ({noverlap}) must be positive integers '
                          f'with n < noverlap and n <= x.size ({x.size})')
 
-    if n == 1 and noverlap == 0:
-        return x[np.newaxis]
-
     step = n - noverlap
     shape = (n, (x.shape[-1]-noverlap)//step)
     strides = (x.strides[0], step*x.strides[0])


### PR DESCRIPTION
## PR summary

I only tested #30231 with a _single_ conflict. Unfortunately, the variable quoting did not work when there were multiple conflicts. This PR should fix that (and currently has a test change to verify it.)

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines