### PR TITLE
Call Refresh on FigureCanvasWxAgg.draw

### DIFF
--- a/lib/matplotlib/backends/backend_wxagg.py
+++ b/lib/matplotlib/backends/backend_wxagg.py
@@ -15,6 +15,7 @@ class FigureCanvasWxAgg(FigureCanvasAgg, _FigureCanvasWxBase):
         self.bitmap = self._create_bitmap()
         self._isDrawn = True
         self.gui_repaint(drawDC=drawDC)
+        self.Refresh()
 
     def blit(self, bbox=None):
         # docstring inherited


### PR DESCRIPTION
This fixes a bug in which some plots are not redrawn under wayland.

## PR summary

- Why is this change necessary?
  
- What problem does it solve?
  Under wayland and wxwidgets, the canvas was only being redraw after user interaction. Programmatic updates from code, such as a background task, would somehow, not trigger a plot redraw.
- What is the reasoning for this implementation?
  Sorry, not much reasoning. I followed the code path and sprinkled what I thought could work. The best I can think of is that wxwidgets is not being notified of the need to repaint the canvas.

I tried to find a way to force redraw of the plot canvas in wxWidgets backend. This place seems to fix it.

Running a demo script with `GDK_BACKEND=x11 python demo.py` fixes it too, but then it is not using wayland.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ N/A ] "closes #10417" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/10417)
- [ N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines