### PR TITLE
[MNT] Typing: Use Literal for set_loglevel 

### DIFF
--- a/lib/matplotlib/__init__.pyi
+++ b/lib/matplotlib/__init__.pyi
@@ -40,6 +40,8 @@ from packaging.version import Version
 
 from matplotlib._api import MatplotlibDeprecationWarning
 from typing import Any, Literal, NamedTuple, overload
+from matplotlib.typing import LogLevel
+
 
 class _VersionInfo(NamedTuple):
     major: int
@@ -52,7 +54,7 @@ __bibtex__: str
 __version__: str
 __version_info__: _VersionInfo
 
-def set_loglevel(level: str) -> None: ...
+def set_loglevel(level: LogLevel) -> None: ...
 
 class _ExecInfo(NamedTuple):
     executable: str

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -144,6 +144,7 @@ if TYPE_CHECKING:
         MouseEventType,
         PickEventType,
         ResizeEventType,
+        LogLevel
     )
     from matplotlib.widgets import SubplotTool
 
@@ -351,7 +352,7 @@ draw_all = _pylab_helpers.Gcf.draw_all
 
 # Ensure this appears in the pyplot docs.
 @_copy_docstring_and_deprecators(matplotlib.set_loglevel)
-def set_loglevel(level: str) -> None:
+def set_loglevel(level: LogLevel) -> None:
     return matplotlib.set_loglevel(level)
 
 

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -83,6 +83,9 @@ JoinStyleType: TypeAlias = JoinStyle | Literal["miter", "round", "bevel"]
 CapStyleType: TypeAlias = CapStyle | Literal["butt", "projecting", "round"]
 """Line cap styles. See :doc:`/gallery/lines_bars_and_markers/capstyle`."""
 
+LogLevel: TypeAlias = Literal["notset", "debug", "info", "warning", "error", "critical"]
+"""Literal type for valid logging levels accepted by `set_loglevel()`."""
+
 CoordsBaseType = Union[
     str,
     Artist,


### PR DESCRIPTION
This PR addresses part of https://github.com/matplotlib/matplotlib/issues/30257 by improving type safety and IDE support for set_loglevel.

Changes in this PR:

- Introduced LogLevel as a TypeAlias in matplotlib.typing, using Literal to restrict accepted values.
- Updated set_loglevel() in init.py to use LogLevel.

This improves discoverability and static type checking for valid logging levels like "info", "debug", "error", etc.

Related work not included here
MarkerType updates were implemented by [@ZPyrolink](https://github.com/ZPyrolink) in https://github.com/matplotlib/matplotlib/pull/30261
Event type literals for connect methods were contributed by [@ZPyrolink](https://github.com/ZPyrolink) in https://github.com/matplotlib/matplotlib/pull/30275