### PR TITLE
DOC: Fix build with pybind11 3

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -122,7 +122,11 @@
       "doc/api/_as_gen/mpl_toolkits.axisartist.floating_axes.rst:32:<autosummary>:1"
     ],
     "numpy.float64": [
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1",
       "doc/docstring of matplotlib.ft2font.PyCapsule.set_text:1"
+    ],
+    "numpy.typing.NDArray": [
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1"
     ],
     "numpy.uint8": [
       "<unknown>:1"


### PR DESCRIPTION
## PR summary

As of https://github.com/pybind/pybind11/pull/5212, pybind11 now uses `numpy.typing.NDArray` instead of `numpy.ndarray`, and as of https://github.com/pybind/pybind11/pull/5580, it changed the name of the internal wrapper that Sphinx sees.

Since we already ignore `numpy.float64` missing references for the same method, add the new name and new class to ignores as well.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines