### PR TITLE
FIX: cast Patch linewidth to float for dash scaling

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -459,7 +459,8 @@ class Patch(artist.Artist):
         w : float or None
         """
         w = mpl._val_or_rc(w, 'patch.linewidth')
-        self._linewidth = float(w)
+        w = float(w)
+        self._linewidth = w
         self._dash_pattern = mlines._scale_dashes(*self._unscaled_dash_pattern, w)
         self.stale = True
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

Fixes #30323.  The code from https://github.com/matplotlib/matplotlib/issues/30323#issuecomment-3083500554 now produces

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/5b862da1-b08e-4d8c-bd5a-6d8d06ab996b" />

For now I have not added a test - as noted at https://github.com/matplotlib/matplotlib/issues/30323#issuecomment-3090023905

> The obvious test (set linewidth with a string) would represent a use-case that seems controversial amongst the maintainers, so I am not sure if we want that in there.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
