### PR TITLE
FIX Update Axes limits from Axes.add_collection(... autolim=True)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2361,7 +2361,17 @@ class _AxesBase(martist.Artist):
                 # the call so that self.dataLim will update its own minpos.
                 # This ensures that log scales see the correct minimum.
                 points = np.concatenate([points, [datalim.minpos]])
-            self.update_datalim(points)
+            # only update the dataLim for x/y if the collection uses transData
+            # in this direction.
+            x_is_data, y_is_data = (collection.get_transform()
+                                    .contains_branch_seperately(self.transData))
+            ox_is_data, oy_is_data = (collection.get_offset_transform()
+                                      .contains_branch_seperately(self.transData))
+            self.update_datalim(
+                points,
+                updatex=x_is_data or ox_is_data,
+                updatey=y_is_data or oy_is_data,
+            )
 
         self.stale = True
         return collection

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -899,17 +899,24 @@ def test_collection_set_array():
 
 
 def test_blended_collection_autolim():
-    a = [1, 2, 4]
-    height = .2
-
-    xy_pairs = np.column_stack([np.repeat(a, 2), np.tile([0, height], len(a))])
-    line_segs = xy_pairs.reshape([len(a), 2, 2])
-
     f, ax = plt.subplots()
+
+    # sample data to give initial data limits
+    ax.plot([2, 3, 4], [0.4, 0.6, 0.5])
+    np.testing.assert_allclose((ax.dataLim.xmin, ax.dataLim.xmax), (2, 4))
+    data_ymin, data_ymax = ax.dataLim.ymin, ax.dataLim.ymax
+
+    # LineCollection with vertical lines spanning the Axes vertical, using transAxes
+    x = [1, 2, 3, 4, 5]
+    vertical_lines = [np.array([[xi, 0], [xi, 1]]) for xi in x]
     trans = mtransforms.blended_transform_factory(ax.transData, ax.transAxes)
-    ax.add_collection(LineCollection(line_segs, transform=trans))
-    ax.autoscale_view(scalex=True, scaley=False)
-    np.testing.assert_allclose(ax.get_xlim(), [1., 4.])
+    ax.add_collection(LineCollection(vertical_lines, transform=trans))
+
+    # check that the x data limits are updated to include the LineCollection
+    np.testing.assert_allclose((ax.dataLim.xmin, ax.dataLim.xmax), (1, 5))
+    # check that the y data limits are not updated (because they are not transData)
+    np.testing.assert_allclose((ax.dataLim.ymin, ax.dataLim.ymax),
+                               (data_ymin, data_ymax))
 
 
 def test_singleton_autolim():


### PR DESCRIPTION
... the update now happens separately for both directions, and only if that direction uses data coordinates. Previously, limits were always recalculated for both directions.

Closes #30320.
