### PR TITLE
Fix `AttributeError: module 'gi' has no attribute 'require_version'`

### DIFF
--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -10,18 +10,18 @@ from matplotlib.backend_bases import (
     CloseEvent, KeyEvent, LocationEvent, MouseEvent, ResizeEvent)
 
 try:
-    import gi
+    from gi import require_version as gi_require_version
 except ImportError as err:
     raise ImportError("The GTK3 backends require PyGObject") from err
 
 try:
     # :raises ValueError: If module/version is already loaded, already
     # required, or unavailable.
-    gi.require_version("Gtk", "3.0")
+    gi_require_version("Gtk", "3.0")
     # Also require GioUnix to avoid PyGIWarning when Gio is imported
     # GioUnix is platform-specific and may not be available on all systems
     try:
-        gi.require_version("GioUnix", "2.0")
+        gi_require_version("GioUnix", "2.0")
     except ValueError:
         # GioUnix is not available on this platform, which is fine
         pass

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -9,18 +9,18 @@ from matplotlib.backend_bases import (
     KeyEvent, LocationEvent, MouseEvent, ResizeEvent, CloseEvent)
 
 try:
-    import gi
+    from gi import require_version as gi_require_version
 except ImportError as err:
     raise ImportError("The GTK4 backends require PyGObject") from err
 
 try:
     # :raises ValueError: If module/version is already loaded, already
     # required, or unavailable.
-    gi.require_version("Gtk", "4.0")
+    gi_require_version("Gtk", "4.0")
     # Also require GioUnix to avoid PyGIWarning when Gio is imported
     # GioUnix is platform-specific and may not be available on all systems
     try:
-        gi.require_version("GioUnix", "2.0")
+        gi_require_version("GioUnix", "2.0")
     except ValueError:
         # GioUnix is not available on this platform, which is fine
         pass
@@ -29,6 +29,7 @@ except ValueError as e:
     # auto-backend selection logic correctly skips.
     raise ImportError(e) from e
 
+import gi
 from gi.repository import Gio, GLib, Gtk, Gdk, GdkPixbuf
 from . import _backend_gtk
 from ._backend_gtk import (  # noqa: F401 # pylint: disable=W0611


### PR DESCRIPTION
On Arch Linux, automatic backend selection fails when [`at-spi2-core`](https://archlinux.org/packages/extra/x86_64/at-spi2-core/files/) is installed but
[`python-gobject`](https://archlinux.org/packages/extra/x86_64/python-gobject/files/) is not. Detect this by importing `gi.require_version` directly.

```python
>>> import matplotlib.pyplot as plt
>>> plt.plot([0, 1], [0, 1])
Traceback (most recent call last):
  File "<python-input-1>", line 1, in <module>
    plt.plot([0, 1], [0, 1])
    ~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 3838, in plot
    return gca().plot(
           ~~~^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 2785, in gca
    return gcf().gca()
           ~~~^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 1108, in gcf
    return figure()
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 1042, in figure
    manager = new_figure_manager(
        num, figsize=figsize, dpi=dpi,
        facecolor=facecolor, edgecolor=edgecolor, frameon=frameon,
        FigureClass=FigureClass, **kwargs)
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 551, in new_figure_manager
    _warn_if_gui_out_of_main_thread()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 528, in _warn_if_gui_out_of_main_thread
    canvas_class = cast(type[FigureCanvasBase], _get_backend_mod().FigureCanvas)
                                                ~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 369, in _get_backend_mod
    switch_backend(rcParams._get("backend"))
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 411, in switch_backend
    switch_backend(candidate)
    ~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.13/site-packages/matplotlib/pyplot.py", line 425, in switch_backend
    module = backend_registry.load_backend_module(newbackend)
  File "/usr/lib/python3.13/site-packages/matplotlib/backends/registry.py", line 317, in load_backend_module
    return importlib.import_module(module_name)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/usr/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "/usr/lib/python3.13/site-packages/matplotlib/backends/backend_gtk4agg.py", line 4, in <module>
    from . import backend_agg, backend_gtk4
  File "/usr/lib/python3.13/site-packages/matplotlib/backends/backend_gtk4.py", line 19, in <module>
    gi.require_version("Gtk", "4.0")
    ^^^^^^^^^^^^^^^^^^
AttributeError: module 'gi' has no attribute 'require_version'
```

Fixes #30654.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
