### PR TITLE
add inline metadata to bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -19,8 +19,10 @@ body:
         have used generative AI as an aid see
         https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
 
-        Consider using [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/)
-        so that calling `uv run issue.py` reproduces the issue when copied into `issue.py` (not strictly required).
+        Consider using
+        [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/)
+        so that calling `uv run issue.py` reproduces the issue when copied into
+        `issue.py` (not strictly required).
 
         This field is automatically formatted as Python code.
       render: Python
@@ -46,7 +48,13 @@ body:
         # Please delete this header if you have _not_ tested this script with `uv run`!
 
         import matplotlib
-        print(matplotlib.__version__)
+        print("matplotlib version:", matplotlib.__version__)
+        print("backend:", matplotlib.get_backend())
+
+        import platform
+        print("python version:", platform.python_version())
+        print("platform:", platform.platform())
+
         import matplotlib.pyplot as plt
         # your reproducer code ...
     validations:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -18,8 +18,37 @@ body:
         If possible, please provide a minimum self-contained example.  If you
         have used generative AI as an aid see
         https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-      placeholder: Paste your code here. This field is automatically formatted as Python code.
+
+        Consider using [inline script metadata](https://packaging.python.org/en/latest/specifications/inline-script-metadata/)
+        so that calling `uv run issue.py` reproduces the issue when copied into `issue.py` (not strictly required).
+
+        This field is automatically formatted as Python code.
       render: Python
+      value: |
+        # /// script
+        # requires-python = ">=3.11"
+        # dependencies = [
+        #   "matplotlib",
+        # ]
+        #
+        # [[tool.uv.index]]
+        # name = "scientific-python-nightly-wheels"
+        # url = "https://pypi.anaconda.org/scientific-python-nightly-wheels/simple/"
+        #
+        # [tool.uv.sources]
+        # matplotlib = { index = "scientific-python-nightly-wheels" }
+        #
+        # [tool.uv]
+        # prerelease = "allow"
+        # ///
+        #
+        # This script uses the nightly development build of matplotlib.
+        # Please delete this header if you have _not_ tested this script with `uv run`!
+
+        import matplotlib
+        print(matplotlib.__version__)
+        import matplotlib.pyplot as plt
+        # your reproducer code ...
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## PR summary

Closes: https://github.com/matplotlib/matplotlib/issues/30584
Adds inline script metadata pointing at nightly wheels (or normal pypi if using a non-uv script runner). I've added this in xarray and zarr and in both places a decent portion of bug reports seem to use it. When there it make it easier to make a true reproducible example, and also easier for other to replicate (just copy and then `uv run` or use my [`script-bisect`](https://github.com/ianhi/script-bisect#script-bisect)


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [NA] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
