### PR TITLE
DOC: Update version switcher for 3.10.8

### DIFF
--- a/doc/_static/switcher.json
+++ b/doc/_static/switcher.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "3.10 (stable)",
-        "version": "3.10.7",
+        "version": "3.10.8",
         "url": "https://matplotlib.org/stable/",
         "preferred": true
     },


### PR DESCRIPTION
... this was missed in the 3.10.8 release.