### PR TITLE
DOC: Improve writer parameter docs of Animation.save()

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -955,9 +955,21 @@ class Animation:
         filename : str
             The output filename, e.g., :file:`mymovie.mp4`.
 
-        writer : `MovieWriter` or str, default: :rc:`animation.writer`
-            A `MovieWriter` instance to use or a key that identifies a
-            class to use, such as 'ffmpeg'.
+        writer : `AbstractMovieWriter` subclass or str, default: :rc:`animation.writer`
+            The writer used to grab the frames and create the movie file.
+            This can be an instance of an `AbstractMovieWriter` subclass or a
+            string. The builtin writers are
+
+            ==================  ==============================
+            str                 class
+            ==================  ==============================
+            'ffmpeg'            `.FFMpegWriter`
+            'ffmpeg_file'       `.FFMpegFileWriter`
+            'imagemagick'       `.ImageMagickWriter`
+            'imagemagick_file'  `.ImageMagickFileWriter`
+            'pillow'            `.PillowWriter`
+            'html'              `.HTMLWriter`
+            ==================  ==============================
 
         fps : int, optional
             Movie frame rate (per second).  If not set, the frame rate from the


### PR DESCRIPTION
Closes #24159.

Note: type stubs already define the type as AbstractMovieWriter: https://github.com/matplotlib/matplotlib/blob/0dc49d9794ab47776019af1595e7d58219b490e3/lib/matplotlib/animation.pyi#L171