### PR TITLE
DOC: remove duplicate whatsnew heading

### DIFF
--- a/doc/release/prev_whats_new/whats_new_3.10.0.rst
+++ b/doc/release/prev_whats_new/whats_new_3.10.0.rst
@@ -62,13 +62,6 @@ colour maps version 8.0.1 (DOI: https://doi.org/10.5281/zenodo.1243862).
     ax[2].imshow(img, cmap="vanimo")
 
 
-
-Plotting and Annotation improvements
-====================================
-
-
-
-
 Plotting and Annotation improvements
 ====================================
 


### PR DESCRIPTION
I just noticed this heading appears twice in the 3.10 whatsnew page.