### PR TITLE
pdf: Simplify Type 3 font character encoding

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -1180,13 +1180,11 @@ end"""
                 'Widths': widthsObject
                 }
 
-            from encodings import cp1252
-
             # Make the "Widths" array
             def get_char_width(charcode):
-                s = ord(cp1252.decoding_table[charcode])
                 width = font.load_char(
-                    s, flags=LoadFlags.NO_SCALE | LoadFlags.NO_HINTING).horiAdvance
+                    charcode,
+                    flags=LoadFlags.NO_SCALE | LoadFlags.NO_HINTING).horiAdvance
                 return cvt(width)
             with warnings.catch_warnings():
                 # Ignore 'Required glyph missing from current font' warning
@@ -2331,9 +2329,13 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             self.draw_path(boxgc, path, mytrans, gc._rgb)
 
     def encode_string(self, s, fonttype):
-        if fonttype in (1, 3):
-            return s.encode('cp1252', 'replace')
-        return s.encode('utf-16be', 'replace')
+        match fonttype:
+            case 1:
+                return s.encode('cp1252', 'replace')
+            case 3:
+                return s.encode('latin-1', 'replace')
+            case _:
+                return s.encode('utf-16be', 'replace')
 
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         # docstring inherited


### PR DESCRIPTION
## PR summary

For a Type 3 font, its encoding is entirely defined by its `Encoding` dictionary (which we create), so there's no reason to use a specific encoding like `cp1252`. Instead, switch to Latin-1, which corresponds exactly to the first 256 character codes in Unicode, and can be mapped directly with `ord`.

Split out of #30512.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines