### PR TITLE
DOC: add brief comments describing AGG backend types

### DIFF
--- a/src/_backend_agg_basic_types.h
+++ b/src/_backend_agg_basic_types.h
@@ -18,6 +18,14 @@
 
 namespace py = pybind11;
 
+// NOTE:
+// This header defines a few lightweight helper types used by the AGG
+// backend and the pybind11 type casters that convert Python-side
+// values to the corresponding C++ representations.  The comments
+// below are intentionally short and non-intrusive to keep the file
+// easy to scan for contributors familiar with AGG and matplotlib's
+// pybind adapters.
+
 struct ClipPath
 {
     mpl::PathIterator path;
@@ -38,6 +46,9 @@ class Dashes
     dash_t dashes;
 
   public:
+        // Represents a dash pattern: pairs of (on_length, off_length),
+        // plus an offset.  This is kept minimal because the conversion
+        // to an AGG stroke happens in dash_to_stroke().
     double get_dash_offset() const
     {
         return dash_offset;
@@ -77,6 +88,10 @@ typedef std::vector<Dashes> DashesVector;
 class GCAgg
 {
   public:
+        // A compact representation of the matplotlib GraphicsContext
+        // attributes that the AGG backend needs.  This mirrors a subset
+        // of the Python-side GC; the pybind11 caster below fills this
+        // struct from the Python object.
     GCAgg()
         : linewidth(1.0),
           alpha(1.0),
@@ -124,6 +139,9 @@ class GCAgg
     GCAgg &operator=(const GCAgg &);
 };
 
+// Pybind11 type_casters: convert Python-level enums/tuples/objects
+// into the small C++ types used by the AGG backend.  These are
+// intentionally permissive and only perform the necessary casts.
 namespace PYBIND11_NAMESPACE { namespace detail {
     template <> struct type_caster<agg::line_cap_e> {
     public:


### PR DESCRIPTION
PR summary
This is a documentation-only change that adds concise, non-functional comments to _backend_agg_basic_types.h. The comments briefly explain the purpose of the small helper types (ClipPath, SketchParams, Dashes, GCAgg) and the pybind11 type casters so that future contributors can more quickly understand the intent and usage of these types when working on the AGG backend.

Why is this change necessary?

The header contains small but central types used by the AGG backend and pybind11 adapters. Adding short, unobtrusive comments improves readability and reduces time-to-understanding for new contributors and reviewers, especially when tracking how Python-side GC attributes are converted into C++ structures

What problem does it solve?

Lowers the cognitive cost of navigating the codebase and reduces repetitive questions in reviews by providing succinct context next to the declarations.
Reasoning for this implementation

Kept changes minimal and non-functional: only comments were added. No code paths, behavior, or API surface was modified. The comments are intentionally brief and placed close to the relevant declarations so they are easy to scan.

Files changed

_backend_agg_basic_types.h — small comment additions only.
Testing & verification

This is a doc-only change and does not require new tests.
No runtime behavior was changed.
I verified that only comments were added (one commit on branch add/comments/_backend_agg_basic_types).
