### PR TITLE
Deprecate redundant axes parameter to RadialLocator.

### DIFF
--- a/doc/api/next_api_changes/deprecations/30469-AL.rst
+++ b/doc/api/next_api_changes/deprecations/30469-AL.rst
@@ -1,0 +1,4 @@
+The *axes* parameter of ``RadialLocator``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated. `~.polar.RadialLocator` now fetches the relevant information
+from the Axis' parent Axes.

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -431,6 +431,7 @@ class RadialLocator(mticker.Locator):
     scale of the *r*-axis).
     """
 
+    @_api.delete_parameter("3.11", "axes")
     def __init__(self, base, axes=None):
         self.base = base
         self._axes = axes
@@ -440,11 +441,11 @@ class RadialLocator(mticker.Locator):
 
     def __call__(self):
         # Ensure previous behaviour with full circle non-annular views.
-        if self._axes:
-            if _is_full_circle_rad(*self._axes.viewLim.intervalx):
-                rorigin = self._axes.get_rorigin() * self._axes.get_rsign()
-                if self._axes.get_rmin() <= rorigin:
-                    return [tick for tick in self.base() if tick > rorigin]
+        ax = self.base.axis.axes
+        if _is_full_circle_rad(*ax.viewLim.intervalx):
+            rorigin = ax.get_rorigin() * ax.get_rsign()
+            if ax.get_rmin() <= rorigin:
+                return [tick for tick in self.base() if tick > rorigin]
         return self.base()
 
     def _zero_in_bounds(self):
@@ -452,7 +453,7 @@ class RadialLocator(mticker.Locator):
         Return True if zero is within the valid values for the
         scale of the radial axis.
         """
-        vmin, vmax = self._axes.yaxis._scale.limit_range_for_scale(0, 1, 1e-5)
+        vmin, vmax = self.base.axis._scale.limit_range_for_scale(0, 1, 1e-5)
         return vmin == 0
 
     def nonsingular(self, vmin, vmax):
@@ -681,7 +682,7 @@ class RadialAxis(maxis.YAxis):
 
     def set_major_locator(self, locator):
         if not isinstance(locator, RadialLocator):
-            locator = RadialLocator(locator, self.axes)
+            locator = RadialLocator(locator)
         super().set_major_locator(locator)
 
     def clear(self):


### PR DESCRIPTION
We can just directly fetch the relevant information from `locator.axis.axes`; the case where `locator.axis.axes` was different from `axes` was not tested and doesn't make much sense anyways.

The change also goes in the direction of having Locators carry less state (and hopefully, in the future, not being associated with an axis, but rather having the axis passed as argument to `__call__`).

Closes #30296.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
