### PR TITLE
Let ticklabels respect set_in_layout(False).

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1333,9 +1333,11 @@ class Axis(martist.Artist):
     def _get_ticklabel_bboxes(self, ticks, renderer):
         """Return lists of bboxes for ticks' label1's and label2's."""
         return ([tick.label1.get_window_extent(renderer)
-                 for tick in ticks if tick.label1.get_visible()],
+                 for tick in ticks
+                 if tick.label1.get_visible() and tick.label1.get_in_layout()],
                 [tick.label2.get_window_extent(renderer)
-                 for tick in ticks if tick.label2.get_visible()])
+                 for tick in ticks
+                 if tick.label2.get_visible() and tick.label2.get_in_layout()])
 
     def get_tightbbox(self, renderer=None, *, for_layout_only=False):
         """

--- a/lib/matplotlib/tests/test_axis.py
+++ b/lib/matplotlib/tests/test_axis.py
@@ -2,6 +2,7 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 from matplotlib.axis import XTick
+from matplotlib.testing.decorators import check_figures_equal
 
 
 def test_tick_labelcolor_array():
@@ -29,6 +30,21 @@ def test_axis_not_in_layout():
     # Positions should not be affected by overlapping 100 label
     assert ax1_left.get_position().bounds == ax2_left.get_position().bounds
     assert ax1_right.get_position().bounds == ax2_right.get_position().bounds
+
+
+@check_figures_equal()
+def test_tick_not_in_layout(fig_test, fig_ref):
+    # Check that the "very long" ticklabel is ignored from layouting after
+    # set_in_layout(False); i.e. the layout is as if the ticklabel was empty.
+    # Ticklabels are set to white so that the actual string doesn't matter.
+    fig_test.set_layout_engine("constrained")
+    ax = fig_test.add_subplot(xticks=[0, 1], xticklabels=["short", "very long"])
+    ax.tick_params(labelcolor="w")
+    fig_test.draw_without_rendering()  # Ensure ticks are correct.
+    ax.xaxis.majorTicks[-1].label1.set_in_layout(False)
+    fig_ref.set_layout_engine("constrained")
+    ax = fig_ref.add_subplot(xticks=[0, 1], xticklabels=["short", ""])
+    ax.tick_params(labelcolor="w")
 
 
 def test_translate_tick_params_reverse():


### PR DESCRIPTION
This is useful for manual finetuning of layout of static plots.

Closes #30263, although @rcomer's suggestion of being able to control separately inlayoutness in the x and y directions would also be nice.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
