### PR TITLE
DOC: Fix missing references on text-overhaul branch

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -126,10 +126,12 @@
       "doc/docstring of matplotlib.ft2font.PyCapsule.set_text:1"
     ],
     "numpy.typing.NDArray": [
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.get_image:1",
       "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1"
     ],
     "numpy.uint8": [
-      "<unknown>:1"
+      "<unknown>:1",
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.get_image:1"
     ]
   },
   "py:obj": {


### PR DESCRIPTION
## PR summary

I thought this was because this branch was missing d2d969ef9d01297728c15c0fdfa957852201834b, but it was actually a change introduced in #30324 as a separate (but similar-looking) issue.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines