### PR TITLE
Exporting concise SVG

### DIFF
--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -68,6 +68,10 @@ class MixedModeRenderer:
         # to the underlying C implementation).
         return getattr(self._renderer, attr)
 
+    def is_svg_renderer(self):
+        from matplotlib.backends.backend_svg import RendererSVG
+        return isinstance(self._renderer, RendererSVG)
+
     def start_rasterizing(self):
         """
         Enter "raster" mode.  All subsequent drawing commands (until


### PR DESCRIPTION
## PR summary
Currently all SVG elements are exported as path, which is currently the most viable solution, as other solutions have their pitfalls. But a concise and apt SVG could make things better and is something probably to work on.

This PR closes #17424. (well, not really, just wanted to link it to the issue as per the PR checklist)
It's not the final solution but it solves the problem. There are restrictions involved in this solution ([reference](https://github.com/melwyncarlo/matplotlib/blob/3b86436fb958dbc1467e88b2553d2f61c27b62bf/lib/matplotlib/backends/backend_svg.py#L689-L724)):

---

```py
        # Option-1: (preferred alternative; currently in use over here)
        #   Set attrib['vector-effects'] = 'non-scaling-stroke'
        #   in _get_style_dict()
        #       Issue:
        #           Part of SVG Tiny 1.2 and SVG 2 (active development)
        #           Supported on modern browsers but not all image editors
        #           Does not scale stroke-width on scaling/zooming,
        #           though it zooms well on browsers while viewing.
        #           Does not directly scale stroke-width when exporting to
        #           higher resolution raster images (PNG); requires first
        #           manually scaling the SVG by:
        #               1. scaling the SVG width, height, and viewbox
        #                   e.g.: current width = 480.0, height = 345.6
        #                         viewbox = 0 0 480.0 345.6
        #                         To obtain 4800px x 3456px image, set
        #                         new width = 4800.0, height = 3456.0
        #                         viewbox = 0 0 4800.0 3456.0
        #               2. Applying transform scale() to the figure
        #                   e.g.: (cont'd) scale factor = 4800 / 480 = 10
        #                         so, change:  <g id="figure_1"> to:
        #                         <g id="figure_1" transform="scale(10)">
        # Option-2:
        #   gc.set_linewidth(gc.get_linewidth() / transform_scale_factor)
        #       Issue:
        #           Works well if tranform_matrix consists only of
        #           uniform scaling and translation, i.e.,
        #           transform_scale_factor = abs(transform_matrix[0, 0])
        #           Otherwise, it requires an advanced affine matrix
        #           decomposition algorithm (SVD or Polar) to compute the
        #           transform_scale_factor.
        #           Still does not correct non-uniform stroke-width
        #           caused by shearing/skewing.
        # Option-3: (currently in use in main branch)
        #   Convert all shapes to path, apply transformations to path,
        #   and then draw path. This basically avoids all the above
        #   mentioned pitfalls.
```

---

I have performed relevant tests:
- [Video link](https://youtu.be/hwPAciI6TjI)
- [Test code repository](https://github.com/melwyncarlo/Matplotlib-Pure-SVG-Tests/)

P.S.: It's not meant to pass any CI/CD tests, as the solution itself is assumed to be subject to changes.