### PR TITLE
Always display WebAgg URL regardless of browser open status

### DIFF
--- a/lib/matplotlib/backends/backend_webagg.py
+++ b/lib/matplotlib/backends/backend_webagg.py
@@ -53,10 +53,9 @@ class FigureManagerWebAgg(core.FigureManagerWebAgg):
 
         if mpl.rcParams['webagg.open_in_browser']:
             import webbrowser
-            if not webbrowser.open(url):
-                print(f"To view figure, visit {url}")
-        else:
-            print(f"To view figure, visit {url}")
+            webbrowser.open(url)
+
+        print(f"To view figure, visit {url}")
 
         WebAggApplication.start()
 


### PR DESCRIPTION
## Summary
Ensures the WebAgg server URL is always displayed to users, even when the browser successfully opens automatically.

## Problem
Currently, the URL is only shown when:
- `webagg.open_in_browser` is `False`, OR
- The browser fails to open

This means users never see the URL when the browser opens successfully, making it difficult to:
- Share the URL with others
- Open in a different browser
- Reconnect if the tab is accidentally closed

## Solution
Moved the `print(f"To view figure, visit {url}")` statement outside the conditional block, ensuring it always executes regardless of the browser open attempt.

## Changes
- **File:** `lib/matplotlib/backends/backend_webagg.py`
- **Method:** `FigureManagerWebAgg.pyplot_show()`
- Simplified conditional logic
- URL now prints in all cases

## Benefits
- ✅ Users always know the exact URL to access their figures
- ✅ Easier to reconnect if browser tab closes
- ✅ Better user experience for remote/headless environments
- ✅ Consistent behavior regardless of settings

## Testing
Tested with:
- `webagg.open_in_browser = True` → URL displays, browser opens
- `webagg.open_in_browser = False` → URL displays, browser doesn't open
- Simulated browser open failure → URL still displays

Fixes #15650