### PR TITLE
Reduce stale bot to run once per week

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,7 +2,7 @@
 name: 'Label inactive PRs'
 on:
   schedule:
-    - cron: '30 1 * * 1,3,5'
+    - cron: '30 1 * * 1'
 
 jobs:
   stale:


### PR DESCRIPTION
I have the impression that we are not systematically reviewing the issues marked as inactive. We had multiple cases of re-opening issues that got closed by the bot, which means they haven't been identified as "keep" during the stale phase. IMHO this should not happen as it increases the danger of overlooking the closing of relevant issues.

