### PR TITLE
BLD: update trove metadata to support py3.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers=[
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Scientific/Engineering :: Visualization",
 ]
 


### PR DESCRIPTION
## PR summary
Matplotlib has begun publishing wheels for python 3.14, but the project metadata does not reflect this. In particular this will be helpful for updating readiness tools such as https://pyreadiness.org/3.14/

## PR checklist
N/A, purely a metadata change.