### PR TITLE
MNT: Fix some broken deprecations

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -2382,10 +2382,9 @@ class _Style:
 
     @classmethod
     @_api.deprecated(
-        '3.10.0',
+        '3.10',
         message="This method is never used internally.",
-        alternative="No replacement.  Please open an issue if you use this."
-    )
+        alternative="No replacement.  Please open an issue if you use this.")
     def register(cls, name, style):
         """Register a new style."""
         if not issubclass(style, cls._Base):

--- a/lib/mpl_toolkits/axes_grid1/axes_grid.py
+++ b/lib/mpl_toolkits/axes_grid1/axes_grid.py
@@ -190,7 +190,7 @@ class Grid:
         return col, row
 
     n_axes = property(lambda self: len(self.axes_all))
-    ngrids = _api.deprecated(property(lambda self: len(self.axes_all)))
+    ngrids = _api.deprecated('3.11')(property(lambda self: len(self.axes_all)))
 
     # Good to propagate __len__ if we have __getitem__
     def __len__(self):

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -806,3 +806,5 @@ def test_grid_n_axes():
     fig = plt.figure()
     grid = Grid(fig, 111, (3, 3), n_axes=5)
     assert len(fig.axes) == grid.n_axes == 5
+    with pytest.warns(mpl.MatplotlibDeprecationWarning, match="ngrids attribute"):
+        assert grid.ngrids == 5


### PR DESCRIPTION
## PR summary

The `ngrids` deprecation was missing the version, and style registration incorrectly included the micro version.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines