### PR TITLE
feat: support x/y-axis zoom

### DIFF
--- a/doc/release/next_whats_new/scroll_to_zoom.rst
+++ b/doc/release/next_whats_new/scroll_to_zoom.rst
@@ -2,7 +2,8 @@ Zooming using mouse wheel
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ``Ctrl+MouseWheel`` can be used to zoom in the plot windows.
+Additionally, ``x+MouseWheel`` zooms only the x-axis and ``y+MouseWheel`` zooms only the y-axis.
 
-The zoom focusses on the mouse pointer, and keeps the aspect ratio of the axes.
+The zoom focusses on the mouse pointer. With ``Ctrl``, the axes aspect ratio is kept; with ``x`` or ``y``, only the respective axis is scaled.
 
 Zooming is currently only supported on rectilinear Axes.

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2592,7 +2592,7 @@ def scroll_handler(event, canvas=None, toolbar=None):
         # is required for interactive navigation.
         return
 
-    if event.key == "control":  # zoom towards the mouse position
+    if event.key in {"control", "x", "X", "y", "Y"}:  # zoom towards the mouse position
         toolbar.push_current()
 
         xmin, xmax = ax.get_xlim()
@@ -2604,10 +2604,21 @@ def scroll_handler(event, canvas=None, toolbar=None):
         x, y = ax.transScale.transform((event.xdata, event.ydata))
 
         scale_factor = 0.85 ** event.step
-        new_xmin = x - (x - xmin) * scale_factor
-        new_xmax = x + (xmax - x) * scale_factor
-        new_ymin = y - (y - ymin) * scale_factor
-        new_ymax = y + (ymax - y) * scale_factor
+        # Determine which axes to scale based on key
+        zoom_x = event.key in {"control", "x", "X"}
+        zoom_y = event.key in {"control", "y", "Y"}
+
+        if zoom_x:
+            new_xmin = x - (x - xmin) * scale_factor
+            new_xmax = x + (xmax - x) * scale_factor
+        else:
+            new_xmin, new_xmax = xmin, xmax
+
+        if zoom_y:
+            new_ymin = y - (y - ymin) * scale_factor
+            new_ymax = y + (ymax - y) * scale_factor
+        else:
+            new_ymin, new_ymax = ymin, ymax
 
         inv_scale = ax.transScale.inverted()
         (new_xmin, new_ymin), (new_xmax, new_ymax) = inv_scale.transform(


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
Addresses issue #30541

`Ctrl`+`Wheel` zoom with fixed axes ratio
`y`+`Wheel`zoom y
`x`+`Wheel`zoom x

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
