### PR TITLE
fix broken configobj link

### DIFF
--- a/doc/users/prev_whats_new/changelog.rst
+++ b/doc/users/prev_whats_new/changelog.rst
@@ -1689,7 +1689,7 @@ recent changes, please refer to the :doc:`/users/release_notes`.
     required by the experimental traited config and are somewhat out of date.
     If needed, install them independently, see
     http://code.enthought.com/pages/traits.html and
-    http://www.voidspace.org.uk/python/configobj.html
+    https://configobj.readthedocs.io/en/latest/
 
 2008-12-12
     Added support to assign labels to histograms of multiple data. - MM


### PR DESCRIPTION

This PR updates one of the links mentioned in #30306 :

http://www.voidspace.org.uk/python/configobj.html is defunct and is replaced with https://configobj.readthedocs.io/en/latest/

## PR summary
Updated link for configobj at ./doc/users/prev_whats_new/changelog.rst - previous link was inactive.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/30306)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
