### PR TITLE
FIX: be more cautious about checking widget size

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -517,7 +517,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
             if not self._draw_pending:
                 return
             self._draw_pending = False
-            if self.height() <= 0 or self.width() <= 0:
+            if _isdeleted(self) or self.height() <= 0 or self.width() <= 0:
                 return
             try:
                 self.draw()

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,11 +2,11 @@
 
 black<24
 certifi
-coverage!=6.3,!=7.10.6
+coverage!=6.3
 psutil
 pytest!=4.6.0,!=5.4.0,!=8.1.0
 pytest-cov
-pytest-rerunfailures
+pytest-rerunfailures!=16.0
 pytest-timeout
 pytest-xdist
 pytest-xvfb

--- a/requirements/testing/all.txt
+++ b/requirements/testing/all.txt
@@ -2,7 +2,7 @@
 
 black<24
 certifi
-coverage!=6.3
+coverage!=6.3,!=7.10.6
 psutil
 pytest!=4.6.0,!=5.4.0,!=8.1.0
 pytest-cov


### PR DESCRIPTION
This can fail if the c++ side of the object has already been cleaned up but the Python side is still lingering (due to refs in callbacks).

closes #29618

I do not think it is worth constructing a test to generate this case, but in the case where I saw it in the wild this fixed the tests locally for me.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [/] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [/] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [/] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
