### PR TITLE
DOC: Link AI policy from developer guide index (#30439)

### DIFF
--- a/doc/devel/index.rst
+++ b/doc/devel/index.rst
@@ -194,6 +194,9 @@ of maintenance work. If you are writing code or documentation, following these p
 helps maintainers more easily review your work. If you are helping triage, community
 manage, or release manage, these guidelines describe how our current process works.
 
+Please also review our :ref:`Restrictions on Generative AI Usage <generative_ai>`, which
+explains how to use AI tools responsibly when contributing to Matplotlib.
+
 .. grid:: 1 1 2 2
    :class-row: sf-fs-1
    :gutter: 2


### PR DESCRIPTION
## PR summary

This adds a short note in the "Policies and guidelines" section of `doc/devel/index.rst` that directs contributors to the existing “Restrictions on Generative AI Usage” guidance (the `generative_ai` reference in `contribute.rst`).

Why is this change necessary?
- New contributors may not see the AI usage policy unless they happen to read `contribute.rst` in full.
- The "Policies and guidelines" page is where we already tell people how to contribute responsibly, so it's the natural place to surface that policy.

What problem does it solve?
- It makes the AI usage expectations visible at the point where contributors first learn about review, triage, maintenance, and process.
- This directly addresses issue #30439.

What is the reasoning for this implementation?
- We insert a two-line paragraph immediately before the existing `.. grid::` block in the "Policies and guidelines" section, pointing to the existing `:ref:\`generative_ai\`` anchor. No new content is invented, and no other structure is changed.

Additionally:
- Title summarizes the change: `DOC: Link AI policy from developer guide index (#30439)`.
- This is documentation-only, no behavior change and no code/API change.


## PR checklist

- [x] "closes #30439" is in the body of the PR description to link the related issue
- [N/A] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines