### PR TITLE
Added Turbo License doc

### DIFF
--- a/doc/project/license.rst
+++ b/doc/project/license.rst
@@ -95,6 +95,12 @@ Colormaps and themes
    .. literalinclude:: ../../LICENSE/LICENSE_YORICK
       :language: none
 
+.. dropdown:: Turbo
+   :class-container: sdd
+
+   The Turbo colormap was contributed directly to Matplotlib by its author in
+   :ghpull:`15275`
+
 
 .. _licenses-fonts:
 


### PR DESCRIPTION
## PR summary
<!--
This PR adds a short clarification for the Turbo colormap under the Colormaps and themes section of the license documentation.

Turbo is included in Matplotlib but was not previously mentioned on the license page, which can create ambiguity for downstream users performing license audits. This change documents that Turbo was contributed directly to Matplotlib and is covered under the Matplotlib license, consistent with prior maintainer discussion.

No licensing terms are changed and no code behavior is affected.

Refs #30651 
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x]  closes #30651
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
