### PR TITLE
DOC: add thumbnail for frame_grabbing gallery example

### DIFF
--- a/galleries/examples/animation/frame_grabbing_sgskip.py
+++ b/galleries/examples/animation/frame_grabbing_sgskip.py
@@ -7,6 +7,7 @@ Use a MovieWriter directly to grab individual frames and write them to a
 file.  This avoids any event loop integration, and thus works even with the Agg
 backend.  This is not recommended for use in an interactive setting.
 """
+# sphinx_gallery_thumbnail_number = 1
 
 import numpy as np
 


### PR DESCRIPTION
##  PR Summary

Add sphinx-gallery thumbnail metadata to the
`frame_grabbing_sgskip.py` animation example so that it generates a
thumbnail in the gallery overview.

This is a documentation-only change and does not modify example logic
or runtime behavior.

## PR Checklist

- [x] Documentation-only change
- [x] Minimal and targeted fix
- [x] No behavior or API changes
- [x] Closes #17479
