### PR TITLE
Backport PR #30697 on branch v3.10.x (BUG: raise when creating a MacOS FigureManager outside the main thread)

### DIFF
--- a/lib/matplotlib/tests/test_backend_macosx.py
+++ b/lib/matplotlib/tests/test_backend_macosx.py
@@ -1,4 +1,5 @@
 import os
+import threading
 from pathlib import Path
 
 import pytest
@@ -84,3 +85,25 @@ def _test_save_figure_return():
 def test_save_figure_return():
     subprocess_run_helper(_test_save_figure_return, timeout=_test_timeout,
                           extra_env={"MPLBACKEND": "macosx"})
+
+
+def _test_create_figure_on_worker_thread_fails():
+    def create_figure():
+        warn_msg = "Matplotlib GUI outside of the main thread will likely fail."
+        err_msg = "Cannot create a GUI FigureManager outside the main thread"
+        with pytest.warns(UserWarning, match=warn_msg):
+            with pytest.raises(RuntimeError, match=err_msg):
+                plt.gcf()
+
+    worker = threading.Thread(target=create_figure)
+    worker.start()
+    worker.join()
+
+
+@pytest.mark.backend('macosx', skip_on_importerror=True)
+def test_create_figure_on_worker_thread_fails():
+    subprocess_run_helper(
+        _test_create_figure_on_worker_thread_fails,
+        timeout=_test_timeout,
+        extra_env={"MPLBACKEND": "macosx"}
+    )

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -580,6 +580,16 @@ typedef struct {
 static PyObject*
 FigureManager_new(PyTypeObject *type, PyObject *args, PyObject *kwds)
 {
+    if (![NSThread isMainThread]) {
+        PyErr_SetString(
+            PyExc_RuntimeError,
+            "Cannot create a GUI FigureManager outside the main thread "
+            "using the MacOS backend. Use a non-interactive "
+            "backend like 'agg' to make plots on worker threads."
+        );
+        return NULL;
+    }
+
     lazy_init();
     Window* window = [Window alloc];
     if (!window) { return NULL; }


### PR DESCRIPTION
It looks like the testing-in-a-subprocess stuff was added recently. Let me know if I should handle the fact that this test could possibly crash if somehow there's a problem with the ObjC patch.