### PR TITLE
Grammar corrections in User guide FAQ

### DIFF
--- a/doc/users/faq.rst
+++ b/doc/users/faq.rst
@@ -91,7 +91,7 @@ background patch. This definition could be checked via::
 
 We've decided not to include this as a figure method because this is only one
 way of defining empty, and checking the above is only rarely necessary.
-Whether or not something has been added to the figure is usually defined 
+Whether or not something has been added to the figure is usually defined
 within the context of the program.
 
 The only reliable way to check whether a figure would render empty is to


### PR DESCRIPTION
- Use "its" (the possessive form of "it") instead of "it's" (the contraction of "it is").
- Change plurality of verb to match compound subject joined by "or". The verb should agree with the part of the subject closest to it. See https://editorsmanual.com/articles/compound-subject-singular-or-plural/.

## PR summary

Minor grammar corrections in existing documentation.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
