### PR TITLE
Add thumbnail for frame grabbing example

### DIFF
--- a/galleries/examples/animation/frame_grabbing_sgskip.py
+++ b/galleries/examples/animation/frame_grabbing_sgskip.py
@@ -1,3 +1,5 @@
+
+
 """
 ==============
 Frame grabbing
@@ -7,6 +9,9 @@ Use a MovieWriter directly to grab individual frames and write them to a
 file.  This avoids any event loop integration, and thus works even with the Agg
 backend.  This is not recommended for use in an interactive setting.
 """
+
+# sphinx_gallery_thumbnail_number = 1
+
 
 import numpy as np
 


### PR DESCRIPTION
This PR adds # sphinx_gallery_thumbnail_number = 1 to the following examples so that the gallery shows thumbnails for them:
– examples/animation/frame_grabbing_sgskip.py
…
This addresses the missing thumbnails mentioned in issue #17479 (Add thumbnails for tutorials/gallery where missing)