### PR TITLE
ENH: Gracefully handle python-build-standalone ImportError with Tk

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -37,10 +37,10 @@ except ImportError as e:
         is_uv_python = "/uv/python" in (os.path.realpath(sys.executable))
         if is_uv_python:
             raise ImportError(
-                "Failed to import tkagg backend. You are using a uv-installed python "
-                "executable, which is not compatible with Tk. "
-                "Please update your python via: "
-                "`uv self update && uv python upgrade --reinstall`"
+                "Failed to import tkagg backend. You appear to be using an outdated "
+                "version of uv's managed Python distribution which is not compatible with Tk. "
+                "Please upgrade to the latest uv version, then update Python with:"
+                "`uv python upgrade --reinstall`"
                 ) from e
         else:
             raise ImportError(

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -22,8 +22,34 @@ from matplotlib.backend_bases import (
     TimerBase, ToolContainerBase, cursors, _Mode, MouseButton,
     CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 from matplotlib._pylab_helpers import Gcf
-from . import _tkagg
-from ._tkagg import TK_PHOTO_COMPOSITE_OVERLAY, TK_PHOTO_COMPOSITE_SET
+
+try:
+    from . import _tkagg
+    from ._tkagg import TK_PHOTO_COMPOSITE_OVERLAY, TK_PHOTO_COMPOSITE_SET
+except ImportError as e:
+    # catch incompatibility of python-build-standalone with Tk
+    cause1 = getattr(e, '__cause__', None)
+    cause2 = getattr(cause1, '__cause__', None)
+    if (isinstance(cause1, ImportError) and
+        isinstance(cause2, AttributeError) and
+        "'_tkinter' has no attribute '__file__'" in str(cause2)):
+
+        is_uv_python = "/uv/python" in (os.path.realpath(sys.executable))
+        if is_uv_python:
+            raise ImportError(
+                "Failed to import tkagg backend. You are using a uv-installed python "
+                "executable, which is not compatible with Tk. "
+                "Please use another Python interpreter or select another backend."
+                ) from e
+        else:
+            raise ImportError(
+                "Failed to import tkagg backend. This is likely caused by using a "
+                "Python executable based on python-build-standalone, which is not "
+                "compatible with Tk. "
+                "Please use another Python interpreter or select another backend."
+                ) from e
+    else:
+        raise
 
 
 _log = logging.getLogger(__name__)

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -38,9 +38,9 @@ except ImportError as e:
         if is_uv_python:
             raise ImportError(
                 "Failed to import tkagg backend. You appear to be using an outdated "
-                "version of uv's managed Python distribution which is not compatible with Tk. "
-                "Please upgrade to the latest uv version, then update Python with:"
-                "`uv python upgrade --reinstall`"
+                "version of uv's managed Python distribution which is not compatible "
+                " with Tk. Please upgrade to the latest uv version, then update "
+                " Python with: `uv python upgrade --reinstall`"
                 ) from e
         else:
             raise ImportError(

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -39,7 +39,8 @@ except ImportError as e:
             raise ImportError(
                 "Failed to import tkagg backend. You are using a uv-installed python "
                 "executable, which is not compatible with Tk. "
-                "Please use another Python interpreter or select another backend."
+                "Please update your python via: "
+                "`uv self update && uv python upgrade --reinstall`"
                 ) from e
         else:
             raise ImportError(

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -39,8 +39,8 @@ except ImportError as e:
             raise ImportError(
                 "Failed to import tkagg backend. You appear to be using an outdated "
                 "version of uv's managed Python distribution which is not compatible "
-                " with Tk. Please upgrade to the latest uv version, then update "
-                " Python with: `uv python upgrade --reinstall`"
+                "with Tk. Please upgrade to the latest uv version, then update "
+                "Python with: `uv python upgrade --reinstall`"
                 ) from e
         else:
             raise ImportError(

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -46,8 +46,9 @@ except ImportError as e:
             raise ImportError(
                 "Failed to import tkagg backend. This is likely caused by using a "
                 "Python executable based on python-build-standalone, which is not "
-                "compatible with Tk. "
-                "Please use another Python interpreter or select another backend."
+                "compatible with Tk. Recent versions of python-build-standalone "
+                "should be compatible with Tk. Please update your python version "
+                "or select another backend."
                 ) from e
     else:
         raise


### PR DESCRIPTION
Closes #30390.

I've tested this locally. I don't think there's a reasonable way to test this in CI unless we are actually willing to do a uv install for this. Mocking the exception does not bring any benefit in detecting whether the error has changed, so would be largely futile.