### PR TITLE
TST: Increase tolerances for Ghostscript 10.06

### DIFF
--- a/lib/matplotlib/tests/test_bbox_tight.py
+++ b/lib/matplotlib/tests/test_bbox_tight.py
@@ -110,7 +110,7 @@ def test_bbox_inches_tight_clipping():
     plt.gcf().artists.append(patch)
 
 
-@image_comparison(['bbox_inches_tight_raster'],
+@image_comparison(['bbox_inches_tight_raster'], tol=0.15,  # For Ghostscript 10.06+.
                   remove_text=True, savefig_kwarg={'bbox_inches': 'tight'})
 def test_bbox_inches_tight_raster():
     """Test rasterization with tight_layout"""

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -36,7 +36,7 @@ def test_alpha_interp():
     axr.imshow(img, interpolation="bilinear")
 
 
-@image_comparison(['interp_nearest_vs_none'],
+@image_comparison(['interp_nearest_vs_none'], tol=3.7,  # For Ghostscript 10.06+.
                   extensions=['pdf', 'svg'], remove_text=True)
 def test_interp_nearest_vs_none():
     """Test the effect of "nearest" and "none" interpolation"""


### PR DESCRIPTION
## PR summary

These started failing in Fedora Rawhide, as they've updated to Ghostscript 10.06 a couple weeks ago.

- `test_bbox_inches_tight_raster` differs by a single pixel in the middle of the line
- `test_interp_nearest_vs_none` shifts the middle of the image over one pixel, causing a line of differences

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines