### PR TITLE
FIX: Mark shared Axes as stale when propagating adjustable

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1736,6 +1736,8 @@ class _AxesBase(martist.Artist):
         Return whether the Axes will adjust its physical dimension ('box') or
         its data limits ('datalim') to achieve the desired aspect ratio.
 
+        Newly created Axes default to 'box'.
+
         See Also
         --------
         matplotlib.axes.Axes.set_adjustable
@@ -1761,6 +1763,8 @@ class _AxesBase(martist.Artist):
 
         See Also
         --------
+        matplotlib.axes.Axes.get_adjustable
+            Return the current value of *adjustable*.
         matplotlib.axes.Axes.set_aspect
             For a description of aspect handling.
 
@@ -1792,7 +1796,7 @@ class _AxesBase(martist.Artist):
                              "Axes which override 'get_data_ratio'")
         for ax in axs:
             ax._adjustable = adjustable
-        self.stale = True
+            ax.stale = True
 
     def get_box_aspect(self):
         """


### PR DESCRIPTION
It can't be right that we set `_adjustable` on all siblings (including self), but only mark self as stale.

While at it, I've slightly improved the documentation.