### PR TITLE
MNT: Fix new F401 unused imports warnings

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -21,13 +21,11 @@ import signal
 import threading
 
 try:
-    import tornado
+    import tornado.web
+    import tornado.ioloop
+    import tornado.websocket
 except ImportError as err:
     raise RuntimeError("The WebAgg backend requires Tornado.") from err
-
-import tornado.web
-import tornado.ioloop
-import tornado.websocket
 
 import matplotlib as mpl
 from matplotlib.backend_bases import _Backend

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -30,7 +30,7 @@ from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
 
 import wx
-import wx.svg
+import wx.svg  # noqa: F401
 
 _log = logging.getLogger(__name__)
 

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -58,7 +58,6 @@ from typing import IO, TYPE_CHECKING, cast, overload
 
 from cycler import cycler  # noqa: F401
 import matplotlib
-import matplotlib.colorbar
 import matplotlib.image
 from matplotlib import _api
 # Re-exported (import x as x) for typing.


### PR DESCRIPTION
## PR summary

It appears ruff now notices these, so either remove, or mark as explicitly done.

I kept `wx.svg` just in case doing so is required to load SVG support.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines