### PR TITLE
Qt: Fix HiDPI handling on X11/Windows

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -273,6 +273,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         window = self.window().windowHandle()
         current_version = tuple(int(x) for x in QtCore.qVersion().split('.', 2)[:2])
         if current_version >= (6, 6):
+            self._update_pixel_ratio()
             window.installEventFilter(self)
         else:
             window.screenChanged.connect(self._update_screen)


### PR DESCRIPTION
## PR summary

With X11, there is only ever a single scale, regardless of monitors as in Wayland, so it's always the highest scale (i.e., it's 2 if you have 1.5&1-scaled monitors). Thus we get no change events and don't update the internal scale. On Wayland though, as noted in the other issue from Qt devs, you only get the fractional scale after the first expose, so there's always at least one event there.

In the older/pre-#30345 code path, in `showEvent`, we'd call `_update_screen` to set callbacks for its changes, and that _also_ called `_update_pixel_ratio`. In the new code, we don't have that initial call, and because Wayland always has at least one event at startup, it all seemed to work.

So just add the `_update_pixel_ratio` call in the new code path as well. On X11, this will be the highest integer scale needed and never changes. On Wayland, this will also be the rounded-up integer scale, but if using fractional scaling, will change with a subsequent event to the correct one. This does cause a few extra changes on startup, but should be more consistent across platforms.

Fixes #30386

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines