### PR TITLE
DOC: add thumbnail for simple_plot gallery example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/simple_plot.py
+++ b/galleries/examples/lines_bars_and_markers/simple_plot.py
@@ -1,3 +1,4 @@
+# sphinx_gallery_thumbnail_number = 1
 """
 =========
 Line plot


### PR DESCRIPTION
## PR summary

This PR adds sphinx-gallery metadata to ensure the `simple_plot` gallery example
generates a thumbnail in the documentation.

The example already produces a figure; this change explicitly instructs
sphinx-gallery to use the first generated figure as the thumbnail, improving
the gallery overview without changing runtime behavior.

Closes #17479

## PR checklist

- [x] closes #17479
- [N/A] new and changed code is tested
- [x] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines
