### PR TITLE
MNT: Pending-deprecate setting colormap extremes in-place

### DIFF
--- a/doc/api/next_api_changes/deprecations/30531-TH.rst
+++ b/doc/api/next_api_changes/deprecations/30531-TH.rst
@@ -1,0 +1,16 @@
+In-place modifications of colormaps
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Colormaps are planned to become immutable in the long term.
+
+As a first step, in-place modifications of colormaps are now pending-deprecated.
+This affects the following methods of `.Colormap`:
+
+- `.Colormap.set_bad` - use ``cmap.with_extremes(bad=...)`` instead
+- `.Colormap.set_under` - use ``cmap.with_extremes(under=...)`` instead
+- `.Colormap.set_over` - use ``cmap.with_extremes(over=...)`` instead
+- `.Colormap.set_extremes` - use ``cmap.with_extremes(...)`` instead
+
+Use the respective `.Colormap.with_extremes` and appropriate keyword arguments
+instead which returns a copy of the colormap (available since matplotlib 3.4).
+Alternatively, if you create the colormap yourself, you can also pass the
+respective arguments to the constructor (available since matplotlib 3.11).

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2966,8 +2966,7 @@ class TestScatter:
     @check_figures_equal()
     def test_scatter_invalid_color(self, fig_test, fig_ref):
         ax = fig_test.subplots()
-        cmap = mpl.colormaps["viridis"].resampled(16)
-        cmap.set_bad("k", 1)
+        cmap = mpl.colormaps["viridis"].resampled(16).with_extremes(bad="black")
         # Set a nonuniform size to prevent the last call to `scatter` (plotting
         # the invalid points separately in fig_ref) from using the marker
         # stamping fast path, which would result in slightly offset markers.

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -111,7 +111,8 @@ def test_colormap_copy():
     with np.errstate(invalid='ignore'):
         ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     cmap2 = copy.copy(copied_cmap)
-    cmap2.set_bad('g')
+    with pytest.warns(PendingDeprecationWarning):
+        cmap2.set_bad('g')
     with np.errstate(invalid='ignore'):
         ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     assert_array_equal(ret1, ret2)
@@ -121,7 +122,8 @@ def test_colormap_copy():
     with np.errstate(invalid='ignore'):
         ret1 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     cmap2 = copy.copy(copied_cmap)
-    cmap2.set_bad('g')
+    with pytest.warns(PendingDeprecationWarning):
+        cmap2.set_bad('g')
     with np.errstate(invalid='ignore'):
         ret2 = copied_cmap([-1, 0, .5, 1, np.nan, np.inf])
     assert_array_equal(ret1, ret2)
@@ -135,7 +137,8 @@ def test_colormap_equals():
     # But the same data should be equal
     assert cm_copy == cmap
     # Change the copy
-    cm_copy.set_bad('y')
+    with pytest.warns(PendingDeprecationWarning):
+        cm_copy.set_bad('y')
     assert cm_copy != cmap
     # Make sure we can compare different sizes without failure
     cm_copy._lut = cm_copy._lut[:10, :]
@@ -1535,7 +1538,8 @@ def test_get_under_over_bad():
 def test_non_mutable_get_values(kind):
     cmap = copy.copy(mpl.colormaps['viridis'])
     init_value = getattr(cmap, f'get_{kind}')()
-    getattr(cmap, f'set_{kind}')('k')
+    with pytest.warns(PendingDeprecationWarning):
+        getattr(cmap, f'set_{kind}')('k')
     black_value = getattr(cmap, f'get_{kind}')()
     assert np.all(black_value == [0, 0, 0, 1])
     assert not np.all(init_value == black_value)


### PR DESCRIPTION
Per #29141 we have the long-term plan to make colormaps immutable. As a result, the in-place modifications have to be removed. We take this particularly slow with at least two minor releases of pending deprecation and two further releases of actual deprecations. As it's quite a common concept and migrating away will take time.
