### PR TITLE
Add datetime test for ax.violin

### DIFF
--- a/lib/matplotlib/tests/test_datetime.py
+++ b/lib/matplotlib/tests/test_datetime.py
@@ -810,7 +810,7 @@ class TestDatetimePlotting:
         fig, ax = plt.subplots()
         ax.triplot(...)
 
-    @pytest.mark.parametrize(("orientation"), ["vertical", "horizontal"])
+    @pytest.mark.parametrize("orientation", ["vertical", "horizontal"])
     @mpl.style.context("default")
     def test_violin(self, orientation):
         fig, ax = plt.subplots()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Part of https://github.com/matplotlib/matplotlib/issues/26864. `violin()` seems to work fine, but the `positions` argument does not work at the moment - it's not immediately obvious to me if it should, so I left a TODO ending with a question mark in the test.

Replaces https://github.com/matplotlib/matplotlib/pull/27486.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
