### PR TITLE
Added handling for undetermined home directory

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -532,19 +532,30 @@ def _get_config_or_cache_dir(xdg_base_getter):
     elif sys.platform.startswith(('linux', 'freebsd')):
         # Only call _xdg_base_getter here so that MPLCONFIGDIR is tried first,
         # as _xdg_base_getter can throw.
-        configdir = Path(xdg_base_getter(), "matplotlib")
+        try:
+            configdir = Path(xdg_base_getter(), "matplotlib")
+        except RuntimeError:
+            pass
     else:
-        configdir = Path.home() / ".matplotlib"
-    # Resolve the path to handle potential issues with inaccessible symlinks.
-    configdir = configdir.resolve()
-    try:
-        configdir.mkdir(parents=True, exist_ok=True)
-    except OSError as exc:
-        _log.warning("mkdir -p failed for path %s: %s", configdir, exc)
+        try:
+            configdir = Path.home() / ".matplotlib"
+        except RuntimeError:
+            pass
+
+    if configdir:
+        # Resolve the path to handle potential issues with inaccessible symlinks.
+        configdir = configdir.resolve()
+        try:
+            configdir.mkdir(parents=True, exist_ok=True)
+        except OSError as exc:
+            _log.warning("mkdir -p failed for path %s: %s", configdir, exc)
+        else:
+            if os.access(str(configdir), os.W_OK) and configdir.is_dir():
+                return str(configdir)
+            _log.warning("%s is not a writable directory", configdir)
+        issue_msg = "the default path ({configdir})"
     else:
-        if os.access(str(configdir), os.W_OK) and configdir.is_dir():
-            return str(configdir)
-        _log.warning("%s is not a writable directory", configdir)
+        issue_msg = "resolving the home directory"
     # If the config or cache directory cannot be created or is not a writable
     # directory, create a temporary one.
     try:
@@ -552,17 +563,17 @@ def _get_config_or_cache_dir(xdg_base_getter):
     except OSError as exc:
         raise OSError(
             f"Matplotlib requires access to a writable cache directory, but there "
-            f"was an issue with the default path ({configdir}), and a temporary "
+            f"was an issue with {issue_msg}, and a temporary "
             f"directory could not be created; set the MPLCONFIGDIR environment "
             f"variable to a writable directory") from exc
     os.environ["MPLCONFIGDIR"] = tmpdir
     atexit.register(shutil.rmtree, tmpdir)
     _log.warning(
         "Matplotlib created a temporary cache directory at %s because there was "
-        "an issue with the default path (%s); it is highly recommended to set the "
+        "an issue with %s; it is highly recommended to set the "
         "MPLCONFIGDIR environment variable to a writable directory, in particular to "
         "speed up the import of Matplotlib and to better support multiprocessing.",
-        tmpdir, configdir)
+        tmpdir, issue_msg)
     return tmpdir
 
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

If the home directory cannot be created/written to, matplotlib defaults to creating a temporary folder for its caching/config. However, previously, if the home directory could not be determined, a RunTimeError was raised. Now, this pr includes code to handle the RunTimeError from `Path.home()` so that Matplotlib will default to using a temp directory for its cache. It  will also throw a warning to describe the issue.

On Windows the following now leads to a temporary cache directory:
```python
import os
os.environ.pop('HOMEPATH', None)
os.environ.pop('USERPROFILE', None)
import matplotlib
```

On Linux the following now leads to a temporary cache directory, if the user is not a part of the password database:
```python
import os
os.environ.pop('HOME', None)
import matplotlib
```

closes #30449 


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
