### PR TITLE
Fix a race condition in TexManager.make_dvi.

### DIFF
--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -281,11 +281,9 @@ class TexManager:
 
         Return the file name.
         """
-        basefile = cls.get_basefile(tex, fontsize)
-        dvifile = '%s.dvi' % basefile
-        if not os.path.exists(dvifile):
-            texfile = Path(cls.make_tex(tex, fontsize))
-            # Generate the dvi in a temporary directory to avoid race
+        dvifile = Path(cls.get_basefile(tex, fontsize)).with_suffix(".dvi")
+        if not dvifile.exists():
+            # Generate the tex and dvi in a temporary directory to avoid race
             # conditions e.g. if multiple processes try to process the same tex
             # string at the same time.  Having tmpdir be a subdirectory of the
             # final output dir ensures that they are on the same filesystem,
@@ -294,15 +292,17 @@ class TexManager:
             # the absolute path may contain characters (e.g. ~) that TeX does
             # not support; n.b. relative paths cannot traverse parents, or it
             # will be blocked when `openin_any = p` in texmf.cnf).
-            cwd = Path(dvifile).parent
-            with TemporaryDirectory(dir=cwd) as tmpdir:
-                tmppath = Path(tmpdir)
+            with TemporaryDirectory(dir=dvifile.parent) as tmpdir:
+                Path(tmpdir, "file.tex").write_text(
+                    cls._get_tex_source(tex, fontsize), encoding='utf-8')
                 cls._run_checked_subprocess(
                     ["latex", "-interaction=nonstopmode", "--halt-on-error",
-                     f"--output-directory={tmppath.name}",
-                     f"{texfile.name}"], tex, cwd=cwd)
-                (tmppath / Path(dvifile).name).replace(dvifile)
-        return dvifile
+                     "file.tex"], tex, cwd=tmpdir)
+                Path(tmpdir, "file.dvi").replace(dvifile)
+                # Also move the tex source to the main cache directory, but
+                # only for backcompat.
+                Path(tmpdir, "file.tex").replace(dvifile.with_suffix(".tex"))
+        return str(dvifile)
 
     @classmethod
     def make_png(cls, tex, fontsize, dpi):
@@ -311,22 +311,23 @@ class TexManager:
 
         Return the file name.
         """
-        basefile = cls.get_basefile(tex, fontsize, dpi)
-        pngfile = '%s.png' % basefile
+        pngfile = Path(cls.get_basefile(tex, fontsize)).with_suffix(".png")
         # see get_rgba for a discussion of the background
-        if not os.path.exists(pngfile):
+        if not pngfile.exists():
             dvifile = cls.make_dvi(tex, fontsize)
-            cmd = ["dvipng", "-bg", "Transparent", "-D", str(dpi),
-                   "-T", "tight", "-o", pngfile, dvifile]
-            # When testing, disable FreeType rendering for reproducibility; but
-            # dvipng 1.16 has a bug (fixed in f3ff241) that breaks --freetype0
-            # mode, so for it we keep FreeType enabled; the image will be
-            # slightly off.
-            if (getattr(mpl, "_called_from_pytest", False) and
-                    mpl._get_executable_info("dvipng").raw_version != "1.16"):
-                cmd.insert(1, "--freetype0")
-            cls._run_checked_subprocess(cmd, tex)
-        return pngfile
+            with TemporaryDirectory(dir=pngfile.parent) as tmpdir:
+                cmd = ["dvipng", "-bg", "Transparent", "-D", str(dpi),
+                       "-T", "tight", "-o", "file.png", dvifile]
+                # When testing, disable FreeType rendering for reproducibility;
+                # but dvipng 1.16 has a bug (fixed in f3ff241) that breaks
+                # --freetype0 mode, so for it we keep FreeType enabled; the
+                # image will be slightly off.
+                if (getattr(mpl, "_called_from_pytest", False) and
+                        mpl._get_executable_info("dvipng").raw_version != "1.16"):
+                    cmd.insert(1, "--freetype0")
+                cls._run_checked_subprocess(cmd, tex, cwd=tmpdir)
+                Path(tmpdir, "file.png").replace(pngfile)
+        return str(pngfile)
 
     @classmethod
     def get_grey(cls, tex, fontsize=None, dpi=None):


### PR DESCRIPTION
Previously, a race condition could occur if, while a process had called make_tex (generating the tex file in the global cache) and was going to call the latex subprocess (to generate the dvi file), another process also called make_tex for the same tex string and started rewriting the tex source.  In that case, the latex subprocess could see a partially written (invalid) tex source.

Fix that by generating the tex source in a process-private temporary directory, where the latex process is already going to run anyways. (This is cheap compared to the latex subprocess invocation.)

See https://github.com/matplotlib/matplotlib/issues/30420#issuecomment-3185809339 (point (2)).

Edit: did the same to make_png.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
