### PR TITLE
MNT: Fix isort line length setting

### DIFF
--- a/galleries/examples/axisartist/demo_axis_direction.py
+++ b/galleries/examples/axisartist/demo_axis_direction.py
@@ -12,8 +12,7 @@ from matplotlib.transforms import Affine2D
 import mpl_toolkits.axisartist as axisartist
 import mpl_toolkits.axisartist.angle_helper as angle_helper
 import mpl_toolkits.axisartist.grid_finder as grid_finder
-from mpl_toolkits.axisartist.grid_helper_curvelinear import \
-    GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 
 
 def setup_axes(fig, rect):

--- a/galleries/examples/axisartist/demo_curvelinear_grid.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid.py
@@ -17,8 +17,7 @@ import numpy as np
 from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D
 from mpl_toolkits.axisartist import Axes, HostAxes, angle_helper
-from mpl_toolkits.axisartist.grid_helper_curvelinear import \
-    GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 
 
 def curvelinear_test1(fig):

--- a/galleries/examples/axisartist/demo_curvelinear_grid2.py
+++ b/galleries/examples/axisartist/demo_curvelinear_grid2.py
@@ -14,10 +14,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from mpl_toolkits.axisartist.axislines import Axes
-from mpl_toolkits.axisartist.grid_finder import (ExtremeFinderSimple,
-                                                 MaxNLocator)
-from mpl_toolkits.axisartist.grid_helper_curvelinear import \
-    GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_finder import ExtremeFinderSimple, MaxNLocator
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 
 
 def curvelinear_test1(fig):

--- a/galleries/examples/axisartist/demo_floating_axes.py
+++ b/galleries/examples/axisartist/demo_floating_axes.py
@@ -22,8 +22,7 @@ from matplotlib.projections import PolarAxes
 from matplotlib.transforms import Affine2D
 import mpl_toolkits.axisartist.angle_helper as angle_helper
 import mpl_toolkits.axisartist.floating_axes as floating_axes
-from mpl_toolkits.axisartist.grid_finder import (DictFormatter, FixedLocator,
-                                                 MaxNLocator)
+from mpl_toolkits.axisartist.grid_finder import DictFormatter, FixedLocator, MaxNLocator
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)

--- a/galleries/examples/axisartist/simple_axis_pad.py
+++ b/galleries/examples/axisartist/simple_axis_pad.py
@@ -13,8 +13,7 @@ from matplotlib.transforms import Affine2D
 import mpl_toolkits.axisartist as axisartist
 import mpl_toolkits.axisartist.angle_helper as angle_helper
 import mpl_toolkits.axisartist.grid_finder as grid_finder
-from mpl_toolkits.axisartist.grid_helper_curvelinear import \
-    GridHelperCurveLinear
+from mpl_toolkits.axisartist.grid_helper_curvelinear import GridHelperCurveLinear
 
 
 def setup_axes(fig, rect):

--- a/galleries/examples/images_contours_and_fields/trigradient_demo.py
+++ b/galleries/examples/images_contours_and_fields/trigradient_demo.py
@@ -9,8 +9,7 @@ Demonstrates computation of gradient with
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib.tri import (CubicTriInterpolator, Triangulation,
-                            UniformTriRefiner)
+from matplotlib.tri import CubicTriInterpolator, Triangulation, UniformTriRefiner
 
 
 # ----------------------------------------------------------------------------

--- a/galleries/examples/misc/anchored_artists.py
+++ b/galleries/examples/misc/anchored_artists.py
@@ -17,8 +17,8 @@ of additional toolkits.
 
 from matplotlib import pyplot as plt
 from matplotlib.lines import Line2D
-from matplotlib.offsetbox import (AnchoredOffsetbox, AuxTransformBox,
-                                  DrawingArea, TextArea, VPacker)
+from matplotlib.offsetbox import (AnchoredOffsetbox, AuxTransformBox, DrawingArea,
+                                  TextArea, VPacker)
 from matplotlib.patches import Circle, Ellipse
 
 

--- a/galleries/examples/specialty_plots/skewt.py
+++ b/galleries/examples/specialty_plots/skewt.py
@@ -151,8 +151,7 @@ if __name__ == '__main__':
     import matplotlib.pyplot as plt
     import numpy as np
 
-    from matplotlib.ticker import (MultipleLocator, NullFormatter,
-                                   ScalarFormatter)
+    from matplotlib.ticker import MultipleLocator, NullFormatter, ScalarFormatter
 
     # Some example data.
     data_txt = '''

--- a/galleries/examples/subplots_axes_and_figures/axes_zoom_effect.py
+++ b/galleries/examples/subplots_axes_and_figures/axes_zoom_effect.py
@@ -7,10 +7,8 @@ Axes zoom effect
 
 import matplotlib.pyplot as plt
 
-from matplotlib.transforms import (Bbox, TransformedBbox,
-                                   blended_transform_factory)
-from mpl_toolkits.axes_grid1.inset_locator import (BboxConnector,
-                                                   BboxConnectorPatch,
+from matplotlib.transforms import Bbox, TransformedBbox, blended_transform_factory
+from mpl_toolkits.axes_grid1.inset_locator import (BboxConnector, BboxConnectorPatch,
                                                    BboxPatch)
 
 

--- a/galleries/examples/text_labels_and_annotations/demo_annotation_box.py
+++ b/galleries/examples/text_labels_and_annotations/demo_annotation_box.py
@@ -13,8 +13,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 from matplotlib.cbook import get_sample_data
-from matplotlib.offsetbox import (AnnotationBbox, DrawingArea, OffsetImage,
-                                  TextArea)
+from matplotlib.offsetbox import AnnotationBbox, DrawingArea, OffsetImage, TextArea
 from matplotlib.patches import Circle
 
 fig, ax = plt.subplots()

--- a/galleries/examples/text_labels_and_annotations/demo_text_path.py
+++ b/galleries/examples/text_labels_and_annotations/demo_text_path.py
@@ -13,8 +13,7 @@ import numpy as np
 
 from matplotlib.cbook import get_sample_data
 from matplotlib.image import BboxImage
-from matplotlib.offsetbox import (AnchoredOffsetbox, AnnotationBbox,
-                                  AuxTransformBox)
+from matplotlib.offsetbox import AnchoredOffsetbox, AnnotationBbox, AuxTransformBox
 from matplotlib.patches import PathPatch, Shadow
 from matplotlib.text import TextPath
 from matplotlib.transforms import IdentityTransform

--- a/galleries/examples/ticks/date_demo_rrule.py
+++ b/galleries/examples/ticks/date_demo_rrule.py
@@ -17,8 +17,7 @@ import datetime
 import matplotlib.pyplot as plt
 import numpy as np
 
-from matplotlib.dates import (YEARLY, DateFormatter, RRuleLocator, drange,
-                              rrulewrapper)
+from matplotlib.dates import YEARLY, DateFormatter, RRuleLocator, drange, rrulewrapper
 
 # Fixing random state for reproducibility
 np.random.seed(19680801)

--- a/galleries/examples/ticks/date_formatters_locators.py
+++ b/galleries/examples/ticks/date_formatters_locators.py
@@ -13,11 +13,10 @@ import matplotlib.pyplot as plt
 import numpy as np
 
 # While these appear unused directly, they are used from eval'd strings.
-from matplotlib.dates import (FR, MO, MONTHLY, SA, SU, TH, TU, WE,
-                              AutoDateFormatter, AutoDateLocator,
-                              ConciseDateFormatter, DateFormatter, DayLocator,
-                              HourLocator, MicrosecondLocator, MinuteLocator,
-                              MonthLocator, RRuleLocator, SecondLocator,
+from matplotlib.dates import (FR, MO, MONTHLY, SA, SU, TH, TU, WE, AutoDateFormatter,
+                              AutoDateLocator, ConciseDateFormatter, DateFormatter,
+                              DayLocator, HourLocator, MicrosecondLocator,
+                              MinuteLocator, MonthLocator, RRuleLocator, SecondLocator,
                               WeekdayLocator, YearLocator, rrulewrapper)
 import matplotlib.ticker as ticker
 

--- a/galleries/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk3_panzoom_sgskip.py
@@ -13,10 +13,8 @@ from gi.repository import Gtk
 
 import numpy as np
 
-from matplotlib.backends.backend_gtk3 import \
-    NavigationToolbar2GTK3 as NavigationToolbar
-from matplotlib.backends.backend_gtk3agg import \
-    FigureCanvasGTK3Agg as FigureCanvas
+from matplotlib.backends.backend_gtk3 import NavigationToolbar2GTK3 as NavigationToolbar
+from matplotlib.backends.backend_gtk3agg import FigureCanvasGTK3Agg as FigureCanvas
 from matplotlib.figure import Figure
 
 win = Gtk.Window()

--- a/galleries/examples/user_interfaces/embedding_in_gtk3_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk3_sgskip.py
@@ -14,8 +14,7 @@ from gi.repository import Gtk
 
 import numpy as np
 
-from matplotlib.backends.backend_gtk3agg import \
-    FigureCanvasGTK3Agg as FigureCanvas
+from matplotlib.backends.backend_gtk3agg import FigureCanvasGTK3Agg as FigureCanvas
 from matplotlib.figure import Figure
 
 win = Gtk.Window()

--- a/galleries/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk4_panzoom_sgskip.py
@@ -13,10 +13,8 @@ from gi.repository import Gtk
 
 import numpy as np
 
-from matplotlib.backends.backend_gtk4 import \
-    NavigationToolbar2GTK4 as NavigationToolbar
-from matplotlib.backends.backend_gtk4agg import \
-    FigureCanvasGTK4Agg as FigureCanvas
+from matplotlib.backends.backend_gtk4 import NavigationToolbar2GTK4 as NavigationToolbar
+from matplotlib.backends.backend_gtk4agg import FigureCanvasGTK4Agg as FigureCanvas
 from matplotlib.figure import Figure
 
 

--- a/galleries/examples/user_interfaces/embedding_in_gtk4_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_gtk4_sgskip.py
@@ -14,8 +14,7 @@ from gi.repository import Gtk
 
 import numpy as np
 
-from matplotlib.backends.backend_gtk4agg import \
-    FigureCanvasGTK4Agg as FigureCanvas
+from matplotlib.backends.backend_gtk4agg import FigureCanvasGTK4Agg as FigureCanvas
 from matplotlib.figure import Figure
 
 

--- a/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_qt_sgskip.py
@@ -15,8 +15,7 @@ import time
 import numpy as np
 
 from matplotlib.backends.backend_qtagg import FigureCanvas
-from matplotlib.backends.backend_qtagg import \
-    NavigationToolbar2QT as NavigationToolbar
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT as NavigationToolbar
 from matplotlib.backends.qt_compat import QtWidgets
 from matplotlib.figure import Figure
 

--- a/galleries/examples/user_interfaces/embedding_in_tk_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_tk_sgskip.py
@@ -11,8 +11,7 @@ import numpy as np
 
 # Implement the default Matplotlib key bindings.
 from matplotlib.backend_bases import key_press_handler
-from matplotlib.backends.backend_tkagg import (FigureCanvasTkAgg,
-                                               NavigationToolbar2Tk)
+from matplotlib.backends.backend_tkagg import FigureCanvasTkAgg, NavigationToolbar2Tk
 from matplotlib.figure import Figure
 
 root = tkinter.Tk()

--- a/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -31,8 +31,8 @@ import tornado.websocket
 import numpy as np
 
 import matplotlib as mpl
-from matplotlib.backends.backend_webagg import (
-    FigureManagerWebAgg, new_figure_manager_given_figure)
+from matplotlib.backends.backend_webagg import (FigureManagerWebAgg,
+                                                new_figure_manager_given_figure)
 from matplotlib.figure import Figure
 
 

--- a/galleries/examples/user_interfaces/mpl_with_glade3_sgskip.py
+++ b/galleries/examples/user_interfaces/mpl_with_glade3_sgskip.py
@@ -13,8 +13,7 @@ from gi.repository import Gtk
 
 import numpy as np
 
-from matplotlib.backends.backend_gtk3agg import \
-    FigureCanvasGTK3Agg as FigureCanvas
+from matplotlib.backends.backend_gtk3agg import FigureCanvasGTK3Agg as FigureCanvas
 from matplotlib.figure import Figure
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,6 +91,7 @@ known_pydata = "numpy, matplotlib.pyplot"
 known_firstparty = "matplotlib,mpl_toolkits"
 sections = "FUTURE,STDLIB,THIRDPARTY,PYDATA,FIRSTPARTY,LOCALFOLDER"
 force_sort_within_sections = true
+line_length = 88
 
 [tool.ruff]
 extend-exclude = [


### PR DESCRIPTION
## PR summary

It is currently at the default of 79, which doesn't match our linting setting of 88.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines