### PR TITLE
Inline intermediate constructs in axisartist demos.

### DIFF
--- a/galleries/examples/axisartist/demo_floating_axes.py
+++ b/galleries/examples/axisartist/demo_floating_axes.py
@@ -56,21 +56,18 @@ def setup_axes2(fig, rect):
     tr = PolarAxes.PolarTransform()
 
     pi = np.pi
-    angle_ticks = [(0, r"$0$"),
-                   (.25*pi, r"$\frac{1}{4}\pi$"),
-                   (.5*pi, r"$\frac{1}{2}\pi$")]
-    grid_locator1 = FixedLocator([v for v, s in angle_ticks])
-    tick_formatter1 = DictFormatter(dict(angle_ticks))
-
-    grid_locator2 = MaxNLocator(2)
-
+    angle_ticks = {
+        0: r"$0$",
+        pi/4: r"$\frac{1}{4}\pi$",
+        pi/2: r"$\frac{1}{2}\pi$",
+    }
     grid_helper = floating_axes.GridHelperCurveLinear(
         tr, extremes=(.5*pi, 0, 2, 1),
-        grid_locator1=grid_locator1,
-        grid_locator2=grid_locator2,
-        tick_formatter1=tick_formatter1,
-        tick_formatter2=None)
-
+        grid_locator1=FixedLocator([*angle_ticks]),
+        tick_formatter1=DictFormatter(angle_ticks),
+        grid_locator2=MaxNLocator(2),
+        tick_formatter2=None,
+    )
     ax1 = fig.add_subplot(
         rect, axes_class=floating_axes.FloatingAxes, grid_helper=grid_helper)
     ax1.grid()
@@ -92,30 +89,22 @@ def setup_axes3(fig, rect):
     Sometimes, things like axis_direction need to be adjusted.
     """
 
-    # rotate a bit for better orientation
-    tr_rotate = Affine2D().translate(-95, 0)
-
-    # scale degree to radians
-    tr_scale = Affine2D().scale(np.pi/180., 1.)
-
+    tr_rotate = Affine2D().translate(-95, 0)  # rotate a bit for better orientation
+    tr_scale = Affine2D().scale(np.pi/180., 1.)  # scale degree to radians
     tr = tr_rotate + tr_scale + PolarAxes.PolarTransform()
-
-    grid_locator1 = angle_helper.LocatorHMS(4)
-    tick_formatter1 = angle_helper.FormatterHMS()
-
-    grid_locator2 = MaxNLocator(3)
 
     # Specify theta limits in degrees
     ra0, ra1 = 8.*15, 14.*15
     # Specify radial limits
     cz0, cz1 = 0, 14000
+
     grid_helper = floating_axes.GridHelperCurveLinear(
         tr, extremes=(ra0, ra1, cz0, cz1),
-        grid_locator1=grid_locator1,
-        grid_locator2=grid_locator2,
-        tick_formatter1=tick_formatter1,
-        tick_formatter2=None)
-
+        grid_locator1=angle_helper.LocatorHMS(4),
+        tick_formatter1=angle_helper.FormatterHMS(),
+        grid_locator2=MaxNLocator(3),
+        tick_formatter2=None,
+    )
     ax1 = fig.add_subplot(
         rect, axes_class=floating_axes.FloatingAxes, grid_helper=grid_helper)
 

--- a/galleries/examples/axisartist/demo_floating_axis.py
+++ b/galleries/examples/axisartist/demo_floating_axis.py
@@ -22,29 +22,19 @@ import mpl_toolkits.axisartist.angle_helper as angle_helper
 def curvelinear_test2(fig):
     """Polar projection, but in a rectangular box."""
     # see demo_curvelinear_grid.py for details
-    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
-
-    extreme_finder = angle_helper.ExtremeFinderCycle(20,
-                                                     20,
-                                                     lon_cycle=360,
-                                                     lat_cycle=None,
-                                                     lon_minmax=None,
-                                                     lat_minmax=(0, np.inf),
-                                                     )
-
-    grid_locator1 = angle_helper.LocatorDMS(12)
-
-    tick_formatter1 = angle_helper.FormatterDMS()
-
-    grid_helper = GridHelperCurveLinear(tr,
-                                        extreme_finder=extreme_finder,
-                                        grid_locator1=grid_locator1,
-                                        tick_formatter1=tick_formatter1
-                                        )
-
+    grid_helper = GridHelperCurveLinear(
+        Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform(),
+        extreme_finder=angle_helper.ExtremeFinderCycle(
+            20, 20,
+            lon_cycle=360, lat_cycle=None,
+            lon_minmax=None, lat_minmax=(0, np.inf),
+        ),
+        grid_locator1=angle_helper.LocatorDMS(12),
+        tick_formatter1=angle_helper.FormatterDMS(),
+    )
     ax1 = fig.add_subplot(axes_class=HostAxes, grid_helper=grid_helper)
 
-    # Now creates floating axis
+    # Now create floating axis
 
     # floating axis whose first coordinate (theta) is fixed at 60
     ax1.axis["lat"] = axis = ax1.new_floating_axis(0, 60)


### PR DESCRIPTION
A bunch of `grid_locator1=grid_locator1` kwargs passing doesn't really help legibility, in particular with respect to showing the object dependency hierarchy.

cf #25747 which made similar changes to another example.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
