### PR TITLE
Fix whitespace in _axes.py error message

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2296,8 +2296,8 @@ class Axes(_AxesBase):
             facecolor = mcolors.to_rgba_array(facecolor)
         except ValueError as err:
             raise ValueError(
-                "'facecolor' or 'color' argument must be a valid color or"
-                    "sequence of colors."
+                "'facecolor' or 'color' argument must be a valid color or "
+                "sequence of colors."
             ) from err
 
         return facecolor, edgecolor


### PR DESCRIPTION
Closes #30285

## PR summary

This PR adds a whitespace following the word "or", resulting in a correctly formatted error message.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

