### PR TITLE
fix: uses scatter markers with facecolor = 'none'

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5231,6 +5231,9 @@ or pandas.DataFrame
         orig_edgecolor = edgecolors
         if edgecolors is None:
             orig_edgecolor = kwargs.get('edgecolor', None)
+        # Store original facecolors value before parsing
+        orig_facecolors = kwargs.get('facecolors', kwargs.get('facecolor', None))
+        
         c, colors, edgecolors = \
             self._parse_scatter_color_args(
                 c, edgecolors, kwargs, x.size,
@@ -5308,9 +5311,20 @@ or pandas.DataFrame
 
         offsets = np.ma.column_stack([x, y])
 
+        # If orig_facecolors is 'none' and we're using colormapping (colors is None),
+        # then we need to map colors to edges instead of faces
+        if colors is None and cbook._str_lower_equal(orig_facecolors, 'none'):
+            facecolors_for_collection = 'none'
+            # Set edgecolors to None to allow color mapping to edges
+            # (unless the user explicitly set edgecolors)
+            if orig_edgecolor is None:
+                edgecolors = None
+        else:
+            facecolors_for_collection = colors
+
         collection = mcoll.PathCollection(
             (path,), scales,
-            facecolors=colors,
+            facecolors=facecolors_for_collection,
             edgecolors=edgecolors,
             linewidths=linewidths,
             offsets=offsets,

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -4073,6 +4073,7 @@ def scatter(
     data=None,
     **kwargs,
 ) -> PathCollection:
+    # print(f"scatter called with facecolors: {facecolors}")   # Adicionado para teste
     __ret = gca().scatter(
         x,
         y,


### PR DESCRIPTION
## PR Summary

Fix the bug described in [#24404](https://github.com/matplotlib/matplotlib/issues/24404), in which the `scatter` function did not respect the `facecolors='none'` option, resulting in filled markers even when the user only wanted an outline. Since there are logs reporting the possibility that the `c` parameter in `scatter()` might fail to override `facecolor`, this implementation accounts for this possibility.

### Why is this change necessary?
The `facecolors='none'` option should produce hollow (unfilled) markers, but the current behavior ignored this setting, filling the markers with the default color.

### What problem does it solve? Allows `plt.scatter(..., facecolors='none')` to correctly draw empty markers—that is, with only the outline visible, as expected and as per the documentation.

### What is the reason for this implementation?
The implementation adjusts the internal handling of `facecolors` in `PathCollection`, ensuring that the value `none` is interpreted correctly and the fill is omitted.

### Minimal Example
```python
from matplotlib.pylab import *
x = arange(0, 10)
scatter(x, x, c=x, facecolors='none')
show()
```
Old output:
<img width="715" height="552" alt="image" src="https://github.com/user-attachments/assets/ffb3c21c-dea7-4e75-9338-8a74b551d04a" />

Result with modification:
<img width="640" height="480" alt="saida" src="https://github.com/user-attachments/assets/37d9d772-402a-4701-b24c-5277e258a45d" />

## Operating system
windows

## Matplotlib Version
latest

## Python version
3.11