### PR TITLE
pdf/ps: Track full character map in CharacterTracker

### DIFF
--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -826,7 +826,7 @@ grestore
             f"{angle:g} rotate\n")
         lastfont = None
         for font, fontsize, ccode, glyph_index, ox, oy in glyphs:
-            self._character_tracker.track_glyph(font, glyph_index)
+            self._character_tracker.track_glyph(font, ccode, glyph_index)
             if (font.postscript_name, fontsize) != lastfont:
                 lastfont = font.postscript_name, fontsize
                 self._pswriter.write(
@@ -1069,18 +1069,19 @@ class FigureCanvasPS(FigureCanvasBase):
             print("mpldict begin", file=fh)
             print("\n".join(_psDefs), file=fh)
             if not mpl.rcParams['ps.useafm']:
-                for font_path, glyphs in ps_renderer._character_tracker.used.items():
-                    if not glyphs:
+                for (font, subset_index), charmap in \
+                        ps_renderer._character_tracker.used.items():
+                    if not charmap:
                         continue
                     fonttype = mpl.rcParams['ps.fonttype']
                     # Can't use more than 255 chars from a single Type 3 font.
-                    if len(glyphs) > 255:
+                    if len(charmap) > 255:
                         fonttype = 42
                     fh.flush()
                     if fonttype == 3:
-                        fh.write(_font_to_ps_type3(font_path, glyphs))
+                        fh.write(_font_to_ps_type3(font, charmap.values()))
                     else:  # Type 42 only.
-                        _font_to_ps_type42(font_path, glyphs, fh)
+                        _font_to_ps_type42(font, charmap.values(), fh)
             print("end", file=fh)
             print("%%EndProlog", file=fh)
 


### PR DESCRIPTION
## PR summary

By tracking both character codes and glyph indices, we can handle producing multiple font subsets if needed by a file format.

This was split out of #30512, but based on #30335.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines