### PR TITLE
DOC: Add note about linear colorbar scale option for TwoSlopeNorm

### DIFF
--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -284,11 +284,11 @@ plt.show()
 # %%
 #
 # .. note::
-#    By default, the colorbar for norms with a `scale` will use that scale
+#    By default, the colorbar for norms with a ``scale`` will use that scale
 #    for the colorbar as well, which can cause it to be non-linear.  For example,
-#    for `TwoSlopeNorm`, the colorbar will be centered at the midpoint of the
+#    for `.TwoSlopeNorm`, the colorbar will be centered at the midpoint of the
 #    colorbar.  If you want a colorbar with linear spacing (e.g., as in
-#    Matplotlib versions before 3.5), call `cb.ax.set_yscale('linear')` after
+#    Matplotlib versions before 3.5), call ``cb.ax.set_yscale('linear')`` after
 #    creating the colorbar.
 
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -281,6 +281,17 @@ cb = fig.colorbar(pcm, shrink=0.6)
 cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 plt.show()
 
+# %%
+#
+# .. note::
+#    By default, the colorbar for norms with a `scale` will use that scale
+#    for the colorbar as well, which can cause it to be non-linear.  For example,
+#    for `TwoSlopeNorm`, the colorbar will be centered at the midpoint of the
+#    colorbar.  If you want a colorbar with linear spacing (e.g., as in
+#    Matplotlib versions before 3.5), call `cb.ax.set_yscale('linear')` after
+#    creating the colorbar.
+
+
 
 # %%
 # FuncNorm: Arbitrary function normalization
@@ -346,3 +357,4 @@ cb = fig.colorbar(pcm, shrink=0.6, extend='both')
 cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 
 plt.show()
+

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -282,14 +282,15 @@ cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 plt.show()
 
 # %%
-# Colorbar scale for norms with a scale
-# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+# Using a linear scale on the colormap
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# By default, the colorbar for norms with a ``scale`` will use that scale
-# for the colorbar as well. For `.TwoSlopeNorm`, this means the colorbar
-# will be centered at the midpoint visually. You can override this to get
-# linear spacing by calling ``cb.ax.set_yscale('linear')`` after creating
-# the colorbar.
+# By default, the colorbar for a .TwoSlopeNorm is divided into two equal
+# parts for the two branches. As a result, the scaling in the two segments
+# is different, i.e. the screen-space per data range. You can override this
+# to get linear scaling by calling `cb.ax.set_yscale('linear')`. This
+# redistributes the colors and values on the colorbar, but leaves the
+# color-to-value mapping unchanged.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -357,4 +357,3 @@ cb = fig.colorbar(pcm, shrink=0.6, extend='both')
 cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 
 plt.show()
-

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -286,8 +286,9 @@ plt.show()
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # By default, colorbars adopt the same scaling as their associated norm.
-# For example, if the `.TwoSlopeNorm` segments are distributed linearly according to the norm,
-# so is the tick positions also follow that nonlinear scaling.
+# For example, if the `.TwoSlopeNorm` segments are distributed linearly
+# according to the norm, so is the tick positions also follow that
+# nonlinear scaling.
 # For example, with a `.TwoSlopeNorm`, the colormap is split evenly between the two
 # halves, even if the ranges are uneven (as above and the left-hand colorbar
 # below).
@@ -324,6 +325,7 @@ plt.show()
 # If the above norms do not provide the normalization you want, you can use
 # `~.colors.FuncNorm` to define your own.  Note that this example is the same
 # as `~.colors.PowerNorm` with a power of 0.5:
+
 
 def _forward(x):
     return np.sqrt(x)

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -381,4 +381,3 @@ cb = fig.colorbar(pcm, shrink=0.6, extend='both')
 cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 
 plt.show()
-

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -285,10 +285,10 @@ plt.show()
 # Using a linear scale on the colormap
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# By default, the colorbar for a .TwoSlopeNorm is divided into two equal
+# By default, the colorbar for a `.TwoSlopeNorm` is divided into two equal
 # parts for the two branches. As a result, the scaling in the two segments
 # is different, i.e. the screen-space per data range. You can override this
-# to get linear scaling by calling `cb.ax.set_yscale('linear')`. This
+# to get linear scaling by calling ``cb.ax.set_yscale('linear')``. This
 # redistributes the colors and values on the colorbar, but leaves the
 # color-to-value mapping unchanged.
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -286,16 +286,18 @@ plt.show()
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
 # By default, colorbars adopt the same axis scaling as their associated norm.
-# For example, for a `.TwoSlopeNorm`, colormap segments are distributed linearly and the
-# colorbar ticks positions are spaced non-linearly (as above, and the left-hand colorbar below).
-# To make the tick spacing linear instead, you can change the scale by calling
-# ``cb.ax.set_yscale('linear')``, as shown in the right-hand colorbar below. The ticks will then
-# be evenly spaced, the colormap will appear compressed in the smaller of the two slope regions.
+# For example, for a `.TwoSlopeNorm`, colormap segments are distributed
+# linearly and the colorbar ticks positions are spaced non-linearly (as above,
+# and the left-hand colorbar below). To make the tick spacing linear instead,
+# you can change the scale by calling ``cb.ax.set_yscale('linear')``, as shown
+# in the right-hand colorbar below. The ticks will then be evenly spaced, the
+# colormap will appear compressed in the smaller of the two slope regions.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 divnorm = colors.TwoSlopeNorm(vmin=-500., vcenter=0, vmax=4000)
 
-for ax, title in zip([ax1, ax2], ['Default: Scaled colorbar', 'Linear colorbar spacing']):
+for ax, title in zip([ax1, ax2],
+                     ['Default: Scaled colorbar', 'Linear colorbar spacing']):
     pcm = ax.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
                         cmap=terrain_map, shading='auto')
     ax.set_aspect(1 / np.cos(np.deg2rad(49)))
@@ -304,7 +306,9 @@ for ax, title in zip([ax1, ax2], ['Default: Scaled colorbar', 'Linear colorbar s
     cb.set_ticks(np.arange(-500, 4001, 500))
 
 # Set linear scale for the right colorbar
-cb.ax.set_yscale('linear')# %%
+cb.ax.set_yscale('linear')
+
+# %%
 # FuncNorm: Arbitrary function normalization
 # ------------------------------------------
 #

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -316,7 +316,6 @@ cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
 cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
 cb2.set_ticks(np.arange(-500, 4001, 500))
 
-
 # %%
 # FuncNorm: Arbitrary function normalization
 # ------------------------------------------

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -285,12 +285,15 @@ plt.show()
 # Using a linear scale on the colormap
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# By default, the colorbar for a `.TwoSlopeNorm` is divided into two equal
-# parts for the two branches. As a result, the scaling in the two segments
-# is different, i.e. the screen-space per data range. You can override this
-# to get linear scaling by calling ``cb.ax.set_yscale('linear')``. This
-# redistributes the colors and values on the colorbar, but leaves the
-# color-to-value mapping unchanged.
+# By default, colorbars adopt the same scaling as their associated norm.
+# For example, if the `.TwoSlopeNorm` segments are distributed linearly according to the norm,
+# so is the tick positions also follow that nonlinear scaling.
+# For example, with a `.TwoSlopeNorm`, the colormap is split evenly between the two
+# halves, even if the ranges are uneven (as above and the left-hand colorbar
+# below).
+# To make the tick spacing linear instead, call ``cb.ax.set_yscale('linear')``, as
+# shown in the right-hand colorbar below. The ticks will then be evenly spaced, and
+# the colormap will appear compressed in the smaller of the two slope regions.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 
@@ -301,7 +304,7 @@ pcm1 = ax1.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
 ax1.set_aspect(1 / np.cos(np.deg2rad(49)))
 ax1.set_title('Default: Scaled colorbar')
 cb1 = fig.colorbar(pcm1, ax=ax1, shrink=0.6)
-cb1.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
+cb1.set_ticks([np.arange(-500, 4001, 500)])
 
 # Right plot: Linear colorbar spacing
 pcm2 = ax2.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
@@ -310,7 +313,7 @@ ax2.set_aspect(1 / np.cos(np.deg2rad(49)))
 ax2.set_title('Linear colorbar spacing')
 cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
 cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
-cb2.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
+cb2.set_ticks([np.arange(-500, 4001, 500)])
 
 plt.show()
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -305,7 +305,7 @@ pcm1 = ax1.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
 ax1.set_aspect(1 / np.cos(np.deg2rad(49)))
 ax1.set_title('Default: Scaled colorbar')
 cb1 = fig.colorbar(pcm1, ax=ax1, shrink=0.6)
-cb1.set_ticks([np.arange(-500, 4001, 500)])
+cb1.set_ticks(np.arange(-500, 4001, 500))
 
 # Right plot: Linear colorbar spacing
 pcm2 = ax2.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
@@ -314,7 +314,7 @@ ax2.set_aspect(1 / np.cos(np.deg2rad(49)))
 ax2.set_title('Linear colorbar spacing')
 cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
 cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
-cb2.set_ticks([np.arange(-500, 4001, 500)])
+cb2.set_ticks(np.arange(-500, 4001, 500))
 
 plt.show()
 
@@ -383,3 +383,4 @@ cb = fig.colorbar(pcm, shrink=0.6, extend='both')
 cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 
 plt.show()
+

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -285,16 +285,12 @@ plt.show()
 # Using a linear scale on the colormap
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# By default, colorbars adopt the same scaling as their associated norm.
-# For example, if the `.TwoSlopeNorm` segments are distributed linearly
-# according to the norm, so is the tick positions also follow that
-# nonlinear scaling.
-# For example, with a `.TwoSlopeNorm`, the colormap is split evenly between the two
-# halves, even if the ranges are uneven (as above and the left-hand colorbar
-# below).
-# To make the tick spacing linear instead, call ``cb.ax.set_yscale('linear')``, as
-# shown in the right-hand colorbar below. The ticks will then be evenly spaced, and
-# the colormap will appear compressed in the smaller of the two slope regions.
+# By default, colorbars adopt the same axis scaling as their associated norm.  
+# For example, for a `.TwoSlopeNorm`, colormap segments are distributed linearly and the 
+# colorbar ticks positions are spaced non-linearly (as above, and the left-hand colorbar below).
+# To make the tick spacing linear instead, you can change the scale by calling 
+# ``cb.ax.set_yscale('linear')``, as shown in the right-hand colorbar below. The ticks will then
+# be evenly spaced, the colormap will appear compressed in the smaller of the two slope regions.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -316,7 +316,6 @@ cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
 cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
 cb2.set_ticks(np.arange(-500, 4001, 500))
 
-plt.show()
 
 # %%
 # FuncNorm: Arbitrary function normalization

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -282,16 +282,36 @@ cb.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
 plt.show()
 
 # %%
+# Colorbar scale for norms with a scale
+# ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# .. note::
-#    By default, the colorbar for norms with a ``scale`` will use that scale
-#    for the colorbar as well, which can cause it to be non-linear.  For example,
-#    for `.TwoSlopeNorm`, the colorbar will be centered at the midpoint of the
-#    colorbar.  If you want a colorbar with linear spacing (e.g., as in
-#    Matplotlib versions before 3.5), call ``cb.ax.set_yscale('linear')`` after
-#    creating the colorbar.
+# By default, the colorbar for norms with a ``scale`` will use that scale
+# for the colorbar as well. For `.TwoSlopeNorm`, this means the colorbar
+# will be centered at the midpoint visually. You can override this to get
+# linear spacing by calling ``cb.ax.set_yscale('linear')`` after creating
+# the colorbar.
 
+fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
 
+# Left plot: Default scaled colorbar (centered at midpoint)
+divnorm = colors.TwoSlopeNorm(vmin=-500., vcenter=0, vmax=4000)
+pcm1 = ax1.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
+                      cmap=terrain_map, shading='auto')
+ax1.set_aspect(1 / np.cos(np.deg2rad(49)))
+ax1.set_title('Default: Scaled colorbar')
+cb1 = fig.colorbar(pcm1, ax=ax1, shrink=0.6)
+cb1.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
+
+# Right plot: Linear colorbar spacing
+pcm2 = ax2.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
+                      cmap=terrain_map, shading='auto')
+ax2.set_aspect(1 / np.cos(np.deg2rad(49)))
+ax2.set_title('Linear colorbar spacing')
+cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
+cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
+cb2.set_ticks([-500, 0, 1000, 2000, 3000, 4000])
+
+plt.show()
 
 # %%
 # FuncNorm: Arbitrary function normalization
@@ -300,6 +320,7 @@ plt.show()
 # If the above norms do not provide the normalization you want, you can use
 # `~.colors.FuncNorm` to define your own.  Note that this example is the same
 # as `~.colors.PowerNorm` with a power of 0.5:
+
 
 def _forward(x):
     return np.sqrt(x)

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -322,7 +322,6 @@ plt.show()
 # `~.colors.FuncNorm` to define your own.  Note that this example is the same
 # as `~.colors.PowerNorm` with a power of 0.5:
 
-
 def _forward(x):
     return np.sqrt(x)
 

--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -285,34 +285,26 @@ plt.show()
 # Using a linear scale on the colormap
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 #
-# By default, colorbars adopt the same axis scaling as their associated norm.  
-# For example, for a `.TwoSlopeNorm`, colormap segments are distributed linearly and the 
+# By default, colorbars adopt the same axis scaling as their associated norm.
+# For example, for a `.TwoSlopeNorm`, colormap segments are distributed linearly and the
 # colorbar ticks positions are spaced non-linearly (as above, and the left-hand colorbar below).
-# To make the tick spacing linear instead, you can change the scale by calling 
+# To make the tick spacing linear instead, you can change the scale by calling
 # ``cb.ax.set_yscale('linear')``, as shown in the right-hand colorbar below. The ticks will then
 # be evenly spaced, the colormap will appear compressed in the smaller of the two slope regions.
 
 fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(10, 4))
-
-# Left plot: Default scaled colorbar (centered at midpoint)
 divnorm = colors.TwoSlopeNorm(vmin=-500., vcenter=0, vmax=4000)
-pcm1 = ax1.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
-                      cmap=terrain_map, shading='auto')
-ax1.set_aspect(1 / np.cos(np.deg2rad(49)))
-ax1.set_title('Default: Scaled colorbar')
-cb1 = fig.colorbar(pcm1, ax=ax1, shrink=0.6)
-cb1.set_ticks(np.arange(-500, 4001, 500))
 
-# Right plot: Linear colorbar spacing
-pcm2 = ax2.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
-                      cmap=terrain_map, shading='auto')
-ax2.set_aspect(1 / np.cos(np.deg2rad(49)))
-ax2.set_title('Linear colorbar spacing')
-cb2 = fig.colorbar(pcm2, ax=ax2, shrink=0.6)
-cb2.ax.set_yscale('linear')  # Set linear scale for colorbar
-cb2.set_ticks(np.arange(-500, 4001, 500))
+for ax, title in zip([ax1, ax2], ['Default: Scaled colorbar', 'Linear colorbar spacing']):
+    pcm = ax.pcolormesh(longitude, latitude, topo, rasterized=True, norm=divnorm,
+                        cmap=terrain_map, shading='auto')
+    ax.set_aspect(1 / np.cos(np.deg2rad(49)))
+    ax.set_title(title)
+    cb = fig.colorbar(pcm, ax=ax, shrink=0.6)
+    cb.set_ticks(np.arange(-500, 4001, 500))
 
-# %%
+# Set linear scale for the right colorbar
+cb.ax.set_yscale('linear')# %%
 # FuncNorm: Arbitrary function normalization
 # ------------------------------------------
 #


### PR DESCRIPTION
Fixes #22197

## Summary
This PR adds a documentation note to the Colormap Normalization tutorial explaining how users can restore the pre-3.5 linear colorbar spacing for `TwoSlopeNorm` and other norms with a scale.

## Changes Made
- Added a note section after the `TwoSlopeNorm` example in `galleries/users_explain/colors/colormapnorms.py`
- Documents that colorbars for norms with a `scale` use that scale by default (behavior introduced in matplotlib 3.5)
- Explains the `cb.ax.set_yscale('linear')` workaround for users who prefer linear spacing

## Context
Since matplotlib 3.5, colorbars for norms with a scale (like `TwoSlopeNorm`) display the scale in the colorbar itself, which can appear non-linear. While this is consistent with other scaled norms like `LogNorm`, many users expect or prefer the linear spacing behavior from versions before 3.5.

This note provides clear guidance on how to achieve linear colorbar spacing when desired, addressing a common user question documented in issue #22197.

## Testing
- Verified the note renders correctly in the documentation
- Checked that the placement after the `TwoSlopeNorm` example is appropriate
- Followed matplotlib documentation style guidelines for reStructuredText notes