### PR TITLE
{,Range}Slider: accept callable valfmt arguments

### DIFF
--- a/doc/users/next_whats_new/sliders_callable_valfmt.rst
+++ b/doc/users/next_whats_new/sliders_callable_valfmt.rst
@@ -1,0 +1,6 @@
+Callable *valfmt* for ``Slider`` and ``RangeSlider``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In addition to the existing %-format string, the *valfmt* parameter of
+`~.matplotlib.widgets.Slider` and `~.matplotlib.widgets.RangeSlider` now
+also accepts a callable of the form ``valfmt(val: float) -> str``.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -364,8 +364,9 @@ class Slider(SliderBase):
             The slider initial position.
 
         valfmt : str, default: None
-            %-format string used to format the slider value.  If None, a
-            `.ScalarFormatter` is used instead.
+            The way to format the slider value. If a string, it must be in %-format.
+            If a callable, it must have the signature ``valfmt(val: float) -> str``.
+            If None, a `.ScalarFormatter` is used.
 
         closedmin : bool, default: True
             Whether the slider interval is closed on the bottom.
@@ -547,7 +548,10 @@ class Slider(SliderBase):
     def _format(self, val):
         """Pretty-print *val*."""
         if self.valfmt is not None:
-            return self.valfmt % val
+            if callable(self.valfmt):
+                return self.valfmt(val)
+            else:
+                return self.valfmt % val
         else:
             _, s, _ = self._fmt.format_ticks([self.valmin, val, self.valmax])
             # fmt.get_offset is actually the multiplicative factor, if any.
@@ -644,9 +648,11 @@ class RangeSlider(SliderBase):
             The initial positions of the slider. If None the initial positions
             will be at the 25th and 75th percentiles of the range.
 
-        valfmt : str, default: None
-            %-format string used to format the slider values.  If None, a
-            `.ScalarFormatter` is used instead.
+        valfmt : str or callable, default: None
+            The way to format the range's minimal and maximal values. If a
+            string, it must be in %-format. If a callable, it must have the
+            signature ``valfmt(val: float) -> str``. If None, a
+            `.ScalarFormatter` is used.
 
         closedmin : bool, default: True
             Whether the slider interval is closed on the bottom.
@@ -890,7 +896,10 @@ class RangeSlider(SliderBase):
     def _format(self, val):
         """Pretty-print *val*."""
         if self.valfmt is not None:
-            return f"({self.valfmt % val[0]}, {self.valfmt % val[1]})"
+            if callable(self.valfmt):
+                return f"({self.valfmt(val[0])}, {self.valfmt(val[1])})"
+            else:
+                return f"({self.valfmt % val[0]}, {self.valfmt % val[1]})"
         else:
             _, s1, s2, _ = self._fmt.format_ticks(
                 [self.valmin, *val, self.valmax]

--- a/lib/matplotlib/widgets.pyi
+++ b/lib/matplotlib/widgets.pyi
@@ -64,7 +64,7 @@ class SliderBase(AxesWidget):
     valmax: float
     valstep: float | ArrayLike | None
     drag_active: bool
-    valfmt: str
+    valfmt: str | None
     def __init__(
         self,
         ax: Axes,
@@ -73,7 +73,7 @@ class SliderBase(AxesWidget):
         closedmax: bool,
         valmin: float,
         valmax: float,
-        valfmt: str,
+        valfmt: str | None,
         dragging: Slider | None,
         valstep: float | ArrayLike | None,
     ) -> None: ...

--- a/lib/matplotlib/widgets.pyi
+++ b/lib/matplotlib/widgets.pyi
@@ -64,7 +64,7 @@ class SliderBase(AxesWidget):
     valmax: float
     valstep: float | ArrayLike | None
     drag_active: bool
-    valfmt: str | None
+    valfmt: str | Callable[[float], str] | None
     def __init__(
         self,
         ax: Axes,
@@ -73,7 +73,7 @@ class SliderBase(AxesWidget):
         closedmax: bool,
         valmin: float,
         valmax: float,
-        valfmt: str | None,
+        valfmt: str | Callable[[float], str] | None,
         dragging: Slider | None,
         valstep: float | ArrayLike | None,
     ) -> None: ...
@@ -130,7 +130,7 @@ class RangeSlider(SliderBase):
         valmax: float,
         *,
         valinit: tuple[float, float] | None = ...,
-        valfmt: str | None = ...,
+        valfmt: str | Callable[[float], str] | None = ...,
         closedmin: bool = ...,
         closedmax: bool = ...,
         dragging: bool = ...,


### PR DESCRIPTION
## PR summary

- Why is this change necessary? What problem does it solve?

I wanted to create a slider for an "order of magnitude" parameter, that scales logarithmic, but prints concisely the number in the `valfmt` parameter.

- What is the reasoning for this implementation?

Somewhat based on the idea here:

- https://github.com/matplotlib/matplotlib/pull/19187

Example:

```python
from matplotlib.widgets import Slider
import matplotlib.pyplot as plt

fig, ax=plt.subplots()

s = Slider(
    ax=ax,
    label=r"$\mathcal{O}(x)$",
    valmin=0,
    valmax=1,
    #valfmt=lambda x: f"$10^{{{x:.1f}}}$",
    valfmt=lambda x: f"{(10**x):.0f}"
)
s.on_changed(lambda x: print(10**x))
plt.show()
```

I'd like to get feedback before writing examples to documentation.

## PR checklist

- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Update docstrings of `Slider` & `RangeSlider` classes.
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
