### PR TITLE
DOC: remove some usages of None as explicit defaults

### DIFF
--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -84,8 +84,8 @@ class Grid:
             ``121``), or as a `~.SubplotSpec`.
         nrows_ncols : (int, int)
             Number of rows and columns in the grid.
-        n_axes : int or None, default: None
-            If not None, only the first *n_axes* axes in the grid are created.
+        n_axes : int, optional
+            If given, only the first *n_axes* axes in the grid are created.
         direction : {"row", "column"}, default: "row"
             Whether axes are created in row-major ("row by row") or
             column-major order ("column by column").  This also affects the
@@ -322,8 +322,8 @@ class ImageGrid(Grid):
             as a three-digit subplot position code (e.g., "121").
         nrows_ncols : (int, int)
             Number of rows and columns in the grid.
-        n_axes : int or None, default: None
-            If not None, only the first *n_axes* axes in the grid are created.
+        n_axes : int, optional
+            If given, only the first *n_axes* axes in the grid are created.
         direction : {"row", "column"}, default: "row"
             Whether axes are created in row-major ("row by row") or
             column-major order ("column by column").  This also affects the
@@ -364,7 +364,7 @@ class ImageGrid(Grid):
         cbar_set_cax : bool, default: True
             If True, each axes in the grid has a *cax* attribute that is bound
             to associated *cbar_axes*.
-        axes_class : subclass of `matplotlib.axes.Axes`, default: None
+        axes_class : subclass of `matplotlib.axes.Axes`, default: `.mpl_axes.Axes`
         """
         _api.check_in_list(["each", "single", "edge", None],
                            cbar_mode=cbar_mode)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -737,9 +737,8 @@ class Patch3DCollection(PatchCollection):
         depthshade : bool
             Whether to shade the patches in order to give the appearance of
             depth.
-        depthshade_minalpha : float, default: None
+        depthshade_minalpha : float, default: :rc:`axes3d.depthshade_minalpha`
             Sets the minimum alpha value used by depth-shading.
-            If None, use the value from rcParams['axes3d.depthshade_minalpha'].
 
             .. versionadded:: 3.11
         """
@@ -1112,17 +1111,15 @@ def patch_collection_2d_to_3d(
     zdir : {'x', 'y', 'z'}
         The axis in which to place the patches. Default: "z".
         See `.get_dir_vector` for a description of the values.
-    depthshade : bool, default: None
+    depthshade : bool, default: :rc:`axes3d.depthshade`
         Whether to shade the patches to give a sense of depth.
-        If None, use the value from rcParams['axes3d.depthshade'].
     axlim_clip : bool, default: False
         Whether to hide patches with a vertex outside the axes view limits.
 
         .. versionadded:: 3.10
 
-    depthshade_minalpha : float, default: None
+    depthshade_minalpha : float, default: :rc:`axes3d.depthshade_minalpha`
         Sets the minimum alpha value used by depth-shading.
-        If None, use the value from rcParams['axes3d.depthshade_minalpha'].
 
         .. versionadded:: 3.11
     """

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -70,7 +70,7 @@ class Axes3D(Axes):
         ----------
         fig : Figure
             The parent figure.
-        rect : tuple (left, bottom, width, height), default: None.
+        rect : tuple (left, bottom, width, height), default: (0, 0, 1, 1)
             The ``(left, bottom, width, height)`` Axes position.
         elev : float, default: 30
             The elevation angle in degrees rotates the camera above and below
@@ -2049,9 +2049,10 @@ class Axes3D(Axes):
             - 'auto': If the points all lie on the same 3D plane, 'polygon' is
               used. Otherwise, 'quad' is used.
 
-        facecolors : list of :mpltype:`color`, default: None
+        facecolors : :mpltype:`color` or list of :mpltype:`color`, optional
             Colors of each individual patch, or a single color to be used for
-            all patches.
+            all patches. If not given, the next color from the patch color
+            cycle is used.
 
         shade : bool, default: None
             Whether to shade the facecolors. If *None*, then defaults to *True*
@@ -2943,15 +2944,13 @@ class Axes3D(Axes):
             - A 2D array in which the rows are RGB or RGBA.
 
             For more details see the *c* argument of `~.axes.Axes.scatter`.
-        depthshade : bool, default: None
+        depthshade : bool, default: :rc:`axes3d.depthshade`
             Whether to shade the scatter markers to give the appearance of
             depth. Each call to ``scatter()`` will perform its depthshading
             independently.
-            If None, use the value from rcParams['axes3d.depthshade'].
 
-        depthshade_minalpha : float, default: None
+        depthshade_minalpha : float, default: :rc:`axes3d.depthshade_minalpha`
             The lowest alpha value applied by depth-shading.
-            If None, use the value from rcParams['axes3d.depthshade_minalpha'].
 
             .. versionadded:: 3.11
 
@@ -3627,12 +3626,12 @@ class Axes3D(Axes):
             Use 'none' (case-insensitive) to plot errorbars without any data
             markers.
 
-        ecolor : :mpltype:`color`, default: None
-            The color of the errorbar lines.  If None, use the color of the
+        ecolor : :mpltype:`color`, optional
+            The color of the errorbar lines. If not given, use the color of the
             line connecting the markers.
 
-        elinewidth : float, default: None
-            The linewidth of the errorbar lines. If None, the linewidth of
+        elinewidth : float, optional
+            The linewidth of the errorbar lines. If not given, the linewidth of
             the current style is used.
 
         capsize : float, default: :rc:`errorbar.capsize`


### PR DESCRIPTION
In docs, we rather specify "optional" instead of "default: None" when None is only used as a sentinel for "not given". We also specify prefer concrete types or rc references over None usage if possible.

