### PR TITLE
Matplotlib Device Scaling on Windows

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -602,6 +602,8 @@ class FigureManagerTk(FigureManagerBase):
                 self.window.protocol("WM_DELETE_WINDOW", destroy)
                 self.window.deiconify()
                 self.canvas._tkcanvas.focus_set()
+                if self._window_dpi.get() != 96:
+                    self._update_window_dpi()
             else:
                 self.canvas.draw_idle()
             if mpl.rcParams['figure.raise_window']:


### PR DESCRIPTION
## PR summary

This PR closes #26733.

Basically, the change in DPI is signaled when resizing or changing the device scale, and not when the canvas is launched/loaded, hence the issue.

This [video](https://youtu.be/Xga3rN4DmnQ) demonstrates the problem and the fix.