### PR TITLE
DOC: clarify Annotation clipping behavior with set_clip_path after axis limit changes

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1857,6 +1857,19 @@ or callable, default: value of *xycoords*
         --------
         :ref:`annotations`
 
+        Notes
+        -----
+        When using `.set_clip_path()` to clip an annotation to a patch (e.g., an
+        `axvspan`), be aware that if the axis limits (such as via `set_xlim()`)
+        are changed *after* assigning the clip path, the clipping may no longer
+        align visually. This is because the patch transform may change, but the
+        annotation’s clip path remains tied to the old coordinates.
+
+        To avoid this issue, you should either:
+        - Set the axis limits *before* setting the clip path, or
+        - Reassign the clip path manually using a new patch with the correct transform
+          (typically `transform=ax.transData`).
+
         """
         _AnnotationBase.__init__(self,
                                  xy,


### PR DESCRIPTION
This PR updates the docstring for `Annotation.__init__()` to clarify that when `.set_clip_path()` is used (e.g., to clip an annotation to an `axvspan` patch), subsequent axis limit changes (like `set_xlim()`) may cause the clipping to become misaligned.

The new `Notes` section advises users to:
- Set axis limits *before* applying the clip path, or
- Reassign the clip path using a new patch with the appropriate transform, e.g., `ax.transData`.

This clarification was inspired by the behavior discussed in issue #28717 and related use cases.

## PR summary

- **Why is this change necessary?**  
  The current documentation does not mention that axis limits applied after setting a clip path can lead to incorrect visual behavior. This can confuse users working with annotations clipped to spans or patches.

- **What problem does it solve?**  
  Prevents misunderstandings by documenting how to maintain correct clipping behavior after axis limit changes.

- **What is the reasoning for this implementation?**  
  A simple docstring clarification is sufficient since the behavior is not a bug but an undocumented side effect.

- **Minimum reproducible example:**

```python
fig, ax = plt.subplots()
rect = ax.axvspan(2, 3.05, ymin=0, ymax=1, color='red', alpha=0.5)
ann = ax.annotate("Hello", xy=(3, 0.5), xycoords=("data", "axes fraction"),
                  xytext=(0, 0), textcoords="offset points", va="center", clip_on=True)
ann.set_clip_path(rect)

# This causes clipping to break visually
ax.set_xlim(0, 3)