### PR TITLE
ci: Remove cibuildwheel override for win_arm64/Py3.14

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -151,10 +151,6 @@ jobs:
           CIBW_ENABLE: "cpython-freethreading cpython-prerelease"
           CIBW_ARCHS: ${{ matrix.cibw_archs }}
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux_2_28
-          CIBW_BEFORE_TEST: >-
-            python -m pip install
-            --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-            --upgrade --pre --only-binary=:all: contourpy numpy pillow
 
       - name: Build wheels for CPython 3.13
         uses: pypa/cibuildwheel@352e01339f0a173aa2a3eb57f01492e341e83865  # v3.1.3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,14 +86,6 @@ local_scheme = "node-and-date"
 parentdir_prefix_version = "matplotlib-"
 fallback_version = "0.0+UNKNOWN"
 
-# FIXME: Remove this override once dependencies are available on PyPI.
-[[tool.cibuildwheel.overrides]]
-select = "*-win_arm64"
-before-test = """\
-    pip install --pre \
-    --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-    contourpy numpy"""
-
 [tool.isort]
 known_pydata = "numpy, matplotlib.pyplot"
 known_firstparty = "matplotlib,mpl_toolkits"


### PR DESCRIPTION
## PR summary

Our dependencies now have wheels for that platform.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines