### PR TITLE
MNT: Remove explicit use of default value add_collection(..., autolim=True)

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3043,7 +3043,7 @@ class Axes(_AxesBase):
             vertices.append([(x0, y0), (x0, y1), (x1, y1), (x1, y0)])
 
         col = mcoll.PolyCollection(np.array(vertices), **kwargs)
-        self.add_collection(col, autolim=True)
+        self.add_collection(col)
 
         return col
 
@@ -5821,7 +5821,7 @@ or pandas.DataFrame
         # Make sure units are handled for x and y values
         args = self._quiver_units(args, kwargs)
         q = mquiver.Quiver(self, *args, **kwargs)
-        self.add_collection(q, autolim=True)
+        self.add_collection(q)
         return q
 
     # args can be some combination of X, Y, U, V, C and all should be replaced
@@ -5832,7 +5832,7 @@ or pandas.DataFrame
         # Make sure units are handled for x and y values
         args = self._quiver_units(args, kwargs)
         b = mquiver.Barbs(self, *args, **kwargs)
-        self.add_collection(b, autolim=True)
+        self.add_collection(b)
         return b
 
     # Uses a custom implementation of data-kwarg handling in

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -524,7 +524,7 @@ def test_regularpolycollection_rotate():
         col = mcollections.RegularPolyCollection(
             4, sizes=(100,), rotation=alpha,
             offsets=[xy], offset_transform=ax.transData)
-        ax.add_collection(col, autolim=True)
+        ax.add_collection(col)
 
 
 @image_comparison(['regularpolycollection_scale.png'], remove_text=True)
@@ -552,7 +552,7 @@ def test_regularpolycollection_scale():
     circle_areas = [np.pi / 2]
     squares = SquareCollection(
         sizes=circle_areas, offsets=xy, offset_transform=ax.transData)
-    ax.add_collection(squares, autolim=True)
+    ax.add_collection(squares)
     ax.axis([-1, 1, -1, 1])
 
 


### PR DESCRIPTION
`autolim=True` is the default value, so no need to specify it.