### PR TITLE
FIX: Increase reruns for flaky test_invisible_Line_rendering (#30809)

### DIFF
--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -33,7 +33,7 @@ def test_segment_hits():
 
 # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
 # won't help, hopefully.
-@pytest.mark.flaky(reruns=3)
+@pytest.mark.flaky(reruns=5)
 def test_invisible_Line_rendering():
     """
     GitHub issue #1256 identified a bug in Line.draw method


### PR DESCRIPTION
## PR summary

This PR addresses the flaky test `test_invisible_Line_rendering` (#30809) by increasing the number of reruns in the `@pytest.mark.flaky` decorator from 3 → 5.  

- Why is this change necessary?  
  The test is timing-based and occasionally fails on loaded systems due to natural timing variability. Increasing reruns reduces intermittent failures while keeping the test fast.  

- What problem does it solve?  
  Reduces false negatives in CI caused by timing noise. No functional code is changed.  

- What is the reasoning for this implementation?  
  Maintainers recommended increasing reruns as the simplest and safest approach to address flaky timing tests. Other approaches (increasing thresholds or repeats) would either reduce sensitivity or slow down the test unnecessarily.  

---

## PR checklist

- [x] "closes #30809" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/30809)
- [x] new and changed code is tested (local `pytest` passes)
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines
