### PR TITLE
Remove forced fallback from FT2Font::load_char

### DIFF
--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -552,7 +552,7 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
         bool was_found = load_char_with_fallback(ft_object_with_glyph, final_glyph_index,
                                                  glyphs, char_to_font,
                                                  charcode, flags, charcode_error, glyph_error,
-                                                 glyph_seen_fonts, true);
+                                                 glyph_seen_fonts);
         if (!was_found) {
             ft_glyph_warn(charcode, glyph_seen_fonts);
             if (charcode_error) {
@@ -613,15 +613,14 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
                                       FT_Int32 flags,
                                       FT_Error &charcode_error,
                                       FT_Error &glyph_error,
-                                      std::set<FT_String*> &glyph_seen_fonts,
-                                      bool override = false)
+                                      std::set<FT_String*> &glyph_seen_fonts)
 {
     FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
     if (!warn_if_used) {
         glyph_seen_fonts.insert(face->family_name);
     }
 
-    if (glyph_index || override) {
+    if (glyph_index) {
         charcode_error = FT_Load_Glyph(face, glyph_index, flags);
         if (charcode_error) {
             return false;
@@ -647,7 +646,7 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
             bool was_found = fallback->load_char_with_fallback(
                 ft_object_with_glyph, final_glyph_index, parent_glyphs,
                 parent_char_to_font, charcode, flags,
-                charcode_error, glyph_error, glyph_seen_fonts, override);
+                charcode_error, glyph_error, glyph_seen_fonts);
             if (was_found) {
                 return true;
             }

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -131,8 +131,7 @@ class FT2Font
                                  FT_Int32 flags,
                                  FT_Error &charcode_error,
                                  FT_Error &glyph_error,
-                                 std::set<FT_String*> &glyph_seen_fonts,
-                                 bool override);
+                                 std::set<FT_String*> &glyph_seen_fonts);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);
     std::tuple<long, long> get_width_height();
     std::tuple<long, long> get_bitmap_offset();


### PR DESCRIPTION
## PR summary

The only thing that expected this to work is Type 3 fonts in the PDF backend, but only to avoid an error when loading a range of characters (not all of which would be used.) This would introduce an odd behaviour in that `load_char` could never fail even if the glyph never existed. You would instead end up with the `null` glyph from the last font.

As of #30512, Type 3 fonts use `load_glyph` instead of `load_char`, with a glyph that we know exists (because it's from the limited subset character map we've created), or 0 for the null glyph. Thus no fallback is needed, and we can instead warn if not found, as the code seems to have originally intended.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines