### PR TITLE
Unimplemented warning for Text3D's rotation/rotation_mode parameters

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -3,7 +3,6 @@ Classes for including text in a figure.
 """
 
 import functools
-import warnings
 import logging
 import math
 from numbers import Real
@@ -181,12 +180,6 @@ class Text(Artist):
         self.set_verticalalignment(verticalalignment)
         self.set_horizontalalignment(horizontalalignment)
         self._multialignment = multialignment
-        if rotation is not None:
-            warnings.showwarning(
-                "The `rotation` parameter has not yet been implemented "
-                "and is currently ignored.",
-                UserWarning, 'Matplotlib - MPL Toolkits - MPlot3D', ''
-            )
         self.set_rotation(rotation)
         self._transform_rotates_text = transform_rotates_text
         self._bbox_patch = None  # a FancyBboxPatch instance
@@ -194,12 +187,6 @@ class Text(Artist):
         if linespacing is None:
             linespacing = 1.2  # Maybe use rcParam later.
         self.set_linespacing(linespacing)
-        if rotation_mode is not None:
-            warnings.showwarning(
-                "The `rotation_mode` parameter has not yet been implemented "
-                "and is currently ignored.",
-                UserWarning, 'Matplotlib - MPL Toolkits - MPlot3D', ''
-            )
         self.set_rotation_mode(rotation_mode)
         self.set_antialiased(mpl._val_or_rc(antialiased, 'text.antialiased'))
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -3,6 +3,7 @@ Classes for including text in a figure.
 """
 
 import functools
+import warnings
 import logging
 import math
 from numbers import Real
@@ -180,6 +181,12 @@ class Text(Artist):
         self.set_verticalalignment(verticalalignment)
         self.set_horizontalalignment(horizontalalignment)
         self._multialignment = multialignment
+        if rotation is not None:
+            warnings.showwarning(
+                "The `rotation` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'Matplotlib - MPL Toolkits - MPlot3D', ''
+            )
         self.set_rotation(rotation)
         self._transform_rotates_text = transform_rotates_text
         self._bbox_patch = None  # a FancyBboxPatch instance
@@ -187,6 +194,12 @@ class Text(Artist):
         if linespacing is None:
             linespacing = 1.2  # Maybe use rcParam later.
         self.set_linespacing(linespacing)
+        if rotation_mode is not None:
+            warnings.showwarning(
+                "The `rotation_mode` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'Matplotlib - MPL Toolkits - MPlot3D', ''
+            )
         self.set_rotation_mode(rotation_mode)
         self.set_antialiased(mpl._val_or_rc(antialiased, 'text.antialiased'))
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -8,6 +8,7 @@ artists into 3D versions which can be added to an Axes3D.
 """
 
 import math
+import warnings
 
 import numpy as np
 
@@ -123,6 +124,18 @@ class Text3D(mtext.Text):
 
     def __init__(self, x=0, y=0, z=0, text='', zdir='z', axlim_clip=False,
                  **kwargs):
+        if kwargs.get('rotation', None) is not None:
+            warnings.showwarning(
+                "The `rotation` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'mpl_toolkits.mplot3d.art3d.Text3D', ''
+            )
+        if kwargs.get('rotation_mode', None) is not None:
+            warnings.showwarning(
+                "The `rotation_mode` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'mpl_toolkits.mplot3d.art3d.Text3D', ''
+            )
         mtext.Text.__init__(self, x, y, text, **kwargs)
         self.set_3d_properties(z, zdir, axlim_clip)
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1950,6 +1950,18 @@ class Axes3D(Axes):
         `.Text3D`
             The created `.Text3D` instance.
         """
+        if kwargs.get('rotation', None) is not None:
+            warnings.showwarning(
+                "The `rotation` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'mpl_toolkits.mplot3d.axes3d.Axes3D.text', ''
+            )
+        if kwargs.get('rotation_mode', None) is not None:
+            warnings.showwarning(
+                "The `rotation_mode` parameter has not yet been implemented "
+                "and is currently ignored.",
+                UserWarning, 'mpl_toolkits.mplot3d.axes3d.Axes3D.text', ''
+            )
         text = super().text(x, y, s, **kwargs)
         art3d.text_2d_to_3d(text, z, zdir, axlim_clip)
         return text


### PR DESCRIPTION
## PR summary

Currently, the `rotation` and `rotation_mode` parameters are ignored for the `Text3D` class.
This affects code that accesses the class directly, as well as via the `Axes3D.text` function.

There is no implementation for the true 3D rotation of text in the current codebase.
It only rotates the text about the axis going through the display screen (set via the `zdir` parameter).
Implementing it is a serious undertaking which can't be achieved in a short matter of time.

Nevertheless, the parameters for it do exist in the public API which confuses users when they don't work as intended.
Therefore, a warning would be beneficial to warn the user about those two parameters being ignored/unimplemented.

This issue provisionally closes #30563.
