### PR TITLE
TYPING: Broaden Axes.annotate xy/xytext types to allow datetime-like values (#30365)

### DIFF
--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -132,8 +132,8 @@ class Axes(_AxesBase):
     def annotate(
         self,
         text: str,
-        xy: tuple[float, float],
-        xytext: tuple[float, float] | None = ...,
+        xy: tuple[Any, Any],
+        xytext: tuple[Any, Any] | None = ...,
         xycoords: CoordsType = ...,
         textcoords: CoordsType | None = ...,
         arrowprops: dict[str, Any] | None = ...,


### PR DESCRIPTION
## PR summary

This updates the type hints for `Axes.annotate` in `lib/matplotlib/axes/_axes.pyi` so that the `xy` and `xytext` parameters are no longer restricted to `tuple[float, float]`, but instead accept `tuple[Any, Any]`.

Why is this change necessary?
- In real usage, `Axes.annotate` supports coordinates that are not just floats. A common example is using datetime-like values on the x-axis together with a float on the y-axis.
- The previous stub annotated both `xy` and `xytext` as `tuple[float, float]`, which caused type checkers (e.g. mypy/pyright) to incorrectly flag valid code.

What problem does it solve?
- It removes false-positive type errors for users who annotate time series plots or other non-numeric coordinate systems.
- This addresses the report in #30365.

What is the reasoning for this implementation?
- We keep the runtime signature exactly as-is (argument names/order/defaults remain unchanged).
- We only widen the stub side to:
  - `xy: tuple[Any, Any]`
  - `xytext: tuple[Any, Any] | None`
- No runtime behavior is changed, and no API behavior is changed. This is strictly a typing/stub correction.

Title: `TYPING: Broaden Axes.annotate xy/xytext types to allow datetime-like values (#30365)`

## PR checklist

- [x] "closes #30365" is in the body of the PR description to link the related issue
- [N/A] new and changed code is tested (no runtime code changed; stub only)
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note (no API change)
- [x] Documentation complies with general and docstring guidelines (no docstring changes, but the types now match actual supported usage)