### PR TITLE
Support fractional HiDPI in GTK4 backend

### DIFF
--- a/galleries/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
@@ -44,10 +44,9 @@ def on_activate(app):
     toolbar = NavigationToolbar(canvas)
     vbox.append(toolbar)
 
-    win.show()
+    win.present()
 
 
-app = Gtk.Application(
-    application_id='org.matplotlib.examples.EmbeddingInGTK4PanZoom')
+app = Gtk.Application(application_id='org.matplotlib.examples.EmbeddingInGTK4PanZoom')
 app.connect('activate', on_activate)
 app.run(None)

--- a/galleries/examples/user_interfaces/embedding_in_gtk4_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk4_sgskip.py
@@ -39,7 +39,7 @@ def on_activate(app):
     canvas.set_size_request(800, 600)
     sw.set_child(canvas)
 
-    win.show()
+    win.present()
 
 
 app = Gtk.Application(application_id='org.matplotlib.examples.EmbeddingInGTK4')

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -30,6 +30,7 @@ from ._backend_gtk import (  # noqa: F401 # pylint: disable=W0611
 )
 
 _GOBJECT_GE_3_47 = gi.version_info >= (3, 47, 0)
+_GTK_GE_4_12 = Gtk.check_version(4, 12, 0) is None
 
 
 class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
@@ -48,7 +49,10 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
 
         self.set_draw_func(self._draw_func)
         self.connect('resize', self.resize_event)
-        self.connect('notify::scale-factor', self._update_device_pixel_ratio)
+        if _GTK_GE_4_12:
+            self.connect('realize', self._realize_event)
+        else:
+            self.connect('notify::scale-factor', self._update_device_pixel_ratio)
 
         click = Gtk.GestureClick()
         click.set_button(0)  # All buttons.
@@ -237,10 +241,20 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
                 and not (mod == "shift" and unikey.isprintable()))]
         return "+".join([*mods, key])
 
+    def _realize_event(self, obj):
+        surface = self.get_native().get_surface()
+        surface.connect('notify::scale', self._update_device_pixel_ratio)
+        self._update_device_pixel_ratio()
+
     def _update_device_pixel_ratio(self, *args, **kwargs):
         # We need to be careful in cases with mixed resolution displays if
         # device_pixel_ratio changes.
-        if self._set_device_pixel_ratio(self.get_scale_factor()):
+        if _GTK_GE_4_12:
+            scale = self.get_native().get_surface().get_scale()
+        else:
+            scale = self.get_scale_factor()
+        assert scale is not None
+        if self._set_device_pixel_ratio(scale):
             self.draw()
 
     def _draw_rubberband(self, rect):


### PR DESCRIPTION
## PR summary

Since GTK 4.12, fractional HiDPI is handled, but with a separate property on the backing surface due to it being a different type.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines