### PR TITLE
Fix outdated documentation links for violin/boxplot example

### DIFF
--- a/galleries/examples/statistics/boxplot_vs_violin.py
+++ b/galleries/examples/statistics/boxplot_vs_violin.py
@@ -12,12 +12,15 @@ range as outliers above or below the whiskers whereas violin plots show
 the whole range of the data.
 
 A good general reference on boxplots and their history can be found
-here: http://vita.had.co.nz/papers/boxplots.pdf
+here: https://vita.had.co.nz/papers/boxplots.pdf
 
 Violin plots require matplotlib >= 1.4.
 
-For more information on violin plots, the scikit-learn docs have a great
-section: https://scikit-learn.org/stable/modules/density.html
+Violin plots show the distribution of the data as a rotated kernel density
+estimate (KDE) along with summary statistics similar to a box plot.
+
+For more information on violin plots, see:
+https://en.wikipedia.org/wiki/Violin_plot
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## PR summary

This PR fixes outdated and incorrect documentation links in the
`boxplot_vs_violin` example.

**Why is this change necessary?**  
The example currently links to the scikit-learn density documentation as a
reference for violin plots, but that page does not mention violin plots.
Additionally, the boxplot reference link uses HTTP, which fails in some browsers.

**What problem does it solve?**  
- Removes a misleading scikit-learn reference
- Fixes a broken boxplot documentation link by switching to HTTPS
- Improves accuracy and reliability of references for users reading the example

**Reasoning for this implementation**  
This is a documentation-only change that updates references without altering
any plotting behavior or APIs.

Closes #28983


## PR checklist

- [x] "closes #28983" is in the body of the PR description
- [N/A] new and changed code is tested (documentation-only change)
- [N/A] *Plotting related* features are demonstrated in an example (existing example updated)
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines
