### PR TITLE
No need to sanitize extrema in Colorizer.set_clim

### DIFF
--- a/lib/matplotlib/colorizer.py
+++ b/lib/matplotlib/colorizer.py
@@ -275,9 +275,9 @@ class Colorizer:
         # until both vmin and vmax are updated
         with self.norm.callbacks.blocked(signal='changed'):
             if vmin is not None:
-                self.norm.vmin = colors._sanitize_extrema(vmin)
+                self.norm.vmin = vmin
             if vmax is not None:
-                self.norm.vmax = colors._sanitize_extrema(vmax)
+                self.norm.vmax = vmax
 
         # emit a update signal if the limits are changed
         if orig_vmin_vmax != (self.norm.vmin, self.norm.vmax):


### PR DESCRIPTION
The @vmin.setter in Normalize (and its subclasses) call colors._sanitize_extrema(), so there is no reason to also do so in Colorizer.

This PR is intended to slightly clean the code before it is modified as the inclusion of MultiNorm https://github.com/matplotlib/matplotlib/pull/29876 and related PRs is propagated to the Colorizer in a future PR.