### PR TITLE
Update mpl-sphinx-theme in environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -37,7 +37,7 @@ dependencies:
   - ipywidgets
   - numpydoc>=1.0
   - packaging>=20
-  - pydata-sphinx-theme~=0.15.0
+  - pydata-sphinx-theme=0.16.1  # required by mpl-sphinx-theme=3.10
   - pyyaml
   - sphinx>=3.0.0,!=6.1.2
   - sphinx-copybutton
@@ -46,12 +46,12 @@ dependencies:
   - sphinx-design
   - sphinx-tags>=0.4.0
   - pystemmer
+  - pikepdf
   - pip
   - pip:
-      - mpl-sphinx-theme~=3.8.0
+      - mpl-sphinx-theme~=3.10.0
       - sphinxcontrib-svg2pdfconverter>=1.1.0
       - sphinxcontrib-video>=0.2.1
-      - pikepdf
   # testing
   - black<26
   - coverage


### PR DESCRIPTION
Update mpl-sphinx-theme in environment.yml

We still explicitly list pydata-sphinx-theme so that it and its dependencies is fetched from conda-forge and not pip.

Also pikepdf is now available on conda-forge
