### PR TITLE
cibw: Switch macos 13 to 15 Intel

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -130,7 +130,7 @@ jobs:
             cibw_archs: "AMD64"
           - os: windows-11-arm
             cibw_archs: "ARM64"
-          - os: macos-13
+          - os: macos-15-intel
             cibw_archs: "x86_64"
           - os: macos-14
             cibw_archs: "arm64"


### PR DESCRIPTION
## PR summary

The former is deprecated.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines