### PR TITLE
GOV: change CoC from Contributor Covenant to NumFOCUS CoC

### DIFF
--- a/doc/project/code_of_conduct.rst
+++ b/doc/project/code_of_conduct.rst
@@ -1,148 +1,52 @@
 .. _code_of_conduct:
 .. redirect-from:: /users/project/code_of_conduct
 
-====================================
-Contributor Covenant Code of Conduct
-====================================
+========================
+NUMFOCUS CODE OF CONDUCT
+========================
 
-Our Pledge
-==========
+You can find the whole document here
+https://numfocus.org/code-of-conduct.
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+THE SHORT VERSION
+=================
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+NumFOCUS is dedicated to providing a harassment-free community for
+everyone, regardless of gender, sexual orientation, gender identity and
+expression, disability, physical appearance, body size, race, or
+religion. We do not tolerate harassment of community members in any
+form.
 
-Our Standards
+Be kind to others. Do not insult or put down others. Behave
+professionally. Remember that harassment and sexist, racist, or
+exclusionary jokes are not appropriate for NumFOCUS.
+
+All communication should be appropriate for a professional audience
+including people of many different backgrounds. Sexual language and
+imagery is not appropriate.
+
+Thank you for helping make this a welcoming, friendly community for all.
+
+LONG VERSION
+============
+
+You can find the long version of the Code of Conduct on the NumFOCUS
+website https://numfocus.org/code-of-conduct
+
+HOW TO REPORT
 =============
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+If you feel that the Code of Conduct has been violated, feel free to
+submit a report, by using the form: `NumFOCUS Code of Conduct Reporting
+Form <https://numfocus.typeform.com/to/ynjGdT?typeform-source=numfocus.org>`__
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
-
-Examples of unacceptable behavior include:
-
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
-
-Enforcement Responsibilities
+WHO WILL RECEIVE YOUR REPORT
 ============================
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+Your report will be received and handled by NumFOCUS Code of Conduct
+Working Group; trained, and experienced contributors with diverse
+backgrounds. The group is making decisions independently from the
+project, PyData, NumFOCUS or any other organization.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
-
-Scope
-=====
-
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
-
-Enforcement
-===========
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement at
-`matplotlib-coc@numfocus.org <mailto:matplotlib-coc@numfocus.org>`_ which is
-monitored by the `CoC subcommittee <https://matplotlib.org/governance/people.html#coc-subcommittee>`_ or a
-report can be made using the `NumFOCUS Code of Conduct report form <https://numfocus.typeform.com/to/ynjGdT>`_.
-If community leaders cannot come to a resolution about enforcement,
-reports will be escalated to the NumFocus Code of Conduct committee
-(conduct@numfocus.org).  All complaints will be reviewed and investigated
-promptly and fairly.
-
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
-
-Enforcement Guidelines
-======================
-
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
-
-1. Correction
--------------
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-2. Warning
-----------
-
-**Community Impact**: A violation through a single incident or series
-of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
-
-3. Temporary Ban
-----------------
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-4. Permanent Ban
-----------------
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
-
-Attribution
-===========
-
-This Code of Conduct is adapted from the `Contributor Covenant <https://www.contributor-covenant.org>`_,
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
-
-Community Impact Guidelines were inspired by `Mozilla's code of conduct
-enforcement ladder <https://github.com/mozilla/diversity>`_.
-
-
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+You can learn more about the current group members, as well as the
+reporting procedure `HERE <https://numfocus.org/code-of-conduct>`__


### PR DESCRIPTION
This also changes the reporting from Matplotlib specific CoC committee to the NumFOCUS Code of Conduct Working group.

I want the PR approved by @efiring @dopplershift and @timhoffm before it is merged and there is a paired PR https://github.com/matplotlib/governance/pull/43 that should be merged at the same time this is merged.