### PR TITLE
Use pathlib.Path instead of matplotlib.path.Path in text.pyi

### DIFF
--- a/lib/matplotlib/text.pyi
+++ b/lib/matplotlib/text.pyi
@@ -2,7 +2,7 @@ from .artist import Artist
 from .backend_bases import RendererBase
 from .font_manager import FontProperties
 from .offsetbox import DraggableAnnotation
-from .path import Path
+from pathlib import Path
 from .patches import FancyArrowPatch, FancyBboxPatch
 from .textpath import (  # noqa: F401, reexported API
     TextPath as TextPath,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

Closes #30669 

Fix type annotation for Text.fontproperties in text.pyi.

Change import from matplotlib.path.Path to pathlib.Path so that fontproperties correctly accepts filesystem paths. This resolves type checker errors while keeping runtime behavior unchanged.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [X] "closes #30669" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/30669)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
