### PR TITLE
Fix display of figure window mouse coordinates using wx python backends.

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -1076,7 +1076,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
         self._coordinates = coordinates
         if self._coordinates:
             self.AddStretchableSpace()
-            self._label_text = wx.StaticText(self, style=wx.ALIGN_RIGHT)
+            self._label_text = wx.StaticText(self, size=(120,-1), style=wx.ALIGN_RIGHT)
             self.AddControl(self._label_text)
 
         self.Realize()


### PR DESCRIPTION
Fix display of figure window mouse coordinates using wx python backends.
Currently the mouse coordinates are not visible when using the wx python backend.

This sets an initial size to the text control used to display the coordinates currently the width is set to 0 when NavigationToolbar2Wx.Realize() is called as there is no label text specified and no size defined.

Setting an initial size of (120,-1) should work for most systems unless the font size is very large.
Alternatively NavigationToolbar2Wx.Realize() can be called in NavigationToolbar2Wx. set_message() after the label text is set so that space in the toolbar is allocated however this causes flickering.

I found a related bug [Bug]: wx + windows draws mouseover cursor text beyond the toolbar's extents #22014
closes #22014 

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ]n/a Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
