### PR TITLE
FIX: Respect animated=True for AxesImage

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3206,7 +3206,7 @@ class _AxesBase(martist.Artist):
         if not self.get_figure(root=True).canvas.is_saving():
             artists = [
                 a for a in artists
-                if not a.get_animated() or isinstance(a, mimage.AxesImage)]
+                if not a.get_animated()]
         artists = sorted(artists, key=attrgetter('zorder'))
 
         # rasterize artists with negative zorder


### PR DESCRIPTION
AxesImage was incorrectly being drawn even when animated=True due to an explicit exception in the artist filtering logic.

Removed the special case for AxesImage so it respects the animated property like all other artists (Line2D, patches, etc).

When animated=True, artists should only be drawn explicitly (e.g., during animation updates), not during normal rendering.

Fixes #18985

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

**Why is this change necessary?**

When using `animated=True` with `imshow()`, the image was still being rendered during interactive display, unlike other artists (lines, patches) which correctly remain invisible. This breaks the expected behavior of the `animated` property and makes animations inconsistent.

**What problem does it solve?**

The bug prevented proper use of `animated=True` with images in animation workflows. Users couldn't hide images from normal rendering like they could with other artists.

**Reproduction:**
```python
import matplotlib.pyplot as plt
import numpy as np

fig, (ax1, ax2) = plt.subplots(ncols=2)
im = ax1.imshow(np.random.random((20, 20)), animated=True)  # Was visible (BUG)
ln, = ax2.plot(np.random.random(20), animated=True)         # Correctly invisible
plt.show()  # Expected: both blank. Actual: left showed image
```
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #18985" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
