### PR TITLE
Fixed the overdeletion of source images for failing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -344,34 +344,29 @@ jobs:
       - name: Cleanup non-failed image files
         if: failure()
         run: |
-          function remove_files() {
-              local extension=$1
-              find ./result_images -name "*-expected*.$extension" | while read file; do
-                  if [[ $file == *"-expected_pdf"* ]]; then
-                      base=${file%-expected_pdf.$extension}_pdf
-                  elif [[ $file == *"-expected_eps"* ]]; then
-                      base=${file%-expected_eps.$extension}_eps
-                  elif [[ $file == *"-expected_svg"* ]]; then
-                      base=${file%-expected_svg.$extension}_svg
-                  elif [[ $file == *"-expected_gif"* ]]; then
-                      base=${file%-expected_gif.$extension}_gif
-                  else
-                      base=${file%-expected.$extension}
-                  fi
-                  if [[ ! -e "${base}-failed-diff.$extension" ]]; then
-                      if [[ -e "$file" ]]; then
-                          rm "$file"
-                          echo "Removed $file"
-                      fi
-                      if [[ -e "${base}.$extension" ]]; then
-                          rm "${base}.$extension"
-                          echo " Removed ${base}.$extension"
-                      fi
-                  fi
+          find ./result_images -name "*-expected*.png" | while read file; do
+            if [[ $file == *-expected_???.png ]]; then
+              extension=${file: -7:3}
+              base=${file%*-expected_$extension.png}_$extension
+            else
+              extension="png"
+              base=${file%-expected.png}
+            fi
+            if [[ ! -e ${base}-failed-diff.png ]]; then
+              indent=""
+              list=($file $base.png)
+              if [[ $extension != "png" ]]; then
+                list+=(${base%_$extension}-expected.$extension ${base%_$extension}.$extension)
+              fi
+              for to_remove in "${list[@]}"; do
+                if [[ -e $to_remove ]]; then
+                  rm $to_remove
+                  echo "${indent}Removed $to_remove"
+                fi
+                indent+=" "
               done
-          }
-
-          remove_files "png"; remove_files "svg"; remove_files "pdf"; remove_files "eps"; remove_files "gif";
+            fi
+          done
 
           if [ "$(find ./result_images -mindepth 1 -type d)" ]; then
               find ./result_images/* -type d -empty -delete


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

This PR further fixes the deletion of all images that have passed tests before uploading the artifact (see #27882 and #30188).  #27882 had separated calls to delete PNGs, PDFs, SVGs, etc., but that approach is flawed because all non-PNG files are converted to PNGs for comparison.  That is, there is never a difference PDF, only a difference PDF-converted-to-PNG, which means that the code would always delete PDFs due to the lack of difference PDFs.  So, after the fix of #30188, the uploaded artifact would have expected/actual PDF-converted-to-PNG for failing PDF tests, but were missing the expected/actual PDF.

Fixing this required a significant rewrite of the shell script.  I've tested this extensively in an unrelated PR with a bunch of failing image tests.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
