### PR TITLE
Let triage_tests support test modules with only figure_equals tests.

### DIFF
--- a/tools/triage_tests.py
+++ b/tools/triage_tests.py
@@ -263,7 +263,7 @@ class Entry:
             ]
         self.thumbnails = [self.dir / x for x in self.thumbnails]
 
-        if not Path(self.destdir, self.generated).exists():
+        if self.destdir is None or not Path(self.destdir, self.generated).exists():
             # This case arises from a check_figures_equal test.
             self.status = 'autogen'
         elif ((self.dir / self.generated).read_bytes()
@@ -281,7 +281,6 @@ class Entry:
             path = self.source / baseline_dir / reldir
             if path.is_dir():
                 return path
-        raise ValueError(f"Can't find baseline dir for {reldir}")
 
     @property
     def display(self):


### PR DESCRIPTION
If there's only check_figure_equals tests in a module (e.g. test_pickle, test_axis) then there's no directory in the baseline_images test, but it still makes sense to run triage_tests in case of test failure. Previously, the missing directory caused an error; this patches fixes that.  To test this, change e.g. one of the check_figures_equal tests in test_pickle to make it fail, run that test, and run tools/triage_tests.py.

Closes #29774 (I ran again into the same issue for #30467).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
