### PR TITLE
MNT: Fix handling of ints in rgb_to_hsv()

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3631,11 +3631,10 @@ def rgb_to_hsv(arr):
                          f"shape {arr.shape} was found.")
 
     in_shape = arr.shape
-    arr = np.array(
-        arr, copy=False,
-        dtype=np.promote_types(arr.dtype, np.float32),  # Don't work on ints.
-        ndmin=2,  # In case input was 1D.
-    )
+    # ensure numerics are done at least on float32; ints are cast as well
+    arr = np.asarray(arr, dtype=np.promote_types(arr.dtype, np.float32))
+    if arr.ndim == 1:
+        arr = np.expand_dims(arr, axis=0)  # ensure arr is 2D
 
     out = np.zeros_like(arr)
     arr_max = arr.max(-1)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -947,6 +947,11 @@ def test_rgb_hsv_round_trip():
             tt, mcolors.rgb_to_hsv(mcolors.hsv_to_rgb(tt)))
 
 
+def test_rgb_to_hsv_int():
+    # Test that int rgb values (still range 0-1) are processed correctly.
+    assert_array_equal(mcolors.rgb_to_hsv((0, 1, 0)), (1/3, 1, 1))  # green
+
+
 def test_autoscale_masked():
     # Test for #2336. Previously fully masked data would trigger a ValueError.
     data = np.ma.masked_all((12, 20))


### PR DESCRIPTION
This is a numpy 2.0 regression. `rgb_to_hsv((0, 1, 0))` used to work for numpy 1.x

```python
In [1]: from matplotlib.colors import rgb_to_hsv

In [2]: rgb_to_hsv((0, 1, 0))
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[2], line 1
----> 1 rgb_to_hsv((0, 1, 0))

File ~/git/matplotlib/lib/matplotlib/colors.py:3634, in rgb_to_hsv(arr)
   3630     raise ValueError("Last dimension of input array must be 3; "
   3631                      f"shape {arr.shape} was found.")
   3633 in_shape = arr.shape
-> 3634 arr = np.array(
   3635     arr, copy=False,
   3636     dtype=np.promote_types(arr.dtype, np.float32),  # Don't work on ints.
   3637     ndmin=2,  # In case input was 1D.
   3638 )
   3640 out = np.zeros_like(arr)
   3641 arr_max = arr.max(-1)

ValueError: Unable to avoid copy while creating an array as requested.
If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```
