### PR TITLE
Prepare for MetaFont/PK font support.

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -32,6 +32,7 @@ from pathlib import Path
 import fontTools.agl
 import numpy as np
 
+import matplotlib as mpl
 from matplotlib import _api, cbook, font_manager
 from matplotlib.ft2font import LoadFlags
 
@@ -127,7 +128,13 @@ class Text(namedtuple('Text', 'x y font glyph width')):
     def _as_unicode_or_name(self):
         if self.font.subfont:
             raise NotImplementedError("Indexing TTC fonts is not supported yet")
-        face = font_manager.get_font(self.font.resolve_path())
+        path = self.font.resolve_path()
+        if path.name.lower().endswith("pk"):
+            # PK fonts have no encoding information; report glyphs as ASCII but
+            # with a "?" to indicate that this is just a guess.
+            return (f"{chr(self.glyph)}?" if chr(self.glyph).isprintable() else
+                    f"pk{self.glyph:#02x}")
+        face = font_manager.get_font(path)
         glyph_name = face.get_glyph_name(self.index)
         glyph_str = fontTools.agl.toUnicode(glyph_name)
         return glyph_str or glyph_name
@@ -758,13 +765,24 @@ class DviFont:
 
     def resolve_path(self):
         if self._path is None:
-            psfont = PsfontsMap(find_tex_file("pdftex.map"))[self.texname]
-            if psfont.filename is None:
-                raise ValueError("No usable font file found for {} ({}); "
-                                 "the font may lack a Type-1 version"
-                                 .format(psfont.psname.decode("ascii"),
-                                         psfont.texname.decode("ascii")))
-            self._path = Path(psfont.filename)
+            fontmap = PsfontsMap(find_tex_file("pdftex.map"))
+            try:
+                psfont = fontmap[self.texname]
+            except LookupError as exc:
+                try:
+                    find_tex_file(f"{self.texname.decode('ascii')}.mf")
+                except FileNotFoundError:
+                    raise exc from None
+                else:
+                    self._path = Path(find_tex_file(
+                        f"{self.texname.decode('ascii')}.600pk"))
+            else:
+                if psfont.filename is None:
+                    raise ValueError("No usable font file found for {} ({}); "
+                                     "the font may lack a Type-1 version"
+                                     .format(psfont.psname.decode("ascii"),
+                                             psfont.texname.decode("ascii")))
+                self._path = Path(psfont.filename)
         return self._path
 
     @cached_property
@@ -773,6 +791,8 @@ class DviFont:
 
     @cached_property
     def effects(self):
+        if self.resolve_path().match("*.600pk"):
+            return {}
         return PsfontsMap(find_tex_file("pdftex.map"))[self.texname].effects
 
     def _index_dvi_to_freetype(self, idx):
@@ -1233,9 +1253,12 @@ class _LuatexKpsewhich:
 
     def _new_proc(self):
         return subprocess.Popen(
-            ["luatex", "--luaonly",
-             str(cbook._get_data_path("kpsewhich.lua"))],
-            stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+            ["luatex", "--luaonly", str(cbook._get_data_path("kpsewhich.lua"))],
+            # mktexpk logs to stderr; suppress that.
+            stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+            # Store generated pk fonts in our own cache.
+            env={"MT_VARTEXFONTS": str(Path(mpl.get_cachedir(), "vartexfonts")),
+                 **os.environ})
 
     def search(self, filename):
         if self._proc.poll() is not None:  # Dead, restart it.
@@ -1287,13 +1310,16 @@ def find_tex_file(filename):
             kwargs = {'env': {**os.environ, 'command_line_encoding': 'utf-8'},
                       'encoding': 'utf-8'}
         else:  # On POSIX, run through the equivalent of os.fsdecode().
-            kwargs = {'encoding': sys.getfilesystemencoding(),
+            kwargs = {'env': {**os.environ},
+                      'encoding': sys.getfilesystemencoding(),
                       'errors': 'surrogateescape'}
+        kwargs['env'].update(
+            MT_VARTEXFONTS=str(Path(mpl.get_cachedir(), "vartexfonts")))
 
         try:
-            path = (cbook._check_and_log_subprocess(['kpsewhich', filename],
-                                                    _log, **kwargs)
-                    .rstrip('\n'))
+            path = cbook._check_and_log_subprocess(
+                ['kpsewhich', '-mktex=pk', filename], _log, **kwargs,
+            ).rstrip('\n')
         except (FileNotFoundError, RuntimeError):
             path = None
 
@@ -1327,7 +1353,6 @@ if __name__ == '__main__':
         print(" ".join(map("{:>11}".format, args)))
 
     with Dvi(args.filename, args.dpi) as dvi:
-        fontmap = PsfontsMap(find_tex_file('pdftex.map'))
         for page in dvi:
             print(f"=== NEW PAGE === "
                   f"(w: {page.width}, h: {page.height}, d: {page.descent})")

--- a/lib/matplotlib/mpl-data/kpsewhich.lua
+++ b/lib/matplotlib/mpl-data/kpsewhich.lua
@@ -1,3 +1,4 @@
 -- see dviread._LuatexKpsewhich
 kpse.set_program_name("latex")
-while true do print(kpse.lookup(io.read():gsub("\r", ""))); io.flush(); end
+kpse.init_prog("", 600, "ljfour")
+while true do print(kpse.lookup(io.read():gsub("\r", ""), {mktexpk=true})); io.flush(); end


### PR DESCRIPTION
TeX MetaFont (.mf) fonts (e.g., from `\usepackage{concmath}`) need to be converted to raster (.pk) fonts before usage.  In dvipng or pdftex this is done by invoking mktexpk via kpsewhich.

This patch ensures that our calls to kpsewhich likewise also generate and finds the raster files (in Matplotlib's own temporary cache) when needed.  The resolution (600dpi) is the documented default (see e.g. the -D option in `man kpsewhich`).  Note that this is only a preliminary step towards full MF/PK font support, which would also require parsing the PK file (which I have implemented elsewhere) and embedding the glyphs into our final output (for which I have a preliminary version in mplcairo).

Work towards fixing #20469.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
