### PR TITLE
Deprecate font_manager.is_opentype_cff_font

### DIFF
--- a/doc/api/next_api_changes/deprecations/30329-ES.rst
+++ b/doc/api/next_api_changes/deprecations/30329-ES.rst
@@ -1,0 +1,4 @@
+``font_manager.is_opentype_cff_font`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There is no replacement.

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1539,7 +1539,7 @@ class FontManager:
         return _cached_realpath(result)
 
 
-@lru_cache
+@_api.deprecated("3.11")
 def is_opentype_cff_font(filename):
     """
     Return whether the given font is a Postscript Compact Font Format Font

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -67,12 +67,14 @@ def test_json_serialization(tmp_path):
 def test_otf():
     fname = '/usr/share/fonts/opentype/freefont/FreeMono.otf'
     if Path(fname).exists():
-        assert is_opentype_cff_font(fname)
+        with pytest.warns(mpl.MatplotlibDeprecationWarning):
+            assert is_opentype_cff_font(fname)
     for f in fontManager.ttflist:
         if 'otf' in f.fname:
             with open(f.fname, 'rb') as fd:
                 res = fd.read(4) == b'OTTO'
-            assert res == is_opentype_cff_font(f.fname)
+            with pytest.warns(mpl.MatplotlibDeprecationWarning):
+                assert res == is_opentype_cff_font(f.fname)
 
 
 @pytest.mark.skipif(sys.platform == "win32" or not has_fclist,


### PR DESCRIPTION
## PR summary

According to the docs, it was used for PostScript and PDF which "cannot subset those fonts". However, that is no longer true, and there are no users of this function.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines