### PR TITLE
Fix typos in API interfaces documentation

### DIFF
--- a/galleries/users_explain/figure/api_interfaces.rst
+++ b/galleries/users_explain/figure/api_interfaces.rst
@@ -174,7 +174,7 @@ referenced by ``plt.gca()``?  One simple way is to call ``subplot`` again with
 the same arguments.  However, that quickly becomes inelegant.  You can also
 inspect the Figure object and get its list of Axes objects, however, that can be
 misleading (colorbars are Axes too!). The best solution is probably to save a
-handle to every Axes you create, but if you do that, why not simply create the
+handle to every Axes you create, but if you do that, why not simply create
 all the Axes objects at the start?
 
 The first approach is to call ``plt.subplot`` again:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->
Fixing small typo in documentation. "are named" was missing from:
```
Functions that set properties are named like the property in pyplot and are prefixed with
  ``set_`` on the Axes.
```

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
