### PR TITLE
Don't set a default size for FT2Font

### DIFF
--- a/doc/api/next_api_changes/behavior/30318-ES.rst
+++ b/doc/api/next_api_changes/behavior/30318-ES.rst
@@ -1,0 +1,9 @@
+FT2Font no longer sets a default size
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In the interest of handling non-scalable fonts and reducing font initialization, the
+`.FT2Font` constructor no longer sets a default size. Non-scalable fonts are sometimes
+used for bitmap-backed emoji fonts.
+
+If metrics are important (i.e., if you are loading character glyphs, or setting a text
+string), then explicitly call `.FT2Font.set_size` beforehand.

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -188,8 +188,8 @@ def test_ft2font_clear():
 
 def test_ft2font_set_size():
     file = fm.findfont('DejaVu Sans')
-    # Default is 12pt @ 72 dpi.
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=1)
+    font.set_size(12, 72)
     font.set_text('ABabCDcd')
     orig = font.get_width_height()
     font.set_size(24, 72)
@@ -757,6 +757,7 @@ def test_ft2font_get_kerning(left, right, unscaled, unfitted, default):
 def test_ft2font_set_text():
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=0)
+    font.set_size(12, 72)
     xys = font.set_text('')
     np.testing.assert_array_equal(xys, np.empty((0, 2)))
     assert font.get_width_height() == (0, 0)
@@ -778,6 +779,7 @@ def test_ft2font_set_text():
 def test_ft2font_loading():
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=0)
+    font.set_size(12, 72)
     for glyph in [font.load_char(ord('M')),
                   font.load_glyph(font.get_char_index(ord('M')))]:
         assert glyph is not None
@@ -818,11 +820,13 @@ def test_ft2font_drawing():
     expected *= 255
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=0)
+    font.set_size(12, 72)
     font.set_text('M')
     font.draw_glyphs_to_bitmap(antialiased=False)
     image = font.get_image()
     np.testing.assert_array_equal(image, expected)
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=0)
+    font.set_size(12, 72)
     glyph = font.load_char(ord('M'))
     image = np.zeros(expected.shape, np.uint8)
     font.draw_glyph_to_bitmap(image, -1, 1, glyph, antialiased=False)
@@ -832,6 +836,7 @@ def test_ft2font_drawing():
 def test_ft2font_get_path():
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file, hinting_factor=1, _kerning_factor=0)
+    font.set_size(12, 72)
     vertices, codes = font.get_path()
     assert vertices.shape == (0, 2)
     assert codes.shape == (0, )

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -221,12 +221,6 @@ FT2Font::FT2Font(FT_Open_Args &open_args,
     if (open_args.stream != nullptr) {
         face->face_flags |= FT_FACE_FLAG_EXTERNAL_STREAM;
     }
-    try {
-        set_size(12., 72.);  // Set a default fontsize 12 pt at 72dpi.
-    } catch (...) {
-        FT_Done_Face(face);
-        throw;
-    }
     // Set fallbacks
     std::copy(fallback_list.begin(), fallback_list.end(), std::back_inserter(fallbacks));
 }


### PR DESCRIPTION
## PR summary

In the interest of handling non-scalable fonts and reducing font initialization, drop the default size from the `FT2Font` constructor. Non-scalable fonts are sometimes used for bitmap-backed emoji fonts. When we start supporting collection fonts (`.ttc`), then setting a size is a waste, as we will just need to read the count of fonts within.

The renderer method `Renderer.draw_text` always sets a size immediately after creating the font object, so this doesn't affect anything in most cases. Only the direct `FT2Font` tests need changes.

I'm only unsure whether we wish to somehow warn/deprecate when this the size isn't set explicitly.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines