### PR TITLE
DOC: Fix raw string in mathtext unicode example

### DIFF
--- a/galleries/users_explain/text/mathtext.py
+++ b/galleries/users_explain/text/mathtext.py
@@ -370,4 +370,4 @@ fig.text(.1, .1, r'even: $ \delta $ = $ \$4 $')
 # If a particular symbol does not have a name (as is true of many of the more
 # obscure symbols in the STIX fonts), Unicode characters can also be used::
 #
-#    r'$\u23ce$'
+#    '$\u23ce$'


### PR DESCRIPTION
This PR closes #30574.

## PR summary

This PR corrects a small typo in the Matplotlib documentation.

- **Why is this change necessary?** The `mathtext` tutorial contained an example for rendering Unicode characters (`r'$\u23ce$'`) that used a raw string (`r''`).

- **What problem does it solve?** Using a raw string prevents Python from interpreting the `\u` escape sequence, causing the example code to crash with a `ParseFatalException`. This could be confusing for users who copy and paste the example directly from the documentation.

- **What is the reasoning for this implementation?** The fix is to simply remove the `r` prefix from the example string, allowing the Unicode escape sequence to be correctly parsed. This makes the documentation accurate and the example functional.

## PR checklist

- [x] "closes #30574" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines