### PR TITLE
Deterministic Rendering

### DIFF
--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -511,16 +511,22 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
 
     transformed_path_t marker_path_transformed(marker_path, marker_trans);
     nan_removed_t marker_path_nan_removed(marker_path_transformed, true, marker_path.has_codes());
+    e_snap_mode snap_mode = gc.snap_mode;
+    if (snap_mode == SNAP_AUTO) {
+        snap_mode = SNAP_FALSE;
+    }
     snap_t marker_path_snapped(marker_path_nan_removed,
-                               SNAP_FALSE,
+                               snap_mode,
                                marker_path.total_vertices(),
                                points_to_pixels(gc.linewidth));
     curve_t marker_path_curve(marker_path_snapped);
 
-    // If the path snapper isn't in effect, at least make sure the marker
-    // at (0, 0) is in the center of a pixel.  This, importantly, makes
-    // the circle markers look centered around the point they refer to.
-    marker_trans *= agg::trans_affine_translation(0.5, 0.5);
+    if (!marker_path_snapped.is_snapping()) {
+        // If the path snapper isn't in effect, at least make sure the marker
+        // at (0, 0) is in the center of a pixel.  This, importantly, makes
+        // the circle markers look centered around the point they refer to.
+        marker_trans *= agg::trans_affine_translation(0.5, 0.5);
+    }
 
     transformed_path_t path_transformed(path, trans);
     nan_removed_t path_nan_removed(path_transformed, false, false);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -512,17 +512,15 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
     transformed_path_t marker_path_transformed(marker_path, marker_trans);
     nan_removed_t marker_path_nan_removed(marker_path_transformed, true, marker_path.has_codes());
     snap_t marker_path_snapped(marker_path_nan_removed,
-                               gc.snap_mode,
+                               SNAP_FALSE,
                                marker_path.total_vertices(),
                                points_to_pixels(gc.linewidth));
     curve_t marker_path_curve(marker_path_snapped);
 
-    if (!marker_path_snapped.is_snapping()) {
-        // If the path snapper isn't in effect, at least make sure the marker
-        // at (0, 0) is in the center of a pixel.  This, importantly, makes
-        // the circle markers look centered around the point they refer to.
-        marker_trans *= agg::trans_affine_translation(0.5, 0.5);
-    }
+    // If the path snapper isn't in effect, at least make sure the marker
+    // at (0, 0) is in the center of a pixel.  This, importantly, makes
+    // the circle markers look centered around the point they refer to.
+    marker_trans *= agg::trans_affine_translation(0.5, 0.5);
 
     transformed_path_t path_transformed(path, trans);
     nan_removed_t path_nan_removed(path_transformed, false, false);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -511,12 +511,8 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
 
     transformed_path_t marker_path_transformed(marker_path, marker_trans);
     nan_removed_t marker_path_nan_removed(marker_path_transformed, true, marker_path.has_codes());
-    e_snap_mode snap_mode = gc.snap_mode;
-    if (snap_mode == SNAP_AUTO) {
-        snap_mode = SNAP_TRUE;
-    }
     snap_t marker_path_snapped(marker_path_nan_removed,
-                               snap_mode,
+                               gc.snap_mode,
                                marker_path.total_vertices(),
                                points_to_pixels(gc.linewidth));
     curve_t marker_path_curve(marker_path_snapped);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -513,7 +513,7 @@ inline void RendererAgg::draw_markers(GCAgg &gc,
     nan_removed_t marker_path_nan_removed(marker_path_transformed, true, marker_path.has_codes());
     e_snap_mode snap_mode = gc.snap_mode;
     if (snap_mode == SNAP_AUTO) {
-        snap_mode = SNAP_FALSE;
+        snap_mode = SNAP_TRUE;
     }
     snap_t marker_path_snapped(marker_path_nan_removed,
                                snap_mode,


### PR DESCRIPTION
## PR summary
This change potentially solves the non-deterministic rendering of polylines.
This is caused by `SNAP_AUTO` and two different methods of performing pixel translation for the same polyline vertices (that is based on a line's diagonality, which is further based on the polyline's vertex order).
Subject to further tests, this PR closes #30549.

This [video](https://youtu.be/EoryoLnGXF4) demonstrates the change.
