### PR TITLE
pdf: Improve text with characters outside embedded font limits

### DIFF
--- a/doc/api/next_api_changes/deprecations/30512-ES.rst
+++ b/doc/api/next_api_changes/deprecations/30512-ES.rst
@@ -1,0 +1,3 @@
+``PdfFile.multi_byte_charprocs``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated with no replacement.

--- a/doc/release/next_whats_new/pdf_fonts.rst
+++ b/doc/release/next_whats_new/pdf_fonts.rst
@@ -1,0 +1,10 @@
+Improved font embedding in PDF
+------------------------------
+
+Both Type 3 and Type 42 fonts (see :ref:`fonts` for more details) are now
+embedded into PDFs without limitation. Fonts may be split into multiple
+embedded subsets in order to satisfy format limits. Additionally, a corrected
+Unicode mapping is added for each.
+
+This means that *all* text should now be selectable and copyable in PDF viewers
+that support doing so.

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -205,6 +205,25 @@ class CharacterTracker:
         self.used.setdefault((font.fname, subset), {})[subset_charcode] = glyph
         return (subset, subset_charcode)
 
+    def subset_to_unicode(self, index: int,
+                          charcode: CharacterCodeType) -> CharacterCodeType:
+        """
+        Map a subset index and character code to a Unicode character code.
+
+        Parameters
+        ----------
+        index : int
+            The subset index within a font.
+        charcode : CharacterCodeType
+            The character code within a subset to map back.
+
+        Returns
+        -------
+        CharacterCodeType
+            The Unicode character code corresponding to the subsetted one.
+        """
+        return index * self.subset_size + charcode
+
 
 class RendererPDFPSBase(RendererBase):
     # The following attributes must be defined by the subclasses:

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -276,11 +276,13 @@ def _gen_multi_font_text():
     latin1_supplement = [chr(x) for x in range(start, 0xFF+1)]
     latin_extended_A = [chr(x) for x in range(0x100, 0x17F+1)]
     latin_extended_B = [chr(x) for x in range(0x180, 0x24F+1)]
+    non_basic_multilingual_plane = [chr(x) for x in range(0x1F600, 0x1F610)]
     count = itertools.count(start - 0xA0)
     non_basic_characters = '\n'.join(
         ''.join(line)
         for _, line in itertools.groupby(  # Replace with itertools.batched for Py3.12+.
-            [*latin1_supplement, *latin_extended_A, *latin_extended_B],
+            [*latin1_supplement, *latin_extended_A, *latin_extended_B,
+             *non_basic_multilingual_plane],
             key=lambda x: next(count) // 32)  # 32 characters per line.
     )
     test_str = f"""There are basic characters

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -526,7 +526,7 @@ def test_svg_metadata():
 
 
 @image_comparison(["multi_font_aspath.svg"])
-def test_multi_font_type3():
+def test_multi_font_aspath():
     fonts, test_str = _gen_multi_font_text()
     plt.rc('font', family=fonts, size=16)
     plt.rc('svg', fonttype='path')
@@ -537,7 +537,7 @@ def test_multi_font_type3():
 
 
 @image_comparison(["multi_font_astext.svg"])
-def test_multi_font_type42():
+def test_multi_font_astext():
     fonts, test_str = _gen_multi_font_text()
     plt.rc('font', family=fonts, size=16)
     plt.rc('svg', fonttype='none')


### PR DESCRIPTION
## PR summary

For character codes outside the embedded font limits (256 for type 3 and 65536 for type 42), we output them as `XObject`s instead of using text commands. But there is nothing in the PDF spec that requires any specific encoding like this.

Since we now support subsetting all fonts before embedding, split each font into groups based on the maximum character code (e.g., 256-entry groups for type 3), then switch text strings to a different font subset and re-map character codes to it when necessary.

This means all text is true text (albeit with some strange encoding), and we no longer need any XObjects for glyphs. For users of non-English text, this means it will become selectable and copyable again.

There are 3 steps to achieve this change:
1. Track both character codes and glyphs in `CharacterTracker`. This class takes care of splitting characters into subsets that fit the desired PDF font type limits. -> moved to #30566
2. Output each used font block as a separate subsetted font. Also change the subset prefix to use the glyph indices, which are unique, unlike the character codes. -> first commit here
3. Generate a `ToUnicode` dictionary for the subset font. We already did this for type 42 fonts, but the implementation was incorrect as it didn't correctly handle non-BMP characters. For type 3, support was added in PDF 1.2, but we produce 1.4; there is a fallback to the glyph names, but it is inconsistent and probably depends on the original font having the right names. -> second commit here

In the future, we may wish to extend the implementation in `CharacterTracker` to "compress" the character map it produces (i.e., if you use 255 characters all from a different 256-sized block with type 3, you get 255 fonts, but we could compress that to a single font.) I tried to avoid hard-coding any assumptions that the mapping is block-by-block, but it is possible that something slipped through, so I do not want to spend too much time on that right now.

Formerly, with `multi_font_type3.pdf` (after adding the emoji to the test), copying the text in evince would produce:
```
There are basic characters
ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz
0123456789 !”#$%&’()*+,-./:;¡=¿?@[“]ˆ˙‘—–˝˜
and accented characters
ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ
in between!
```
and with `multi_font_type42.pdf`:
```
There are basic characters
ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz
0123456789 !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
and accented characters
ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ
ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğ
ĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿ
ŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞş
ŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ
ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟ
ƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿ
ǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟ
ǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿ
ȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟ
ȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿ
ɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ
in between!
```
and now we get for both type 3 and 42:
```
There are basic characters
ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz
0123456789 !"#$%&'()*+,-./:;<=>?@[\]^_`{|}~
and accented characters
ÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞß
àáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿ
ĀāĂăĄąĆćĈĉĊċČčĎďĐđĒēĔĕĖėĘęĚěĜĝĞğ
ĠġĢģĤĥĦħĨĩĪīĬĭĮįİıĲĳĴĵĶķĸĹĺĻļĽľĿ
ŀŁłŃńŅņŇňŉŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŜŝŞş
ŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžſ
ƀƁƂƃƄƅƆƇƈƉƊƋƌƍƎƏƐƑƒƓƔƕƖƗƘƙƚƛƜƝƞƟ
ƠơƢƣƤƥƦƧƨƩƪƫƬƭƮƯưƱƲƳƴƵƶƷƸƹƺƻƼƽƾƿ
ǀǁǂǃǄǅǆǇǈǉǊǋǌǍǎǏǐǑǒǓǔǕǖǗǘǙǚǛǜǝǞǟ
ǠǡǢǣǤǥǦǧǨǩǪǫǬǭǮǯǰǱǲǳǴǵǶǷǸǹǺǻǼǽǾǿ
ȀȁȂȃȄȅȆȇȈȉȊȋȌȍȎȏȐȑȒȓȔȕȖȗȘșȚțȜȝȞȟ
ȠȡȢȣȤȥȦȧȨȩȪȫȬȭȮȯȰȱȲȳȴȵȶȷȸȹȺȻȼȽȾȿ
ɀɁɂɃɄɅɆɇɈɉɊɋɌɍɎɏ😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏
in between!
```
Note how in the third line for type 3:
1. the quotes are 'curly' instead of straight quotes
2. the chevrons `<>` are inverted exclamation/question marks `¡¿`
3. the backslash `\` is a curly opening double quote `“`
4. the caret `^`, underscore `_`, and tilde `~` are {circumflex, dot, tilde} accents/smaller glyphs `ˆ˙˜`
6. the braces `{}` are em-dash and curly quotes `—˝`
7. the pipe `|` is en-dash `–`
Everything from the seventh to second-last line is missing in type 3 since it's outside of the 256 limit, and all the emoji are missing from type 42 since that's outside the 65536 limit.

~~This depends on #30520, #30335, #30566, and #30567.~~

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines