### PR TITLE
ENH: Allow partial autoscaling when limits are set pre-plot

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3031,7 +3031,8 @@ class _AxesBase(martist.Artist):
         def handle_single_axis(
                 scale, shared_axes, name, axis, margin, stickies, set_bound):
 
-            if not (scale and (axis._get_autoscale_on() or axis._autoscale_lower or axis._autoscale_upper)):
+            if not (scale and (axis._get_autoscale_on()
+                               or axis._autoscale_lower or axis._autoscale_upper)):
                 return  # nothing to do...
 
             shared = shared_axes.get_siblings(self)
@@ -3087,7 +3088,7 @@ class _AxesBase(martist.Artist):
 
             if not self._tight:
                 x0, x1 = locator.view_limits(x0, x1)
-            
+
             # If the user has previously set a partial limit (e.g., via
             # `set_xlim(left=0, right=None)`), override the calculated
             # autoscale limit with the user's fixed value.
@@ -3095,7 +3096,7 @@ class _AxesBase(martist.Artist):
                 x0 = axis.get_view_interval()[0]
             if not axis._autoscale_upper:
                 x1 = axis.get_view_interval()[1]
-            
+
             set_bound(x0, x1)
             # End of definition of internal function 'handle_single_axis'.
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3031,7 +3031,7 @@ class _AxesBase(martist.Artist):
         def handle_single_axis(
                 scale, shared_axes, name, axis, margin, stickies, set_bound):
 
-            if not (scale and axis._get_autoscale_on()):
+            if not (scale and (axis._get_autoscale_on() or axis._autoscale_lower or axis._autoscale_upper)):
                 return  # nothing to do...
 
             shared = shared_axes.get_siblings(self)
@@ -3087,6 +3087,15 @@ class _AxesBase(martist.Artist):
 
             if not self._tight:
                 x0, x1 = locator.view_limits(x0, x1)
+            
+            # If the user has previously set a partial limit (e.g., via
+            # `set_xlim(left=0, right=None)`), override the calculated
+            # autoscale limit with the user's fixed value.
+            if not axis._autoscale_lower:
+                x0 = axis.get_view_interval()[0]
+            if not axis._autoscale_upper:
+                x1 = axis.get_view_interval()[1]
+            
             set_bound(x0, x1)
             # End of definition of internal function 'handle_single_axis'.
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -668,7 +668,11 @@ class Axis(martist.Artist):
             self._converter_is_explicit = False
             self.units = None
 
+        # Flags to track whether the user has manually set a limit,
+        # used to enable partial autoscaling.
         self._autoscale_on = True
+        self._autoscale_lower = True
+        self._autoscale_upper = True
 
     @property
     def isDefault_majloc(self):
@@ -1215,6 +1219,12 @@ class Axis(martist.Artist):
             Whether to turn on autoscaling of the x-axis. True turns on, False
             turns off, None leaves unchanged.
         """
+        if auto is False:
+            # On a manual limit set, update the autoscale flags. A `None`
+            # value implies the user wants that side to remain autoscaled.
+            self._autoscale_lower = (v0 is None)
+            self._autoscale_upper = (v1 is None)
+
         name = self._get_axis_name()
 
         self.axes._process_unit_info([(name, (v0, v1))], convert=False)


### PR DESCRIPTION
Closes #30585.

## PR summary

This pull request fixes a bug where partially set axis limits (e.g., `ax.set_xlim(left=0, right=None)`) are ignored if they are set *before* any data is plotted.

- **Why is this change necessary?**
  Currently, a user's intent to keep one side of an axis fixed while allowing the other to autoscale is lost if `set_xlim`/`set_ylim` is called before `plot()`.

- **What problem does it solve?**
  When `set_xlim(left=0, right=None)` is called on an empty `Axes`, the axis view is locked to the default `[0, 1]` range. The subsequent `plot()` call triggers `autoscale_view()`, but because the axis's `_autoscale_on` flag has been set to `False` by the manual `set_xlim` call, `autoscale_view` exits early and does not expand the view. This results in the plotted data being invisible or cut off.

- **What is the reasoning for this implementation?**
  The solution implements a "sticky" behavior for partially set limits by tracking the user's intent:
  1.  Two new flags, `_autoscale_lower` and `_autoscale_upper`, have been added to the `Axis` class to record whether a side should be autoscaled.
  2.  `Axis._set_lim` has been modified to update these flags whenever a user makes a manual call (`auto=False`). A `None` value for a limit sets the corresponding flag to `True` (autoscale this side).
  3.  `Axes.autoscale_view` (and its inner `handle_single_axis` function) has been modified to respect these flags. It now proceeds with autoscaling if the main `_autoscale_on` flag is `True` **OR** if partial autoscaling has been requested. After calculating the new view limits, it overrides them with the user's fixed values if the corresponding flag is `False`.

This ensures the user's intent is preserved while maintaining all existing autoscaling functionality.
<hr>

### Visual Demonstration of the Fix
The following self-contained example demonstrates the bug and the fix.
```python
# new_test_plot.py

import matplotlib.pyplot as plt
import numpy as np

fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(6, 6))

# --- Scenario 1: set_xlim BEFORE plot ---
# We EXPECT this to FAIL (i.e., not look right)
ax1.set_xlim(left=0, right=None) # Set limit on an empty plot
ax1.plot(np.linspace(2, 10, 100), np.sin(np.linspace(2, 10, 100)))
ax1.set_title("Scenario 1: set_xlim() BEFORE plot()")


# --- Scenario 2: set_xlim AFTER plot (for comparison) ---
# We EXPECT this to WORK (this is our previous successful test)
ax2.plot(np.linspace(2, 10, 100), np.sin(np.linspace(2, 10, 100)))
ax2.set_xlim(left=0, right=None) # Set limit after data is present
ax2.set_title("Scenario 2: set_xlim() AFTER plot() (Original Test)")

plt.tight_layout()
plt.show()
```

<img width="1895" height="988" alt="Screenshot 2025-10-02 175545" src="https://github.com/user-attachments/assets/3c8fd26b-8632-4ad3-9094-b9a685243704" />


```python
import matplotlib.pyplot as plt
import numpy as np

fig, ax = plt.subplots(figsize=(8, 4))

# Using data that starts at 0.5 but goes all the way to 5.
x_data = np.linspace(0.5, 5, 200)
y_data = np.sin(x_data * np.pi) # Multiplied by pi to show more waves

# Setting the limit BEFORE plotting the data.
ax.set_xlim(left=0, right=None)

ax.plot(x_data, y_data)

# --- Analysis of the Expected vs. Actual Result ---
# EXPECTED (Correct) Behavior:
# The left limit should be 0.

# ACTUAL (Buggy) Behavior:
# set_xlim defaults the view to [0, 1].
# When plot() is called, this pre-set limit is not updated.
# All data where x > 1 is cut off and not visible.

ax.set_title("Bug Demo: Data is cut off at x=1")
plt.show()
```

<img width="1613" height="694" alt="Screenshot 2025-10-02 181659" src="https://github.com/user-attachments/assets/18bcc493-7180-460c-8963-7f50d31a14cc" />
<br></br>
After this PR, the same script now produces the correct plot:
<br></br>

<img width="1627" height="697" alt="image" src="https://github.com/user-attachments/assets/bc6bfe6c-d6a0-4669-be46-10f3dd1b8312" />
<img width="1852" height="977" alt="image" src="https://github.com/user-attachments/assets/ea7e1a11-d8ac-45ad-8ede-4bdbc376487c" />
<hr>

_This is my first contribution to Matplotlib. I'm very open to feedback on the implementation, code style, and testing approach. Thank you!_

### PR checklist

- [x] "closes #30585" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) (Validated with a comprehensive suite of 10 manual test cases covering x/y axes, overwriting, and interaction with autoscale(False)).
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials) (This is a bug fix, not a new gallery-style feature).
- [N/A] New Features and API Changes are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features) (No new public API was added).
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines (Added comments explaining the new logic).