### PR TITLE
Adds `CenteredAsinhNorm` class to automatically center asinh-normaliz…

### DIFF
--- a/lib/matplotlib/colors.pyi
+++ b/lib/matplotlib/colors.pyi
@@ -388,6 +388,26 @@ class AsinhNorm(Normalize):
     @linear_width.setter
     def linear_width(self, value: float) -> None: ...
 
+class CenteredAsinhNorm(AsinhNorm):
+    """Type stub for CenteredAsinhNorm - symmetric asinh normalization."""
+    def __init__(
+        self,
+        vcenter: float = ...,
+        halfrange: float | None = ...,
+        linear_width: float = ...,
+        clip: bool = ...,
+    ) -> None: ...
+    @property
+    def vcenter(self) -> float: ...
+    @vcenter.setter
+    def vcenter(self, vcenter: float) -> None: ...
+    @property
+    def halfrange(self) -> float | None: ...
+    @halfrange.setter
+    def halfrange(self, halfrange: float | None) -> None: ...
+    def autoscale(self, A: ArrayLike) -> None: ...
+    def autoscale_None(self, A: ArrayLike) -> None: ...
+
 class PowerNorm(Normalize):
     gamma: float
     def __init__(


### PR DESCRIPTION
…ed data around a specified value (typically   zero). This is useful for diverging colormaps where symmetric scaling is desired.

Users currently need to manually calculate and set symmetric vmin/vmax values when using `AsinhNorm` with
  diverging colormaps. This new class automates that process, similar to how `CenteredNorm` works for linear
  scaling.

  ## Changes
  - Added `CenteredAsinhNorm` class in `lib/matplotlib/colors.py`
  -  Added type stubs in `lib/matplotlib/colors.pyi`
  - Added 11 comprehensive test cases in `lib/matplotlib/tests/test_colors.py`
  - Fully documented with NumPy-style docstrings
  - Bilingual comments for maintainability

Closes #30679
