### PR TITLE
Prepare `CharacterTracker` for advanced font features

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -157,20 +157,10 @@ class CharacterTracker:
             whole). If *subset_size* is not specified, then the subset will always be 0
             and the character codes will be returned from the string unchanged.
         """
-        font_glyphs = []
-        char_to_font = font._get_fontmap(s)
-        for _c, _f in char_to_font.items():
-            charcode = ord(_c)
-            glyph_index = _f.get_char_index(charcode)
-            if self.subset_size != 0:
-                subset = charcode // self.subset_size
-                subset_charcode = charcode % self.subset_size
-            else:
-                subset = 0
-                subset_charcode = charcode
-            self.used.setdefault((_f.fname, subset), {})[subset_charcode] = glyph_index
-            font_glyphs.append((subset, subset_charcode))
-        return font_glyphs
+        return [
+            self.track_glyph(f, ord(c), f.get_char_index(ord(c)))
+            for c, f in font._get_fontmap(s).items()
+        ]
 
     def track_glyph(
             self, font: FT2Font, charcode: CharacterCodeType,

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -22,6 +22,12 @@ if typing.TYPE_CHECKING:
     from fontTools.ttLib import TTFont
 
 
+_FONT_MAX_GLYPH = {
+    3: 256,
+    42: 65536,
+}
+
+
 @functools.lru_cache(50)
 def _cached_get_afm_from_fname(fname):
     with open(fname, "rb") as fh:

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -251,9 +251,15 @@ class CharacterTracker:
         # Default to preserving the character code as it was.
         use_next_charmap = (
             self.subset_size != 0
-            # But start filling a new subset if outside the first block; this preserves
-            # ASCII (for Type 3) or the Basic Multilingual Plane (for Type 42).
-            and charcode >= self.subset_size
+            and (
+                # But start filling a new subset if outside the first block; this
+                # preserves ASCII (for Type 3) or the Basic Multilingual Plane (for
+                # Type 42).
+                charcode >= self.subset_size
+                # Or, use a new subset if the character code is already mapped for the
+                # first block. This means it's using an alternate glyph.
+                or charcode in subset_maps[0]
+            )
         )
         if use_next_charmap:
             if len(subset_maps) == 1 or len(subset_maps[-1]) == self.subset_size:

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -103,6 +103,58 @@ def font_as_file(font):
     return fh
 
 
+class GlyphMap:
+    """
+    A two-way glyph mapping.
+
+    The forward glyph map is from (character code, glyph index)-pairs to (subset index,
+    subset character code)-pairs.
+
+    The inverse glyph map is from to (subset index, subset character code)-pairs to
+    (character code, glyph index)-pairs.
+    """
+
+    def __init__(self) -> None:
+        self._forward: dict[tuple[CharacterCodeType, GlyphIndexType],
+                            tuple[int, CharacterCodeType]] = {}
+        self._inverse: dict[tuple[int, CharacterCodeType],
+                            tuple[CharacterCodeType, GlyphIndexType]] = {}
+
+    def get(self, charcode: CharacterCodeType,
+            glyph_index: GlyphIndexType) -> tuple[int, CharacterCodeType] | None:
+        """
+        Get the forward mapping from a (character code, glyph index)-pair.
+
+        This may return *None* if the pair is not currently mapped.
+        """
+        return self._forward.get((charcode, glyph_index))
+
+    def iget(self, subset: int,
+             subset_charcode: CharacterCodeType) -> tuple[CharacterCodeType,
+                                                          GlyphIndexType]:
+        """Get the inverse mapping from a (subset, subset charcode)-pair."""
+        return self._inverse[(subset, subset_charcode)]
+
+    def add(self, charcode: CharacterCodeType, glyph_index: GlyphIndexType, subset: int,
+            subset_charcode: CharacterCodeType) -> None:
+        """
+        Add a mapping to this instance.
+
+        Parameters
+        ----------
+        charcode : CharacterCodeType
+            The character code to record.
+        glyph : GlyphIndexType
+            The corresponding glyph index to record.
+        subset : int
+            The subset in which the subset character code resides.
+        subset_charcode : CharacterCodeType
+            The subset character code within the above subset.
+        """
+        self._forward[(charcode, glyph_index)] = (subset, subset_charcode)
+        self._inverse[(subset, subset_charcode)] = (charcode, glyph_index)
+
+
 class CharacterTracker:
     """
     Helper for font subsetting by the PDF and PS backends.
@@ -114,16 +166,20 @@ class CharacterTracker:
     ----------
     subset_size : int
         The size at which characters are grouped into subsets.
-    used : dict[tuple[str, int], dict[CharacterCodeType, GlyphIndexType]]
+    used : dict
         A dictionary of font files to character maps.
 
-        The key is a font filename and subset within that font.
+        The key is a font filename.
 
-        The value is a dictionary mapping a character code to a glyph index. Note this
-        mapping is the inverse of FreeType, which maps glyph indices to character codes.
+        The value is a list of dictionaries, each mapping at most *subset_size*
+        character codes to glyph indices. Note this mapping is the inverse of FreeType,
+        which maps glyph indices to character codes.
 
         If *subset_size* is not set, then there will only be one subset per font
         filename.
+    glyph_maps : dict
+        A dictionary of font files to glyph maps. You probably will want to use the
+        `.subset_to_unicode` method instead of this attribute.
     """
 
     def __init__(self, subset_size: int = 0):
@@ -134,7 +190,8 @@ class CharacterTracker:
             The maximum size that is supported for an embedded font. If provided, then
             characters will be grouped into these sized subsets.
         """
-        self.used: dict[tuple[str, int], dict[CharacterCodeType, GlyphIndexType]] = {}
+        self.used: dict[str, list[dict[CharacterCodeType, GlyphIndexType]]] = {}
+        self.glyph_maps: dict[str, GlyphMap] = {}
         self.subset_size = subset_size
 
     def track(self, font: FT2Font, s: str) -> list[tuple[int, CharacterCodeType]]:
@@ -186,25 +243,42 @@ class CharacterTracker:
             The character code within the above subset. If *subset_size* was not
             specified on this instance, then this is just *charcode* unmodified.
         """
-        if self.subset_size != 0:
-            subset = charcode // self.subset_size
-            subset_charcode = charcode % self.subset_size
+        glyph_map = self.glyph_maps.setdefault(font.fname, GlyphMap())
+        if result := glyph_map.get(charcode, glyph):
+            return result
+
+        subset_maps = self.used.setdefault(font.fname, [{}])
+        # Default to preserving the character code as it was.
+        use_next_charmap = (
+            self.subset_size != 0
+            # But start filling a new subset if outside the first block; this preserves
+            # ASCII (for Type 3) or the Basic Multilingual Plane (for Type 42).
+            and charcode >= self.subset_size
+        )
+        if use_next_charmap:
+            if len(subset_maps) == 1 or len(subset_maps[-1]) == self.subset_size:
+                subset_maps.append({})
+            subset = len(subset_maps) - 1
+            subset_charcode = len(subset_maps[-1])
         else:
             subset = 0
             subset_charcode = charcode
-        self.used.setdefault((font.fname, subset), {})[subset_charcode] = glyph
+        subset_maps[subset][subset_charcode] = glyph
+        glyph_map.add(charcode, glyph, subset, subset_charcode)
         return (subset, subset_charcode)
 
-    def subset_to_unicode(self, index: int,
-                          charcode: CharacterCodeType) -> CharacterCodeType:
+    def subset_to_unicode(self, fontname: str, subset: int,
+                          subset_charcode: CharacterCodeType) -> CharacterCodeType:
         """
         Map a subset index and character code to a Unicode character code.
 
         Parameters
         ----------
-        index : int
+        fontname : str
+            The name of the font, from the *used* dictionary key.
+        subset : int
             The subset index within a font.
-        charcode : CharacterCodeType
+        subset_charcode : CharacterCodeType
             The character code within a subset to map back.
 
         Returns
@@ -212,7 +286,7 @@ class CharacterTracker:
         CharacterCodeType
             The Unicode character code corresponding to the subsetted one.
         """
-        return index * self.subset_size + charcode
+        return self.glyph_maps[fontname].iget(subset, subset_charcode)[0]
 
 
 class RendererPDFPSBase(RendererBase):

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -948,9 +948,8 @@ class PdfFile:
             else:
                 # a normal TrueType font
                 _log.debug('Writing TrueType font.')
-                charmap = self._character_tracker.used.get((filename, subset))
-                if charmap:
-                    fonts[Fx] = self.embedTTF(filename, subset, charmap)
+                charmap = self._character_tracker.used[filename][subset]
+                fonts[Fx] = self.embedTTF(filename, subset, charmap)
         self.writeObject(self.fontObject, fonts)
 
     def _write_afm_font(self, filename):
@@ -992,8 +991,11 @@ class PdfFile:
 
         # Reduce the font to only the glyphs used in the document, get the encoding
         # for that subset, and compute various properties based on the encoding.
-        charmap = self._character_tracker.used[(dvifont.fname, 0)]
-        chars = frozenset(charmap.keys())
+        charmap = self._character_tracker.used[dvifont.fname][0]
+        chars = {
+            self._character_tracker.subset_to_unicode(dvifont.fname, 0, ccode)
+            for ccode in charmap
+        }
         t1font = t1font.subset(chars, self._get_subset_prefix(charmap.values()))
         fontdict['BaseFont'] = Name(t1font.prop['FontName'])
         # createType1Descriptor writes the font data as a side effect
@@ -1144,14 +1146,16 @@ end"""
                     unicode_groups[-1][1] = ccode
                 last_ccode = ccode
 
+            def _to_unicode(ccode):
+                real_ccode = self._character_tracker.subset_to_unicode(
+                    filename, subset_index, ccode)
+                unicodestr = chr(real_ccode).encode('utf-16be').hex()
+                return f'<{unicodestr}>'
+
             width = 2 if fonttype == 3 else 4
             unicode_bfrange = []
             for start, end in unicode_groups:
-                real_start = self._character_tracker.subset_to_unicode(subset_index,
-                                                                       start)
-                real_end = self._character_tracker.subset_to_unicode(subset_index, end)
-                real_values = ' '.join('<%s>' % chr(x).encode('utf-16be').hex()
-                                       for x in range(real_start, real_end+1))
+                real_values = ' '.join(_to_unicode(x) for x in range(start, end+1))
                 unicode_bfrange.append(
                     f'<{start:0{width}x}> <{end:0{width}x}> [{real_values}]')
             unicode_cmap = (self._identityToUnicodeCMap %

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -993,7 +993,8 @@ class PdfFile:
         # for that subset, and compute various properties based on the encoding.
         charmap = self._character_tracker.used[dvifont.fname][0]
         chars = {
-            self._character_tracker.subset_to_unicode(dvifont.fname, 0, ccode)
+            # DVI type 1 fonts always map single glyph to single character.
+            ord(self._character_tracker.subset_to_unicode(dvifont.fname, 0, ccode))
             for ccode in charmap
         }
         t1font = t1font.subset(chars, self._get_subset_prefix(charmap.values()))
@@ -1147,10 +1148,10 @@ end"""
                 last_ccode = ccode
 
             def _to_unicode(ccode):
-                real_ccode = self._character_tracker.subset_to_unicode(
+                chars = self._character_tracker.subset_to_unicode(
                     filename, subset_index, ccode)
-                unicodestr = chr(real_ccode).encode('utf-16be').hex()
-                return f'<{unicodestr}>'
+                hexstr = chars.encode('utf-16be').hex()
+                return f'<{hexstr}>'
 
             width = 2 if fonttype == 3 else 4
             unicode_bfrange = []
@@ -2329,7 +2330,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             for item in _text_helpers.layout(s, font, kern_mode=Kerning.UNFITTED,
                                              language=language):
                 subset, charcode = self.file._character_tracker.track_glyph(
-                    item.ft_object, ord(item.char), item.glyph_index)
+                    item.ft_object, item.char, item.glyph_index)
                 if (item.ft_object, subset) != prev_font:
                     if singlebyte_chunk:
                         output_singlebyte_chunk(singlebyte_chunk)

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -368,12 +368,6 @@ def pdfRepr(obj):
                         "objects")
 
 
-_FONT_MAX_GLYPH = {
-    3: 256,
-    42: 65536,
-}
-
-
 class Reference:
     """
     PDF reference object.
@@ -691,7 +685,7 @@ class PdfFile:
         self._fontNames = {}     # maps filenames to internal font names
         self._dviFontInfo = {}   # maps pdf names to dvifonts
         self._character_tracker = _backend_pdf_ps.CharacterTracker(
-            _FONT_MAX_GLYPH.get(mpl.rcParams['pdf.fonttype'], 0))
+            _backend_pdf_ps._FONT_MAX_GLYPH.get(mpl.rcParams['ps.fonttype'], 0))
 
         self.alphaStates = {}   # maps alpha values to graphics state objects
         self._alpha_state_seq = (Name(f'A{i}') for i in itertools.count(1))

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1065,24 +1065,24 @@ class FigureCanvasPS(FigureCanvasBase):
             Ndict = len(_psDefs)
             print("%%BeginProlog", file=fh)
             if not mpl.rcParams['ps.useafm']:
-                Ndict += len(ps_renderer._character_tracker.used)
+                Ndict += sum(map(len, ps_renderer._character_tracker.used.values()))
             print("/mpldict %d dict def" % Ndict, file=fh)
             print("mpldict begin", file=fh)
             print("\n".join(_psDefs), file=fh)
             if not mpl.rcParams['ps.useafm']:
-                for (font, subset_index), charmap in \
-                        ps_renderer._character_tracker.used.items():
-                    if not charmap:
-                        continue
-                    fonttype = mpl.rcParams['ps.fonttype']
-                    # Can't use more than 255 chars from a single Type 3 font.
-                    if len(charmap) > 255:
-                        fonttype = 42
-                    fh.flush()
-                    if fonttype == 3:
-                        fh.write(_font_to_ps_type3(font, charmap.values()))
-                    else:  # Type 42 only.
-                        _font_to_ps_type42(font, charmap.values(), fh)
+                for font, subsets in ps_renderer._character_tracker.used.items():
+                    for charmap in subsets:
+                        if not charmap:
+                            continue
+                        fonttype = mpl.rcParams['ps.fonttype']
+                        # Can't use more than 255 chars from a single Type 3 font.
+                        if len(charmap) > 255:
+                            fonttype = 42
+                        fh.flush()
+                        if fonttype == 3:
+                            fh.write(_font_to_ps_type3(font, charmap.values()))
+                        else:  # Type 42 only.
+                            _font_to_ps_type42(font, charmap.values(), fh)
             print("end", file=fh)
             print("%%EndProlog", file=fh)
 


### PR DESCRIPTION
## PR summary

The original code split fonts into subsets based on the character modulo the subset size (determined by font type limits). This had some limitations:
1. If characters were used from across various font blocks (especially for type 3, whose blocks were only 256 characters), then there would be many, possibly sparsely-populated, font subsets.
2. Sometimes a single character code may map to multiple glyphs. This is the case if you mix languages (i.e., #29794), but the naive tracking would only produce one glyph.
3. Sometimes multiple characters can map to a single glyph. This is the case for ligatures, and also with complex text shaping (such as Arabic), and this would just fail calling `ord` on a multi-char string.

To fix this, `CharacterTracker` now tracks characters and glyphs more closely. Specifically,
1. for each font, a (character code(s), glyph index)-pair is mapped to a (subset index, subset character code)-pair. This ensures that point 2 above is handled.
2. If the above map doesn't exist yet, then a subset index/character code is calculated:
    1. if the (singular) character code is in the first block (255 for type 3, or 64k for type 42), then keep the character code the same and put it in subset 0; this preserves the text in those lower ranges if you happen to be looking at a PDF directly
    2. if the (singular) character code is _already_ in subset 0, then bump it to the next available spot; a conflict here means the character is being used with multiple glyphs (i.e., another case for part 2 above)
    3. if the character code is in fact multiple character codes, then also bump to the next available spot as it could never be in the subset 0 (this is part 3 above)
    4. the next available spot is the next character code in the next subset block, if necessary; by filling as needed, this takes care of point 1 above

With these changes, the complex/font features/languages tests in #30607 produce correct results.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines