### PR TITLE
Switch get_grid_info to take a single Bbox as parameter.

### DIFF
--- a/doc/api/next_api_changes/deprecations/30368-AL.rst
+++ b/doc/api/next_api_changes/deprecations/30368-AL.rst
@@ -1,0 +1,3 @@
+``GridFinder.get_grid_info`` now takes a single bbox as parameter
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Passing ``x1, y1, x2, y2`` as separate parameters is deprecated.

--- a/lib/mpl_toolkits/axisartist/grid_finder.py
+++ b/lib/mpl_toolkits/axisartist/grid_finder.py
@@ -169,13 +169,23 @@ class GridFinder:
         return (fmt.format_ticks(levels) if isinstance(fmt, mticker.Formatter)
                 else fmt(direction, factor, levels))
 
-    def get_grid_info(self, x1, y1, x2, y2):
+    def get_grid_info(self, *args, **kwargs):
         """
-        lon_values, lat_values : list of grid values. if integer is given,
-                           rough number of grids in each direction.
+        Compute positioning information for grid lines and ticks, given the
+        axes' data *bbox*.
         """
+        params = _api.select_matching_signature(
+            [lambda x1, y1, x2, y2: locals(), lambda bbox: locals()], *args, **kwargs)
+        if "x1" in params:
+            _api.warn_deprecated("3.11", message=(
+                "Passing extents as separate arguments to get_grid_info is deprecated "
+                "since %(since)s and support will be removed %(removal)s; pass a "
+                "single bbox instead."))
+            bbox = Bbox.from_extents(
+                params["x1"], params["y1"], params["x2"], params["y2"])
+        else:
+            bbox = params["bbox"]
 
-        bbox = Bbox.from_extents(x1, y1, x2, y2)
         tbbox = self.extreme_finder._find_transformed_bbox(
             self.get_transform().inverted(), bbox)
 

--- a/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/grid_helper_curvelinear.py
@@ -341,7 +341,7 @@ class GridHelperCurveLinear(GridHelperBase):
         return axisline
 
     def _update_grid(self, bbox):
-        self._grid_info = self.grid_finder.get_grid_info(*bbox.extents)
+        self._grid_info = self.grid_finder.get_grid_info(bbox)
 
     def get_gridlines(self, which="major", axis="both"):
         grid_lines = []


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

Followup to #27551 ("replace some uses of (x1, y1, x2, y2) quadruplets by single Bbox objects, which avoid having to keep track of the order of the points (is it x1, y1, x2, y2 or x1, x2, y1, y2?).")

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
