### PR TITLE
ENH: Allow tuple for borderpad in AnchoredOffsetbox

### DIFF
--- a/doc/users/next_whats_new/updated_borderpad_parameter.rst
+++ b/doc/users/next_whats_new/updated_borderpad_parameter.rst
@@ -1,0 +1,18 @@
+``borderpad`` accepts a tuple for separate x/y padding
+-------------------------------------------------------
+
+The ``borderpad`` parameter used for placing anchored artists (such as inset axes) now accepts a tuple of ``(x_pad, y_pad)``.
+
+This allows for specifying separate padding values for the horizontal and
+vertical directions, providing finer control over placement. For example, when
+placing an inset in a corner, one might want horizontal padding to avoid
+overlapping with the main plot's axis labels, but no vertical padding to keep
+the inset flush with the plot area edge.
+
+Example usage with :func:`~mpl_toolkits.axes_grid1.inset_locator.inset_axes`:
+
+.. code-block:: python
+
+    ax_inset = inset_axes(
+        ax, width="30%", height="30%", loc='upper left',
+        borderpad=(4, 0))

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1140,9 +1140,10 @@ class Legend(Artist):
         parentbbox : `~matplotlib.transforms.Bbox`
             A parent box which will contain the bbox, in display coordinates.
         """
+        pad = self.borderaxespad * renderer.points_to_pixels(self._fontsize)
         return offsetbox._get_anchored_bbox(
             loc, bbox, parentbbox,
-            self.borderaxespad * renderer.points_to_pixels(self._fontsize))
+            pad, pad)
 
     def _find_best_position(self, width, height, renderer):
         """Determine the best location to place the legend."""

--- a/lib/matplotlib/offsetbox.pyi
+++ b/lib/matplotlib/offsetbox.pyi
@@ -157,7 +157,7 @@ class AnchoredOffsetbox(OffsetBox):
         loc: str,
         *,
         pad: float = ...,
-        borderpad: float = ...,
+        borderpad: float | tuple[float, float] = ...,
         child: OffsetBox | None = ...,
         prop: FontProperties | None = ...,
         frameon: bool = ...,
@@ -185,7 +185,7 @@ class AnchoredText(AnchoredOffsetbox):
         loc: str,
         *,
         pad: float = ...,
-        borderpad: float = ...,
+        borderpad: float | tuple[float, float] = ...,
         prop: dict[str, Any] | None = ...,
         **kwargs
     ) -> None: ...

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -470,3 +470,40 @@ def test_draggable_in_subfigure():
     bbox = ann.get_window_extent()
     MouseEvent("button_press_event", fig.canvas, bbox.x1+2, bbox.y1+2)._process()
     assert not ann._draggable.got_artist
+
+
+def test_anchored_offsetbox_tuple_and_float_borderpad():
+    """
+    Test AnchoredOffsetbox correctly handles both float and tuple for borderpad.
+    """
+
+    fig, ax = plt.subplots()
+
+    # Case 1: Establish a baseline with float value
+    text_float = AnchoredText("float", loc='lower left', borderpad=5)
+    ax.add_artist(text_float)
+
+    # Case 2: Test that a symmetric tuple gives the exact same result.
+    text_tuple_equal = AnchoredText("tuple", loc='lower left', borderpad=(5, 5))
+    ax.add_artist(text_tuple_equal)
+
+    # Case 3: Test that an asymmetric tuple with different values works as expected.
+    text_tuple_asym = AnchoredText("tuple_asym", loc='lower left', borderpad=(10, 4))
+    ax.add_artist(text_tuple_asym)
+
+    # Draw the canvas to calculate final positions
+    fig.canvas.draw()
+
+    pos_float = text_float.get_window_extent()
+    pos_tuple_equal = text_tuple_equal.get_window_extent()
+    pos_tuple_asym = text_tuple_asym.get_window_extent()
+
+    # Assertion 1: Prove that borderpad=5 is identical to borderpad=(5, 5).
+    assert pos_tuple_equal.x0 == pos_float.x0
+    assert pos_tuple_equal.y0 == pos_float.y0
+
+    # Assertion 2: Prove that the asymmetric padding moved the box
+    # further from the origin than the baseline in the x-direction and less far
+    # in the y-direction.
+    assert pos_tuple_asym.x0 > pos_float.x0
+    assert pos_tuple_asym.y0 < pos_float.y0

--- a/lib/mpl_toolkits/axes_grid1/inset_locator.py
+++ b/lib/mpl_toolkits/axes_grid1/inset_locator.py
@@ -341,10 +341,15 @@ def inset_axes(parent_axes, width, height, loc='upper right',
 
         %(Axes:kwdoc)s
 
-    borderpad : float, default: 0.5
+    borderpad : float or (float, float), default: 0.5
         Padding between inset axes and the bbox_to_anchor.
+        If a float, the same padding is used for both x and y.
+        If a tuple of two floats, it specifies the (x, y) padding.
         The units are axes font size, i.e. for a default font size of 10 points
         *borderpad = 0.5* is equivalent to a padding of 5 points.
+
+        .. versionadded:: 3.11
+           The *borderpad* parameter now accepts a tuple of (x, y) paddings.
 
     Returns
     -------


### PR DESCRIPTION
This PR closes #30331 .

## PR summary

This PR enhances `AnchoredOffsetbox` to allow the `borderpad` parameter to accept a tuple of `(x_pad, y_pad)` in addition to a single float value.

- **Why is this change necessary?** Currently, `borderpad` applies the same padding in both x and y directions. This can be inflexible, especially when placing inset axes in a corner. For example, a user may want horizontal padding to avoid overlapping the main plot's y-axis labels, but no vertical padding in order to keep the inset flush with the top of the plot area.

- **What problem does it solve?** It gives users finer control over the positioning of anchored elements, allowing for separate horizontal and vertical padding.

- **What is the reasoning for this implementation?**
  - The implementation modifies `AnchoredOffsetbox.get_offset`.
  - It checks if `self.borderpad` is a tuple and calculates separate `pad_x_pixels` and `pad_y_pixels`.
  - These values are then used to create a manually padded anchor box, which is a robust approach that does not require changing downstream helper functions.
  - The implementation is fully backward-compatible, treating single float values as before.

A new unit test has been added to verify this functionality, and the docstring for `AnchoredOffsetbox` has been updated to reflect the new API.

## PR checklist

- [x] "closes #30331" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines