### PR TITLE
Fix test_ensure_multivariate_data on 32-bit systems

### DIFF
--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -2102,15 +2102,15 @@ def test_ensure_multivariate_data():
     data = [[0, 0, 0], [1, 1, 1]]
     mdata = mcolorizer._ensure_multivariate_data(data, 2)
     assert mdata.shape == (3,)
-    assert mdata.dtype.fields['f0'][0] == np.int64
-    assert mdata.dtype.fields['f1'][0] == np.int64
+    assert mdata.dtype.fields['f0'][0] == np.int_
+    assert mdata.dtype.fields['f1'][0] == np.int_
 
     # test input of floats, ints as tuple of lists
     data = ([0.0, 0.0], [1, 1])
     mdata = mcolorizer._ensure_multivariate_data(data, 2)
     assert mdata.shape == (2,)
     assert mdata.dtype.fields['f0'][0] == np.float64
-    assert mdata.dtype.fields['f1'][0] == np.int64
+    assert mdata.dtype.fields['f1'][0] == np.int_
 
     # test input of array of floats
     data = np.array([[0.0, 0, 0], [1, 1, 1]])


### PR DESCRIPTION
## PR summary

In that case, the default int is also 32-bit, so the test will fail to be equal to `int64`.

This is similar to #30629.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines