### PR TITLE
CI: remove macos13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,7 +83,7 @@ jobs:
             python-version: '3.12'
             # https://github.com/matplotlib/matplotlib/issues/29732
             pygobject-ver: '<3.52.0'
-          - os: macos-14  # This runner is on M1 (arm64) chips.
+          - os: macos-15  # This runner is on M1 (arm64) chips.
             python-version: '3.13'
             # https://github.com/matplotlib/matplotlib/issues/29732
             pygobject-ver: '<3.52.0'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -77,8 +77,7 @@ jobs:
             pygobject-ver: '<3.52.0'
           - os: ubuntu-24.04
             python-version: '3.12'
-          - os: macos-13  # This runner is on Intel chips.
-            # merge numpy and pandas install in nighties test when this runner is dropped
+          - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.11'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.12'
@@ -297,13 +296,7 @@ jobs:
           python -m pip install pytz tzdata  # Must be installed for Pandas.
           python -m pip install \
             --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-            --upgrade --only-binary=:all: numpy
-          # wheels for intel osx is not always available on nightly wheels index, merge this back into
-          # the above install command when the OSX-13 (intel) runners are dropped.
-          python -m pip install \
-            --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple \
-            --upgrade --only-binary=:all: pandas || true
-
+            --upgrade --only-binary=:all: numpy pandas
 
       - name: Install Matplotlib
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,6 +79,8 @@ jobs:
             python-version: '3.12'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.11'
+            # https://github.com/matplotlib/matplotlib/issues/29732
+            pygobject-ver: '<3.52.0'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.12'
             # https://github.com/matplotlib/matplotlib/issues/29732


### PR DESCRIPTION
The VM is being dropped by GH [1] on macOS is no longer supported by homebrew or Apple.

This job is starting to fail on installing homebrew dependencies.  Rather than try to fix this, move on to the next image which we need to do by the end of the CY anyway.

This means we no longer are testing on intel macs.

[1] https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/#macos-13-is-closing-down
