### PR TITLE
Fix boolean contour defaults

### DIFF
--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -84,6 +84,57 @@ def test_contour_Nlevels():
     assert (cs1.levels == cs2.levels).all()
 
 
+def test_contour_bool_default_levels():
+    z = np.array([[True, False], [False, True]])
+
+    fig, ax = plt.subplots()
+    cs = ax.contour(z)
+    assert np.allclose(cs.levels, [0.5])
+
+
+def test_contourf_bool_default_levels():
+    z = np.array([[True, False], [False, True]])
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(z)
+    assert np.allclose(cs.levels, [0.0, 0.5, 1.0])
+
+
+def test_contour_bool_explicit_levels_preserved():
+    z = np.array([[True, False], [False, True]])
+
+    fig, ax = plt.subplots()
+    levels = [0.25, 0.75]
+    cs = ax.contour(z, levels=levels)
+    assert np.allclose(cs.levels, levels)
+
+
+def test_contourf_masked_bool_default_levels():
+    data = np.array([[True, False], [False, True]])
+    mask = [[False, True], [False, False]]
+    z = np.ma.array(data, mask=mask)
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(z)
+    assert np.allclose(cs.levels, [0.0, 0.5, 1.0])
+
+
+def test_contour_int_data_no_bool_special_case():
+    z = np.array([[1, 0], [0, 1]], dtype=int)
+
+    fig, ax = plt.subplots()
+    cs = ax.contour(z)
+    assert not np.allclose(cs.levels, [0.5])
+
+
+def test_contourf_bool_lognorm_no_override():
+    z = np.ones((2, 2), dtype=bool)
+
+    fig, ax = plt.subplots()
+    cs = ax.contourf(z, norm=LogNorm())
+    assert not np.allclose(cs.levels, [0.0, 0.5, 1.0])
+
+
 def test_contour_badlevel_fmt():
     # Test edge case from https://github.com/matplotlib/matplotlib/issues/9742
     # User supplied fmt for each level as a dictionary, but Matplotlib changed


### PR DESCRIPTION
## Summary
- detect boolean Z arrays before type conversion
- default auto contour levels for bool inputs to binary thresholds
- add regression coverage for bool, masked, and lognorm cases

## Testing
- PYTEST_ADDOPTS='-W ignore::DeprecationWarning' MPLBACKEND=Agg PYTHONPATH=/workspace/matplotlib/lib LD_LIBRARY_PATH=/nix/store/qipd93x9gjyiygqk673rd2ssnf8y7jj0-gcc-14.3.0-lib/lib:/nix/store/f8w1i7yisixb9hivzbk0l4ixmf67fjqr-gcc-14.3.0-libgcc/lib:/nix/store/4wdz42ns29ys6fm1xak68bnp51nxhd2s-zlib-1.3.1/lib .venv/bin/pytest lib/matplotlib/tests/test_contour.py -k 'bool'
- PYTHONPATH=/workspace/matplotlib/lib .venv/bin/flake8 lib/matplotlib/contour.py lib/matplotlib/tests/test_contour.py

Resolves #43