### PR TITLE
Fix grouped_bar TypeError with label/color in kwargs

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -3311,6 +3311,11 @@ or pandas.DataFrame
 
         _api.check_in_list(["vertical", "horizontal"], orientation=orientation)
 
+        # Remove 'label' and 'color' from kwargs to avoid passing them twice
+        # (they are already handled explicitly)
+        kwargs.pop('label', None)
+        kwargs.pop('color', None)
+
         if colors is None:
             colors = itertools.cycle([None])
         else:


### PR DESCRIPTION
I ran into issue #30739 when trying to use grouped_bar with explicit label and color arguments. The problem was that these parameters were being passed both explicitly and through **kwargs, which Python doesn't allow.

The fix is pretty simple - just pop 'label' and 'color' from kwargs before passing them along, since the function already handles them explicitly. This way users can pass these in kwargs without causing a TypeError, and the function still works correctly.

Tested this with the example from the issue and it works fine now.