### PR TITLE
MNT: Do not use colormap setters in tests

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -735,13 +735,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
                     i0 = 1
 
             cmap = mcolors.ListedColormap(
-                cbook._resize_sequence(color_sequence[i0:], ncolors))
-
-            if use_set_under_over:
-                if self._extend_min:
-                    cmap.set_under(color_sequence[0])
-                if self._extend_max:
-                    cmap.set_over(color_sequence[-1])
+                cbook._resize_sequence(color_sequence[i0:], ncolors),
+                under=(color_sequence[0]
+                       if use_set_under_over and self._extend_min else None),
+                over=(color_sequence[-1]
+                      if use_set_under_over and self._extend_max else None),
+            )
 
         # label lists must be initialized here
         self.labelTexts = []

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2982,8 +2982,7 @@ class TestScatter:
     def test_scatter_no_invalid_color(self, fig_test, fig_ref):
         # With plotnonfinite=False we plot only 2 points.
         ax = fig_test.subplots()
-        cmap = mpl.colormaps["viridis"].resampled(16)
-        cmap.set_bad("k", 1)
+        cmap = mpl.colormaps["viridis"].resampled(16).with_extremes(bad="k")
         ax.scatter(range(4), range(4),
                    c=[1, np.nan, 2, np.nan], s=[1, 2, 3, 4],
                    cmap=cmap, plotnonfinite=False)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -946,9 +946,10 @@ def test_proportional_colorbars():
 
     levels = [-1.25, -0.5, -0.125, 0.125, 0.5, 1.25]
     cmap = mcolors.ListedColormap(
-        ['0.3', '0.5', 'white', 'lightblue', 'steelblue'])
-    cmap.set_under('darkred')
-    cmap.set_over('crimson')
+        ['0.3', '0.5', 'white', 'lightblue', 'steelblue'],
+        under='darkred',
+        over='crimson',
+    )
     norm = mcolors.BoundaryNorm(levels, cmap.N)
 
     extends = ['neither', 'both']

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -53,13 +53,9 @@ def test_resampled():
     colorlist[:, 1] = 0.2
     colorlist[:, 2] = np.linspace(1, 0, n)
     colorlist[:, 3] = 0.7
-    lsc = mcolors.LinearSegmentedColormap.from_list('lsc', colorlist)
-    lc = mcolors.ListedColormap(colorlist)
-    # Set some bad values for testing too
-    for cmap in [lsc, lc]:
-        cmap.set_under('r')
-        cmap.set_over('g')
-        cmap.set_bad('b')
+    lsc = mcolors.LinearSegmentedColormap.from_list(
+        'lsc', colorlist, under='red', over='green', bad='blue')
+    lc = mcolors.ListedColormap(colorlist, under='red', over='green', bad='blue')
     lsc3 = lsc.resampled(3)
     lc3 = lc.resampled(3)
     expected = np.array([[0.0, 0.2, 1.0, 0.7],
@@ -371,9 +367,7 @@ def test_BoundaryNorm():
     assert_array_equal(mynorm(x), ref)
 
     # Without interpolation
-    cmref = mcolors.ListedColormap(['blue', 'red'])
-    cmref.set_over('black')
-    cmref.set_under('white')
+    cmref = mcolors.ListedColormap(['blue', 'red'], under='white', over='black')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red', 'black'])
 
     assert mcolors.same_color(cmref.get_over(), 'black')
@@ -395,8 +389,7 @@ def test_BoundaryNorm():
     assert_array_equal(cmshould(mynorm(x)), cmref(refnorm(x)))
 
     # Just min
-    cmref = mcolors.ListedColormap(['blue', 'red'])
-    cmref.set_under('white')
+    cmref = mcolors.ListedColormap(['blue', 'red'], under='white')
     cmshould = mcolors.ListedColormap(['white', 'blue', 'red'])
 
     assert mcolors.same_color(cmref.get_under(), 'white')
@@ -413,8 +406,7 @@ def test_BoundaryNorm():
     assert_array_equal(cmshould(mynorm(x)), cmref(refnorm(x)))
 
     # Just max
-    cmref = mcolors.ListedColormap(['blue', 'red'])
-    cmref.set_over('black')
+    cmref = mcolors.ListedColormap(['blue', 'red'], over='black')
     cmshould = mcolors.ListedColormap(['blue', 'red', 'black'])
 
     assert mcolors.same_color(cmref.get_over(), 'black')
@@ -928,7 +920,7 @@ def test_cmap_and_norm_from_levels_and_colors2():
     for extend, i1, cases in tests:
         cmap, norm = mcolors.from_levels_and_colors(levels, colors[0:i1],
                                                     extend=extend)
-        cmap.set_bad(bad)
+        cmap = cmap.with_extremes(bad=bad)
         for d_val, expected_color in cases.items():
             if d_val == masked_value:
                 d_val = np.ma.array([1], mask=True)

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -616,8 +616,7 @@ def test_contourf_legend_elements():
     cs = plt.contourf(h, levels=[10, 30, 50],
                       colors=['#FFFF00', '#FF00FF', '#00FFFF'],
                       extend='both')
-    cs.cmap.set_over('red')
-    cs.cmap.set_under('blue')
+    cs.cmap = cs.cmap.with_extremes(over='red', under='blue')
     cs.changed()
     artists, labels = cs.legend_elements()
     assert labels == ['$x \\leq -1e+250s$',

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1,5 +1,4 @@
 from contextlib import ExitStack
-from copy import copy
 import functools
 import io
 import os
@@ -1194,8 +1193,7 @@ def test_image_array_alpha_validation():
 
 @mpl.style.context('mpl20')
 def test_exact_vmin():
-    cmap = copy(mpl.colormaps["autumn_r"])
-    cmap.set_under(color="lightgrey")
+    cmap = mpl.colormaps["autumn_r"].with_extremes(under="lightgrey")
 
     # make the image exactly 190 pixels wide
     fig = plt.figure(figsize=(1.9, 0.1), dpi=100)
@@ -1469,9 +1467,7 @@ def test_rgba_antialias():
     aa[70:90, 195:215] = 1e6
     aa[20:30, 195:215] = -1e6
 
-    cmap = plt.colormaps["RdBu_r"]
-    cmap.set_over('yellow')
-    cmap.set_under('cyan')
+    cmap = plt.colormaps["RdBu_r"].with_extremes(over='yellow', under='cyan')
 
     axs = axs.flatten()
     # zoom in
@@ -1726,8 +1722,7 @@ def test_downsampling_speckle():
     axs = axs.flatten()
     img = ((np.arange(1024).reshape(-1, 1) * np.ones(720)) // 50).T
 
-    cm = plt.get_cmap("viridis")
-    cm.set_over("m")
+    cm = plt.get_cmap("viridis").with_extremes(over="m")
     norm = colors.LogNorm(vmin=3, vmax=11)
 
     # old default cannot be tested because it creates over/under speckles

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -285,18 +285,11 @@ def test_contourf3d_extend(fig_test, fig_ref, extend, levels):
     # Z is in the range [0, 8]
     Z = X**2 + Y**2
 
-    # Manually set the over/under colors to be the end of the colormap
-    cmap = mpl.colormaps['viridis'].copy()
-    cmap.set_under(cmap(0))
-    cmap.set_over(cmap(255))
-    # Set vmin/max to be the min/max values plotted on the reference image
-    kwargs = {'vmin': 1, 'vmax': 7, 'cmap': cmap}
-
     ax_ref = fig_ref.add_subplot(projection='3d')
-    ax_ref.contourf(X, Y, Z, levels=[0, 2, 4, 6, 8], **kwargs)
+    ax_ref.contourf(X, Y, Z, levels=[0, 2, 4, 6, 8], vmin=1, vmax=7)
 
     ax_test = fig_test.add_subplot(projection='3d')
-    ax_test.contourf(X, Y, Z, levels, extend=extend, **kwargs)
+    ax_test.contourf(X, Y, Z, levels, extend=extend, vmin=1, vmax=7)
 
     for ax in [ax_ref, ax_test]:
         ax.set_xlim(-2, 2)

--- a/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
@@ -90,8 +90,7 @@ def test_contourf_legend_elements():
     cs = ax.contourf(x, y, h, levels=[10, 30, 50],
                      colors=['#FFFF00', '#FF00FF', '#00FFFF'],
                      extend='both')
-    cs.cmap.set_over('red')
-    cs.cmap.set_under('blue')
+    cs.cmap = cs.cmap.with_extremes(over='red', under='blue')
     cs.changed()
     artists, labels = cs.legend_elements()
     assert labels == ['$x \\leq -1e+250s$',


### PR DESCRIPTION
Instead use the more modern ways to specify extremes during Colormap creation or using `with_extremes()`

This is in preparation of deprecating setters in #30531.

