### PR TITLE
Log warning during ..plot to sphix logger

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -585,7 +585,7 @@ def _run_code(code, code_path, ns=None, function_name=None):
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
 
-    with (warnings.catch_warnings() as caught_warnings,
+    with (warnings.catch_warnings(record=True) as caught_warnings,
         cbook._setattr_cm(
             sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
             contextlib.redirect_stdout(StringIO())):
@@ -611,6 +611,7 @@ def _run_code(code, code_path, ns=None, function_name=None):
             raise PlotError(traceback.format_exc()) from err
         finally:
             os.chdir(pwd)
+
         for warn in caught_warnings:
             _log.warning(
                 "[plot] Python warning during plot execution: %s (%s)",

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -196,6 +196,7 @@ import shutil
 import sys
 import textwrap
 import traceback
+import warnings
 
 from docutils.parsers.rst import directives, Directive
 from docutils.parsers.rst.directives.images import Image
@@ -584,9 +585,10 @@ def _run_code(code, code_path, ns=None, function_name=None):
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
 
-    with cbook._setattr_cm(
+    with (warnings.catch_warnings() as caught_warnings,
+        cbook._setattr_cm(
             sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
-            contextlib.redirect_stdout(StringIO()):
+            contextlib.redirect_stdout(StringIO())):
         try:
             if ns is None:
                 ns = {}
@@ -609,6 +611,12 @@ def _run_code(code, code_path, ns=None, function_name=None):
             raise PlotError(traceback.format_exc()) from err
         finally:
             os.chdir(pwd)
+        for warn in caught_warnings:
+            _log.warning(
+                "[plot] Python warning during plot execution: %s (%s)",
+                warn.message,
+                warn.category.__name__
+            )
     return ns
 
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
closes #15715

As described in #15715, currently the warning in the ..plot is not correctly handled by the sphinx 
By modifying file lib/matplotlib/sphinxext/plot_directive.py , I catch any warning generated during the code execution and log it through sphinx logs. When compiling the document, sphinx will fail on warning with the -W flag

```
(matplotlib_dev_env) PS D:\CodeProjects\matplot_lib_test_file> sphinx-build -E  -b html -d _build/doctrees   . _build/html -W    
Running Sphinx v9.1.0
loading translations [en]... done
building [mo]: targets for 0 po files that are out of date
writing output... 
building [html]: targets for 1 source files that are out of date
updating environment: [new config] 1 added, 0 changed, 0 removed
reading sources... [100%] index
WARNING: [plot] Python warning during plot execution: A warning occurred (UserWarning)
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
copying assets... 
copying downloadable files... [100%] _build/plot_directive/index-1.py
copying static files... 
Writing evaluated template result to D:\CodeProjects\matplot_lib_test_file\_build\html\_static\basic.css
Writing evaluated template result to D:\CodeProjects\matplot_lib_test_file\_build\html\_static\documentation_options.js
Writing evaluated template result to D:\CodeProjects\matplot_lib_test_file\_build\html\_static\language_data.js
Writing evaluated template result to D:\CodeProjects\matplot_lib_test_file\_build\html\_static\alabaster.css
copying static files: done
copying extra files... 
copying extra files: done
copying assets: done
writing output... [100%] index
generating indices... genindex done
writing additional pages... search done
dumping search index in English (code: en)... done
dumping object inventory... done
build finished with problems, 1 warning (with warnings treated as errors).
(matplotlib_dev_env) PS D:\CodeProjects\matplot_lib_test_file> 
```


<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
