### PR TITLE
Small correction of a typo in the galleries: axis instead of axes

### DIFF
--- a/galleries/users_explain/artists/color_cycle.py
+++ b/galleries/users_explain/artists/color_cycle.py
@@ -52,7 +52,7 @@ plt.rc('axes', prop_cycle=default_cycler)
 
 # %%
 # Now we'll generate a figure with two Axes, one on top of the other. On the
-# first axis, we'll plot with the default cycler. On the second axis, we'll
+# first axes, we'll plot with the default cycler. On the second axes, we'll
 # set the ``prop_cycle`` using :func:`matplotlib.axes.Axes.set_prop_cycle`,
 # which will only set the ``prop_cycle`` for this :mod:`matplotlib.axes.Axes`
 # instance. We'll use a second ``cycler`` that combines a color cycler and a

--- a/galleries/users_explain/axes/constrainedlayout_guide.py
+++ b/galleries/users_explain/axes/constrainedlayout_guide.py
@@ -164,7 +164,7 @@ fig.suptitle('Big Suptitle')
 # Legends
 # =======
 #
-# Legends can be placed outside of their parent axis.
+# Legends can be placed outside of their parent axes.
 # *Constrained layout* is designed to handle this for :meth:`.Axes.legend`.
 # However, *constrained layout* does *not* handle legends being created via
 # :meth:`.Figure.legend` (yet).


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
It is a very small typo correction between **axis** and **axes**. It clarifies the notion in the text [here](https://matplotlib.org/stable/users/explain/axes/constrainedlayout_guide.html#legends) and [here](https://matplotlib.org/stable/users/explain/artists/color_cycle.html) as it is about axes and not axis.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
