### PR TITLE
TST: Force Agg backend in test_openin_any_paranoid

### DIFF
--- a/lib/matplotlib/tests/test_texmanager.py
+++ b/lib/matplotlib/tests/test_texmanager.py
@@ -70,6 +70,7 @@ def test_openin_any_paranoid():
          'import matplotlib.pyplot as plt;'
          'plt.rcParams.update({"text.usetex": True});'
          'plt.title("paranoid");'
-         'plt.show(block=False);'],
-        env={**os.environ, 'openin_any': 'p'}, check=True, capture_output=True)
+         'plt.gcf().canvas.draw();'],
+        env={**os.environ, 'MPLBACKEND': 'Agg', 'openin_any': 'p'},
+        check=True, capture_output=True)
     assert completed.stderr == ""


### PR DESCRIPTION
## PR summary

On some CI, the Qt backend seems to be picked, but something is confused and it fails due to an invalid `DISPLAY` variable. But this test doesn't need an interactive backend, so don't use one.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines