### PR TITLE
FIX: ValueError: Format 'avif' is not supported

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -76,6 +76,7 @@ _default_filetypes = {
     'tif': 'Tagged Image File Format',
     'tiff': 'Tagged Image File Format',
     'webp': 'WebP Image Format',
+    'avif': 'Av1 Image File Format',
 }
 _default_backends = {
     'eps': 'matplotlib.backends.backend_ps',
@@ -93,6 +94,7 @@ _default_backends = {
     'tif': 'matplotlib.backends.backend_agg',
     'tiff': 'matplotlib.backends.backend_agg',
     'webp': 'matplotlib.backends.backend_agg',
+    'avif': 'matplotlib.backends.backend_agg',
 }
 
 

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -36,6 +36,7 @@ from matplotlib.mathtext import MathTextParser
 from matplotlib.path import Path
 from matplotlib.transforms import Bbox, BboxBase
 from matplotlib.backends._backend_agg import RendererAgg as _RendererAgg
+from PIL import features
 
 
 def get_hinting_flag():
@@ -511,7 +512,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         self._print_pil(filename_or_obj, "webp", pil_kwargs, metadata)
 
     def print_avif(self, filename_or_obj, *, metadata=None, pil_kwargs=None):
-        if not PIL.features.check("avif"):
+        if not features.check("avif"):
             raise RuntimeError(
                 "The installed pillow version does not support avif. Full "
                 "avif support has been added in pillow 11.3."

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -510,7 +510,14 @@ class FigureCanvasAgg(FigureCanvasBase):
     def print_webp(self, filename_or_obj, *, metadata=None, pil_kwargs=None):
         self._print_pil(filename_or_obj, "webp", pil_kwargs, metadata)
 
-    print_gif.__doc__, print_jpg.__doc__, print_tif.__doc__, print_webp.__doc__ = map(
+    def print_avif(self, filename_or_obj, *, metadata=None, pil_kwargs=None):
+        self._print_pil(filename_or_obj, "avif", pil_kwargs, metadata)
+
+    (print_gif.__doc__,
+     print_jpg.__doc__,
+     print_tif.__doc__,
+     print_webp.__doc__,
+     print_avif.__doc__) = map(
         """
         Write the figure to a {} file.
 
@@ -521,7 +528,7 @@ class FigureCanvasAgg(FigureCanvasBase):
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to
             `PIL.Image.Image.save` when saving the figure.
-        """.format, ["GIF", "JPEG", "TIFF", "WebP"])
+        """.format, ["GIF", "JPEG", "TIFF", "WebP", "AVIF"])
 
 
 @_Backend.export

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -511,6 +511,11 @@ class FigureCanvasAgg(FigureCanvasBase):
         self._print_pil(filename_or_obj, "webp", pil_kwargs, metadata)
 
     def print_avif(self, filename_or_obj, *, metadata=None, pil_kwargs=None):
+        if not PIL.features.check("avif"):
+            raise RuntimeError(
+                "The installed pillow version does not support avif. Full "
+                "avif support has been added in pillow 11.3."
+            )
         self._print_pil(filename_or_obj, "avif", pil_kwargs, metadata)
 
     (print_gif.__doc__,

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -525,6 +525,9 @@ class FigureCanvasAgg(FigureCanvasBase):
         ----------
         filename_or_obj : str or path-like or file-like
             The file to write to.
+        metadata : None
+            Unused for pillow-based writers. All supported options
+            can be passed via *pil_kwargs*.
         pil_kwargs : dict, optional
             Additional keyword arguments that are passed to
             `PIL.Image.Image.save` when saving the figure.

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -263,6 +263,20 @@ def test_pil_kwargs_webp():
     assert buf_large.getbuffer().nbytes > buf_small.getbuffer().nbytes
 
 
+@pytest.mark.skipif(not features.check("avif"), reason="AVIF support not available")
+def test_pil_kwargs_avif():
+    plt.plot([0, 1, 2], [0, 1, 0])
+    buf_small = io.BytesIO()
+    pil_kwargs_low = {"quality": 1}
+    plt.savefig(buf_small, format="avif", pil_kwargs=pil_kwargs_low)
+    assert len(pil_kwargs_low) == 1
+    buf_large = io.BytesIO()
+    pil_kwargs_high = {"quality": 100}
+    plt.savefig(buf_large, format="avif", pil_kwargs=pil_kwargs_high)
+    assert len(pil_kwargs_high) == 1
+    assert buf_large.getbuffer().nbytes > buf_small.getbuffer().nbytes
+
+
 def test_gif_no_alpha():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf = io.BytesIO()
@@ -286,6 +300,15 @@ def test_webp_alpha():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf = io.BytesIO()
     plt.savefig(buf, format="webp", transparent=True)
+    im = Image.open(buf)
+    assert im.mode == "RGBA"
+
+
+@pytest.mark.skipif(not features.check("avif"), reason="AVIF support not available")
+def test_avif_alpha():
+    plt.plot([0, 1, 2], [0, 1, 0])
+    buf = io.BytesIO()
+    plt.savefig(buf, format="avif", transparent=True)
     im = Image.open(buf)
     assert im.mode == "RGBA"
 


### PR DESCRIPTION
## PR summary
closes #28809

This fixes the error
`ValueError: Format 'avif' is not supported (supported formats: eps, jpeg, jpg, pdf, pgf, png, ps, raw, rgba, svg, svgz, tif, tiff, webp)` mentioned when saving a .avif figure by doing `fig.savefig('test.avif')` .

I am not sure if I should add new tests for this, however I got the same results I got when merging the main branch so I would like feedback on that

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-  [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines