### PR TITLE
fix(font manager): Allow Rebuilding Cache

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1504,6 +1504,9 @@ class FontManager:
                 default_prop.set_family(self.defaultFamily[fontext])
                 return self.findfont(default_prop, fontext, directory,
                                      fallback_to_default=False)
+            elif rebuild_if_missing:
+                # Continue to rebuild condition
+                result = ''
             else:
                 # This return instead of raise is intentional, as we wish to
                 # cache that it was not found, which will not occur if it was


### PR DESCRIPTION
One could never rebuild the cache given the existing conditional logic (premature return to exception based solely on fallback_to_default). Now, if a user disables fallback and enables rebuild, the rebuild logic will execute.

This allows a user to install a font and run:

```python

import matplotlib.font_manager as fm
fm.findfont("Font Spec", fallback_to_default=False, rebuild_if_missing=True)
```

to force a rebuild of the font cache.

It was a simple fix to the conditional logic: if fallback is False, don't return with error if rebuild is True, but instead set result to empty string (used later in the rebuild code) so that the rebuild code can actually be proceeded to.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
<details>
<summary>

- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

</summary>

Tested on my font cache locally in my normal non-dev env.
Unless other ideas exist, a unit test would require:

1. A dummy font file
2. A way to create a temporary cache that does not affect the user's cache
3. Updating of said cache with dummy font using above code
4. Validation that cache has been updated
5. Someone who's written unit tests (not me)

</details>

- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
