### PR TITLE
ci: Bump Ubuntu ARM builder to 24.04

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,10 +60,6 @@ jobs:
             extra-requirements: '-r requirements/testing/extra.txt'
             # https://github.com/matplotlib/matplotlib/issues/29844
             pygobject-ver: '<3.52.0'
-          - os: ubuntu-22.04-arm
-            python-version: '3.12'
-            # https://github.com/matplotlib/matplotlib/issues/29844
-            pygobject-ver: '<3.52.0'
           - name-suffix: "(Extra TeX packages)"
             os: ubuntu-22.04
             python-version: '3.13'
@@ -76,6 +72,8 @@ jobs:
             # https://github.com/matplotlib/matplotlib/issues/29844
             pygobject-ver: '<3.52.0'
           - os: ubuntu-24.04
+            python-version: '3.12'
+          - os: ubuntu-24.04-arm
             python-version: '3.12'
           - os: macos-14  # This runner is on M1 (arm64) chips.
             python-version: '3.11'
@@ -150,7 +148,7 @@ jobs:
             if [[ "${{ matrix.name-suffix }}" != '(Minimum Versions)' ]]; then
               sudo apt-get install -yy --no-install-recommends ffmpeg poppler-utils
             fi
-            if [[ "${{ matrix.os }}" = ubuntu-22.04 || "${{ matrix.os }}" = ubuntu-22.04-arm ]]; then
+            if [[ "${{ matrix.os }}" = ubuntu-22.04 ]]; then
               sudo apt-get install -yy --no-install-recommends \
                 gir1.2-gtk-4.0 \
                 libgirepository1.0-dev
@@ -257,7 +255,7 @@ jobs:
             )
 
           # PyQt5 does not have any wheels for ARM on Linux.
-          if [[ "${{ matrix.os }}" != 'ubuntu-22.04-arm' ]]; then
+          if [[ "${{ matrix.os }}" != 'ubuntu-24.04-arm' ]]; then
             python -mpip install --upgrade --only-binary :all: pyqt5 &&
               python -c 'import PyQt5.QtCore' &&
               echo 'PyQt5 is available' ||
@@ -372,7 +370,7 @@ jobs:
         run: |
           if [[ "${{ runner.os }}" != 'macOS' ]]; then
             LCOV_IGNORE_ERRORS=','  # do not ignore any lcov errors by default
-            if [[ "${{ matrix.os }}" = ubuntu-24.04 ]]; then
+            if [[ "${{ matrix.os }}" = ubuntu-24.04 || "${{ matrix.os }}" = ubuntu-24.04-arm ]]; then
               # filter mismatch and unused-entity errors detected by lcov 2.x
               LCOV_IGNORE_ERRORS='mismatch,unused'
             fi

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1382,7 +1382,8 @@ def test_pcolorargs_5205():
     plt.pcolor(X, Y, list(Z[:-1, :-1]))
 
 
-@image_comparison(['pcolormesh'], remove_text=True)
+@image_comparison(['pcolormesh'], remove_text=True,
+                  tol=0.11 if platform.machine() == 'aarch64' else 0)
 def test_pcolormesh():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False
@@ -1434,7 +1435,7 @@ def test_pcolormesh_small():
 
 @image_comparison(['pcolormesh_alpha'], extensions=["png", "pdf"],
                   remove_text=True,
-                  tol=0.2 if platform.machine() == "aarch64" else 0)
+                  tol=0.4 if platform.machine() == "aarch64" else 0)
 def test_pcolormesh_alpha():
     # Remove this line when this test image is regenerated.
     plt.rcParams['pcolormesh.snap'] = False


### PR DESCRIPTION
## PR summary

Since earlier today, the `ubuntu-22.04-arm` image has actually been Ubuntu 24.04. Instead of working out how to fix that, switch to the newer image explicitly.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines