### PR TITLE
ft2font: Split layouting from set_text

### DIFF
--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -113,6 +113,9 @@ class FT2Font
     void set_size(double ptsize, double dpi);
     void set_charmap(int i);
     void select_charmap(unsigned long i);
+    std::vector<raqm_glyph_t> layout(std::u32string_view text, FT_Int32 flags,
+                                     LanguageType languages,
+                                     std::set<FT_String*>& glyph_seen_fonts);
     void set_text(std::u32string_view codepoints, double angle, FT_Int32 flags,
                   LanguageType languages, std::vector<double> &xys);
     int get_kerning(FT_UInt left, FT_UInt right, FT_Kerning_Mode mode);


### PR DESCRIPTION
## PR summary

The former may be used even on PS/PDF backend where nothing is rendered.

I split this out of the actual vector backend changes because it's mostly independent and doesn't need to wait for other PDF code refactors.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines