### PR TITLE
Fix typo in key-mapping for "f11"

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -55,7 +55,7 @@ SPECIAL_KEYS = {
         ("Key_F8", "f8"),
         ("Key_F9", "f9"),
         ("Key_F10", "f10"),
-        ("Key_F10", "f11"),
+        ("Key_F11", "f11"),
         ("Key_F12", "f12"),
         ("Key_Super_L", "super"),
         ("Key_Super_R", "super"),


### PR DESCRIPTION
## PR summary
I just wanted to connect a keypress event to f11 and in the process noticed that there is a typo in the qt backend for exactly that key... so I thought I'll fix it right away 🙂

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
