### PR TITLE
Exclude confirmed bugs from stale bot

### DIFF
--- a/.github/workflows/stale-tidy.yml
+++ b/.github/workflows/stale-tidy.yml
@@ -20,5 +20,5 @@ jobs:
           close-issue-label: "status: closed as inactive"
           days-before-issue-close: 30
           ascending: true
-          exempt-issue-labels: "keep"
+          exempt-issue-labels: "keep,status: confirmed bug"
           exempt-pr-labels: "keep,status: orphaned PR"


### PR DESCRIPTION
We should not close confirmed bugs through a timeout mechanism. The bug exists and should be tracked as open bug as long as we don't fix it or explicitly decide to not handle this, in which case, we'd manually close
 as "won't fix".

