### PR TITLE
DOC: Fix pip link

### DIFF
--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -220,7 +220,7 @@ Build dependencies
 Python
 ------
 
-``pip`` normally builds packages using :external+pip:doc:`build isolation <reference/build-system/pyproject-toml>`,
+``pip`` normally builds packages using :external+pip:doc:`build isolation <reference/build-system>`,
 which means that ``pip`` installs the dependencies listed here for the
 duration of the build process. However, build isolation is disabled via the the
 :external+pip:ref:`--no-build-isolation <install_--no-build-isolation>` flag


### PR DESCRIPTION
The pip docs were restructured in
https://github.com/pypa/pip/commit/5a17132f46ab6620a3329a16620fa275b280b76c

As a result our doc builds fail with the warning

> /home/circleci/project/doc/install/dependencies.rst:223: WARNING: external std:doc reference target not found: reference/build-system/pyproject-toml [ref.doc]

Therefore, our pip doc link must be adapted.

