### PR TITLE
Use standard property alias machinery in contour().

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -865,3 +865,15 @@ def test_contourf_rasterize():
     circle = mpatches.Circle([0.5, 0.5], 0.5, transform=ax.transAxes)
     cs = ax.contourf(data, clip_path=circle, rasterized=True)
     assert cs._rasterized
+
+
+@check_figures_equal(extensions=["png"])
+def test_contour_aliases(fig_test, fig_ref):
+    data = np.arange(100).reshape((10, 10)) ** 2
+    fig_test.add_subplot().contour(data, linestyle=":")
+    fig_ref.add_subplot().contour(data, linestyles="dotted")
+
+
+def test_contour_singular_color():
+    with pytest.raises(TypeError):
+        plt.figure().add_subplot().contour([[0, 1], [2, 3]], color="r")


### PR DESCRIPTION
Note that 'color(s)' remains special-cased because the ContourSet constructor needs to do a fair bit of special wrangling for it.

Closes #1963.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
