### PR TITLE
fix(config): Correct invalid value for svg.fonttype in matplotlibrc

### DIFF
--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -761,7 +761,7 @@
 #svg.fonttype: path      # How to handle SVG fonts:
                          #     path: Embed characters as paths -- supported
                          #           by most SVG renderers
-                         #     None: Assume fonts are installed on the
+                         #     none: Assume fonts are installed on the
                          #           machine where the SVG will be viewed.
 #svg.hashsalt: None      # If not None, use this string as hash salt instead of uuid4
 #svg.id: None            # If not None, use this string as the value for the `id`


### PR DESCRIPTION
The `None` value for `svg.fonttype` is invalid and causes a `ValueError`. This change replaces `None` with the valid string `'none'` to resolve the error.