### PR TITLE
Fix: respect animated=True for imshow; add regression test (closes #18985)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3203,10 +3203,9 @@ class _AxesBase(martist.Artist):
             for _axis in self._axis_map.values():
                 artists.remove(_axis)
 
-        if not self.get_figure(root=True).canvas.is_saving():
-            artists = [
-                a for a in artists
-                if not a.get_animated() or isinstance(a, mimage.AxesImage)]
+        if not self.figure.canvas.is_saving():
+            artists = [a for a in artists if not a.get_animated()]
+
         artists = sorted(artists, key=attrgetter('zorder'))
 
         # rasterize artists with negative zorder

--- a/lib/matplotlib/tests/test_imshow_animated.py
+++ b/lib/matplotlib/tests/test_imshow_animated.py
@@ -1,0 +1,13 @@
+from matplotlib.testing.decorators import check_figures_equal
+import numpy as np
+
+
+@check_figures_equal()
+def test_imshow_respects_animated(fig_test, fig_ref):
+    rng = np.random.default_rng(19680801)
+    data = rng.random((8, 8))
+
+    ax_t = fig_test.subplots()
+    ax_t.imshow(data, animated=True)  # should be skipped on initial draw
+
+    fig_ref.subplots()  # blank reference


### PR DESCRIPTION
AxesImage objects created by imshow(..., animated=True) were still drawn on the initial render. Other artists marked animated=True are skipped until explicitly drawn, so this was inconsistent.

This PR removes the special-case that exempted AxesImage from the animated filter in _AxesBase.draw. Animated images are now treated the same as other animated artists on first draw. A regression test asserts visual equality with a blank reference.

Why needed: makes animated=True semantics consistent across artist types and prevents confusing initial frames in animation workflows.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X ] "closes #18985" is in the body of the PR description to https://github.com/matplotlib/matplotlib/issues/18985(https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
