### PR TITLE
Avoid copy of font properties in font metrics cache

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -69,12 +69,7 @@ def _get_text_metrics_with_cache(renderer, text, fontprop, ismath, dpi):
     # for this renderer instance
     get_text_metrics = _get_text_metrics_function(renderer)
     # call the function to compute the metrics and return
-    #
-    # We pass a copy of the fontprop because FontProperties is both mutable and
-    # has a `__hash__` that depends on that mutable state.  This is not ideal
-    # as it means the hash of an object is not stable over time which leads to
-    # very confusing behavior when used as keys in dictionaries or hashes.
-    return get_text_metrics(text, fontprop.copy(), ismath, dpi)
+    return get_text_metrics(text, fontprop, ismath, dpi)
 
 
 def _get_text_metrics_function(input_renderer, _cache=weakref.WeakKeyDictionary()):
@@ -140,7 +135,12 @@ def _get_text_metrics_function(input_renderer, _cache=weakref.WeakKeyDictionary(
                     "This should never happen and is evidence of a bug elsewhere."
                     )
             # do the actual method call we need and return the result
-            return local_renderer.get_text_width_height_descent(text, fontprop, ismath)
+            # We make a copy of the fontprop because FontProperties is both mutable and
+            # has a `__hash__` that depends on that mutable state.  This is not ideal
+            # as it means the hash of an object is not stable over time which leads to
+            # very confusing behavior when used as keys in dictionaries or hashes.
+            return local_renderer.get_text_width_height_descent(text,
+                                                                fontprop.copy(), ismath)
 
         # stash the function for later use.
         _cache[input_renderer] = _text_metrics


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

@tacaswell This is a small followup to https://github.com/matplotlib/matplotlib/pull/28831. We avoid a copy of the font properties by making the copy inside the cache.

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
