### PR TITLE
TST: Use a temporary directory for test_save_figure_return

### DIFF
--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -215,14 +215,15 @@ def test_figureoptions():
 
 
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)
-def test_save_figure_return():
+def test_save_figure_return(tmp_path):
     fig, ax = plt.subplots()
     ax.imshow([[1]])
+    expected = tmp_path / "foobar.png"
     prop = "matplotlib.backends.qt_compat.QtWidgets.QFileDialog.getSaveFileName"
-    with mock.patch(prop, return_value=("foobar.png", None)):
+    with mock.patch(prop, return_value=(str(expected), None)):
         fname = fig.canvas.manager.toolbar.save_figure()
-        os.remove("foobar.png")
-        assert fname == "foobar.png"
+        assert fname == str(expected)
+        assert expected.exists()
     with mock.patch(prop, return_value=(None, None)):
         fname = fig.canvas.manager.toolbar.save_figure()
         assert fname is None


### PR DESCRIPTION
## PR summary

This avoids having to manually clean up the resulting file, which seems flaky.

Fixes #30493

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines