### PR TITLE
PR commit Issue 30159 for fixing Axes.clear()

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4753,14 +4753,25 @@ class _AxesBase(martist.Artist):
         self._label_outer_yaxis(skip_non_rectangular_axes=False,
                                 remove_inner_ticks=remove_inner_ticks)
 
+    def _get_subplotspec_with_optional_colorbar(self):
+        """
+        Return the subplotspec for this Axes, except that if this Axes has been
+        moved to a subgridspec to make room for a colorbar, then return the
+        subplotspec that encloses both this Axes and the colorbar Axes.
+        """
+        ss = self.get_subplotspec()
+        if any(cax.get_subplotspec() for cax in self._colorbars):
+            ss = ss.get_gridspec()._subplot_spec
+        return ss
+
     def _label_outer_xaxis(self, *, skip_non_rectangular_axes,
                            remove_inner_ticks=False):
         # see documentation in label_outer.
         if skip_non_rectangular_axes and not isinstance(self.patch,
                                                         mpl.patches.Rectangle):
             return
-        ss = self.get_subplotspec()
-        if not ss:
+        ss = self._get_subplotspec_with_optional_colorbar()
+        if ss is None:
             return
         label_position = self.xaxis.get_label_position()
         if not ss.is_first_row():  # Remove top label/ticklabels/offsettext.
@@ -4786,8 +4797,8 @@ class _AxesBase(martist.Artist):
         if skip_non_rectangular_axes and not isinstance(self.patch,
                                                         mpl.patches.Rectangle):
             return
-        ss = self.get_subplotspec()
-        if not ss:
+        ss = self._get_subplotspec_with_optional_colorbar()
+        if ss is None:
             return
         label_position = self.yaxis.get_label_position()
         if not ss.is_first_col():  # Remove left label/ticklabels/offsettext.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -897,7 +897,7 @@ class _AxesBase(martist.Artist):
         Mark a single axis, or all of them, as stale wrt. autoscaling.
 
         No computation is performed until the next autoscaling; thus, separate
-        calls to control individual `Axis`s incur negligible performance cost.
+        calls to control individual axises incur negligible performance cost.
 
         Parameters
         ----------
@@ -1314,8 +1314,9 @@ class _AxesBase(martist.Artist):
         xaxis_visible = self.xaxis.get_visible()
         yaxis_visible = self.yaxis.get_visible()
 
-        for axis in self._axis_map.values():
-            axis.clear()  # Also resets the scale to linear.
+        for name, axis in self._axis_map.items():
+            if self._shared_axes[name].get_siblings(self) == [self]:
+                axis.clear()  # Also resets the scale to linear.
         for spine in self.spines.values():
             spine._clear()  # Use _clear to not clear Axis again
 
@@ -1420,6 +1421,9 @@ class _AxesBase(martist.Artist):
             share = getattr(self, f"_share{name}")
             if share is not None:
                 getattr(self, f"share{name}")(share)
+            elif self in self._shared_axes[name]:
+                # Do not mess with limits of shared axes.
+                continue
             else:
                 # Although the scale was set to linear as part of clear,
                 # polar requires that _set_scale is called again
@@ -2185,9 +2189,9 @@ class _AxesBase(martist.Artist):
                     xlim = self.get_xlim()
                     ylim = self.get_ylim()
                     edge_size = max(np.diff(xlim), np.diff(ylim))[0]
-                    self.set_xlim(xlim[0], xlim[0] + edge_size,
+                    self.set_xlim([xlim[0], xlim[0] + edge_size],
                                   emit=emit, auto=False)
-                    self.set_ylim(ylim[0], ylim[0] + edge_size,
+                    self.set_ylim([ylim[0], ylim[0] + edge_size],
                                   emit=emit, auto=False)
             else:
                 raise ValueError(f"Unrecognized string {arg!r} to axis; "
@@ -4749,25 +4753,14 @@ class _AxesBase(martist.Artist):
         self._label_outer_yaxis(skip_non_rectangular_axes=False,
                                 remove_inner_ticks=remove_inner_ticks)
 
-    def _get_subplotspec_with_optional_colorbar(self):
-        """
-        Return the subplotspec for this Axes, except that if this Axes has been
-        moved to a subgridspec to make room for a colorbar, then return the
-        subplotspec that encloses both this Axes and the colorbar Axes.
-        """
-        ss = self.get_subplotspec()
-        if any(cax.get_subplotspec() for cax in self._colorbars):
-            ss = ss.get_gridspec()._subplot_spec
-        return ss
-
     def _label_outer_xaxis(self, *, skip_non_rectangular_axes,
                            remove_inner_ticks=False):
         # see documentation in label_outer.
         if skip_non_rectangular_axes and not isinstance(self.patch,
                                                         mpl.patches.Rectangle):
             return
-        ss = self._get_subplotspec_with_optional_colorbar()
-        if ss is None:
+        ss = self.get_subplotspec()
+        if not ss:
             return
         label_position = self.xaxis.get_label_position()
         if not ss.is_first_row():  # Remove top label/ticklabels/offsettext.
@@ -4793,8 +4786,8 @@ class _AxesBase(martist.Artist):
         if skip_non_rectangular_axes and not isinstance(self.patch,
                                                         mpl.patches.Rectangle):
             return
-        ss = self._get_subplotspec_with_optional_colorbar()
-        if ss is None:
+        ss = self.get_subplotspec()
+        if not ss:
             return
         label_position = self.yaxis.get_label_position()
         if not ss.is_first_col():  # Remove left label/ticklabels/offsettext.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -897,7 +897,7 @@ class _AxesBase(martist.Artist):
         Mark a single axis, or all of them, as stale wrt. autoscaling.
 
         No computation is performed until the next autoscaling; thus, separate
-        calls to control individual axises incur negligible performance cost.
+        calls to control individual `Axis`'s incur negligible performance cost.
 
         Parameters
         ----------


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

### Quick fix for shared axis warning during .clear()

This PR implements a minimal, targeted fix for issue [#30159](https://github.com/matplotlib/matplotlib/issues/30159), where calling .clear() on a shared axes — particularly with log scale — results in:

- Limits being reset to (0, 1), which is invalid in log scale
- Warnings emitted due to improper propagation of limits

This patch does a quick fix for the warnings in the issue but does not fully implement the proposed fix in issue [#28851](https://github.com/matplotlib/matplotlib/issues/28851#issuecomment-1712086607)

### What does this fix do?

- Prevents resetting axis limits and scale in .clear() if the axis is shared
- Ensures .clear() only clears data-like elements (lines, text, collections), not layout or shared state

### What this does not do?

- This does not define long-term .clear() semantics

---

## PR checklist

- [x] "closes #30159" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->