### PR TITLE
Keep default minor log ticks if there's 1 major & 1 minor tick.

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -356,6 +356,10 @@ class TestLogLocator:
         loc = mticker.LogLocator(subs=np.arange(2, 10))
         assert 1.0 not in loc.tick_values(0.9, 20.)
         assert 10.0 not in loc.tick_values(0.9, 20.)
+        # don't switch if there's already one major and one minor tick (10 & 20)
+        loc = mticker.LogLocator(subs="auto")
+        tv = loc.tick_values(10, 20)
+        assert_array_equal(tv[(10 <= tv) & (tv <= 20)], [20])
 
     def test_set_params(self):
         """

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2522,10 +2522,12 @@ class LogLocator(Locator):
 
         if (len(subs) > 1
                 and stride == 1
-                and ((vmin <= ticklocs) & (ticklocs <= vmax)).sum() <= 1):
+                and (len(decades) - 2  # major
+                     + ((vmin <= ticklocs) & (ticklocs <= vmax)).sum())  # minor
+                     <= 1):
             # If we're a minor locator *that expects at least two ticks per
             # decade* and the major locator stride is 1 and there's no more
-            # than one minor tick, switch to AutoLocator.
+            # than one major or minor tick, switch to AutoLocator.
             return AutoLocator().tick_values(vmin, vmax)
         else:
             return self.raise_if_exceeds(ticklocs)


### PR DESCRIPTION
... rather than switching to AutoLocator.

The old logic only checked whether there's two minor ticks, but one major plus one minor tick works too.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
