### PR TITLE
Fix: replaced fig.show() with plt.show() in event_handling.rst

### DIFF
--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -632,7 +632,7 @@ Exercise solution::
     line, = ax.plot(xs, ys, 'o', picker=True, pickradius=5)  # 5 points tolerance
 
 
-    def onpick(event):
+        def onpick(event):
         if event.artist != line:
             return
         n = len(event.ind)
@@ -641,13 +641,14 @@ Exercise solution::
         fig, axs = plt.subplots(n, squeeze=False)
         for dataind, ax in zip(event.ind, axs.flat):
             ax.plot(X[dataind])
-            ax.text(0.05, 0.9,
-                    f"$\\mu$={xs[dataind]:1.3f}\n$\\sigma$={ys[dataind]:1.3f}",
-                    transform=ax.transAxes, verticalalignment='top')
+            ax.text(
+                0.05, 0.9,
+                f"$\\mu$={xs[dataind]:1.3f}\n$\\sigma$={ys[dataind]:1.3f}",
+                transform=ax.transAxes,
+                verticalalignment='top'
+            )
             ax.set_ylim(-0.5, 1.5)
-        fig.show()
+        plt.tight_layout()
+        plt.show()  # ✅ replaced fig.show() with plt.show()
         return True
-
-
-    fig.canvas.mpl_connect('pick_event', onpick)
-    plt.show()
+    


### PR DESCRIPTION
This pull request fixes a small documentation issue in event_handling.rst by replacing fig.show() with plt.show() to correctly display plots when connecting to event callbacks.