### PR TITLE
MNT: Introduce cmap(..., by_index=...) parameter

### DIFF
--- a/lib/matplotlib/colors.pyi
+++ b/lib/matplotlib/colors.pyi
@@ -80,7 +80,11 @@ class Colormap:
     ) -> None: ...
     @overload
     def __call__(
-        self, X: Sequence[float] | np.ndarray, alpha: ArrayLike | None = ..., bytes: bool = ...
+        self,
+        X: Sequence[float] | np.ndarray,
+        alpha: ArrayLike | None = ...,
+        bytes: bool = ...,
+        by_index: bool | Literal['auto'] = ...,
     ) -> np.ndarray: ...
     @overload
     def __call__(

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -203,6 +203,22 @@ def test_colormap_invalid():
     assert_array_equal(cmap(np.nan), [0., 0., 0., 0.])
 
 
+def test_colormap_by_index():
+    cmap = mpl.colormaps["plasma"]
+    N = cmap.N
+    assert_array_equal(cmap([0., 0.5, 1.]), cmap([0., 0.5, 1.], by_index=False))
+    # auto-detection based on input type by default
+    assert_array_equal(cmap([0., 0.5, 1.]), cmap([0, N//2, N]))
+    # by_index=True forces floats as index interpretation
+    assert_array_equal(cmap([0., N/2, float(N)], by_index=True), cmap([0, N//2, N]))
+
+    cmap = mpl.colormaps["plasma"].with_extremes(over='r', under='b', bad='g')
+
+    assert cmap(1) == cmap(1/N)
+    assert cmap(1., by_index=True) == cmap(1/N)
+    assert cmap(1, by_index=False) == cmap(1.)
+
+
 def test_colormap_return_types():
     """
     Make sure that tuples are returned for scalar input and


### PR DESCRIPTION
This allows to explicitly state whether inputs should be handled as normalized values [0, 1] or indices into the colormap.

The value `by_index='auto'` is the current default and makes the interpretation dependent on the data type. Resulting in surprising behavior #28198. It is planned to deprecate this in a follow-up PR and switch to
`by_index=False` eventually. The standard case of float inputs will not be affected by this change. But users that want to pass indices, will then have to explicitly use `by_index=True`.

Note: We currently rely on the auto detection for `BoundaryNorm`. That will be handled by special casing `BoundaryNorm` in the colorizer pipeline, essentially switching `cmap(norm(data))` to `cmap(norm(data), by_index=isinstance(norm, BoundaryNorm))`. It's better to do the special casing there rather than the type-based autodetection in `Colormap.__call__`. Hopefully, we can additionally get rid of that special case through https://github.com/matplotlib/matplotlib/issues/21911#issuecomment-3276419772, but that's a separate discussion and its result does not impact the meaningfulness of this PR.
