### PR TITLE
Fix stubtest with mypy 18

### DIFF
--- a/tools/stubtest.py
+++ b/tools/stubtest.py
@@ -108,6 +108,7 @@ with tempfile.TemporaryDirectory() as d:
         [
             "stubtest",
             "--mypy-config-file=pyproject.toml",
+            "--ignore-disjoint-bases",
             "--allowlist=ci/mypy-stubtest-allowlist.txt",
             f"--allowlist={p}",
             "matplotlib",


### PR DESCRIPTION
Closes #30551 by disabling checks for disjoint bases. There may be other
 solutions like decorating Container and dviread.Text with
 @disjoint_base, however I've not yet fully understood whether that'd be
  technically correct. We have survived without disjoint bases checks so
   far, so at least as a quick fix this should good enough.

