### PR TITLE
Fix legend `labelcolor=‘linecolor’` to handle various corner cases, e.g. step histograms and transparent markers

### DIFF
--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -1068,6 +1068,244 @@ def test_legend_labelcolor_rcparam_markerfacecolor_short():
         assert mpl.colors.same_color(text.get_color(), color)
 
 
+def test_legend_labelcolor_linecolor_histograms():
+    x = np.arange(10)
+
+    # testing c kwarg for bar, step, and stepfilled histograms
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='bar', color='r',
+                      label="red bar hist with a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='step', color='g',
+                      label="green step hist with a green label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'g')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, h[0].get_edgecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='stepfilled', color='b',
+                      label="blue stepfilled hist with a blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    # testing c, fc, and ec combinations for bar histograms
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='bar', color='r', ec='b',
+                      label="red bar hist with blue edges and a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='bar', fc='r', ec='b',
+                      label="red bar hist with blue edges and a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='bar', fc='none', ec='b',
+                      label="unfilled blue bar hist with a blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, h[0].get_edgecolor())
+
+    # testing c, and ec combinations for step histograms
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='step', color='r', ec='b',
+                      label="blue step hist with a blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, h[0].get_edgecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='step', ec='b',
+                      label="blue step hist with a blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, h[0].get_edgecolor())
+
+    # testing c, fc, and ec combinations for stepfilled histograms
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='stepfilled', color='r', ec='b',
+                      label="red stepfilled hist, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='stepfilled', fc='r', ec='b',
+                      label="red stepfilled hist, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='stepfilled', fc='none', ec='b',
+                      label="unfilled blue stepfilled hist, blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, h[0].get_edgecolor())
+
+    fig, ax = plt.subplots()
+    _, _, h = ax.hist(x, histtype='stepfilled', fc='r', ec='none',
+                      label="edgeless red stepfilled hist with a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_patches()[0].get_facecolor())
+    assert mpl.colors.same_color(tc, h[0].get_facecolor())
+    plt.close('all')
+
+
+def test_legend_labelcolor_linecolor_plot():
+    x = np.arange(5)
+
+    # testing line plot
+    fig, ax = plt.subplots()
+    p = ax.plot(x, c='r', label="red line with a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_color())
+    assert mpl.colors.same_color(tc, p[0].get_color())
+
+    # testing c, fc, and ec combinations for maker plots
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', c='r', label="red circles with a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_color())
+    assert mpl.colors.same_color(tc, p[0].get_color())
+
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', c='r', mec='b', label="red circles, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_color())
+    assert mpl.colors.same_color(tc, p[0].get_color())
+
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', mfc='r', mec='b', label="red circles, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_markerfacecolor())
+    assert mpl.colors.same_color(tc, p[0].get_markerfacecolor())
+
+    # 'none' cases
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', mfc='none', mec='b', label="blue unfilled circles, blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_markeredgecolor())
+    assert mpl.colors.same_color(tc, p[0].get_markeredgecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', mfc='r', mec='none', label="red edgeless circles, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.get_lines()[0].get_markerfacecolor())
+    assert mpl.colors.same_color(tc, p[0].get_markerfacecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.plot(x, 'o', c='none', label="invisible circles with invisible label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert tc == 'none'
+    assert tc == leg.get_lines()[0].get_markerfacecolor()
+    assert tc == leg.get_lines()[0].get_markeredgecolor()
+    assert tc == leg.get_lines()[0].get_color()
+    assert tc == p[0].get_markerfacecolor()
+    assert tc == p[0].get_markeredgecolor()
+    assert tc == p[0].get_color()
+    plt.close('all')
+
+
+def test_legend_labelcolor_linecolor_scatter():
+    x = np.arange(5)
+
+    # testing c, fc, and ec combinations for scatter plots
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, c='r', label="red circles with a red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.legend_handles[0].get_facecolor())
+    assert mpl.colors.same_color(tc, p.get_facecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, c='r', ec='b', label="red circles, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.legend_handles[0].get_facecolor())
+    assert mpl.colors.same_color(tc, p.get_facecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, fc='r', ec='b', label="red circles, blue edges, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.legend_handles[0].get_facecolor())
+    assert mpl.colors.same_color(tc, p.get_facecolor())
+
+    # 'none' cases
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, fc='none', ec='b', label="blue unfilled circles, blue label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'b')
+    assert mpl.colors.same_color(tc, leg.legend_handles[0].get_edgecolor())
+    assert mpl.colors.same_color(tc, p.get_edgecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, fc='r', ec='none', label="red edgeless circles, red label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert mpl.colors.same_color(tc, 'r')
+    assert mpl.colors.same_color(tc, leg.legend_handles[0].get_facecolor())
+    assert mpl.colors.same_color(tc, p.get_facecolor())
+
+    fig, ax = plt.subplots()
+    p = ax.scatter(x, x, c='none', label="invisible circles with invisible label")
+    leg = ax.legend(loc=1, labelcolor='linecolor')
+    tc = leg.texts[0].get_color()
+    assert tc == 'none'
+    plt.close('all')
+
+
 @pytest.mark.filterwarnings("ignore:No artists with labels found to put in legend")
 def test_get_set_draggable():
     legend = plt.legend()


### PR DESCRIPTION

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

This PR addresses issue #30298, which pointed out some corner cases, where `labelcolor='linecolor'` did not work as expected, e.g.:
* histograms with `histtype='step'` or scatter plots with `fc='none'` had an empty legend label.
* plots that specified `mec` and `mfc` but not `c` would end up with non-matching handle and label colours.


### Changes:
* Change `'linecolor'` ordering of checks from `c, fc` to `mfc, fc, mec, ec, c`.
* Skip when `color` is empty, equal to `none` or with a zero alpha value, e.g. when `fc` is `'none'` continue the loop to check whether there is some color in `ec`.


Thanks to @nrnavaneet, who worked on this in #30299, and which this PR is based on.

Closes #30298


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] ~~*Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)~~
- [ ] ~~*New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)~~
- [ ] ~~Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines~~

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
