### PR TITLE
[ENH] `Line2D.contains()` to return additional details

### DIFF
--- a/doc/release/next_whats_new/line2d_new_contains_detail.rst
+++ b/doc/release/next_whats_new/line2d_new_contains_detail.rst
@@ -1,0 +1,8 @@
+New details item in ``Line2D.contains()`` output
+------------------------------------------------
+
+A new item, ``'vertex_hit'``, is added to the ``details`` output dict of
+`lines.Line2D.contains()` to complement the existing ``'ind'`` item.
+The ``'vertex_hit'`` item is a boolean array of the same size as ``'ind'`` and
+indicates whether the corresponding index in ``'ind'`` is an index of a vertex
+of the line (``True``)

--- a/galleries/examples/event_handling/pick_event_demo.py
+++ b/galleries/examples/event_handling/pick_event_demo.py
@@ -92,6 +92,7 @@ fig, (ax1, ax2) = plt.subplots(2, 1)
 ax1.set_title('click on points, rectangles or text', picker=True)
 ax1.set_ylabel('ylabel', picker=True, bbox=dict(facecolor='red'))
 line, = ax1.plot(rand(100), 'o', picker=True, pickradius=5)
+line2, = ax1.plot([0,100],[0,1], 'o-', picker=True, pickradius=5)
 
 # Pick the rectangle.
 ax2.bar(range(10), rand(10), picker=True)
@@ -105,7 +106,11 @@ def onpick1(event):
         xdata = thisline.get_xdata()
         ydata = thisline.get_ydata()
         ind = event.ind
-        print('onpick1 line:', np.column_stack([xdata[ind], ydata[ind]]))
+        print('onpick1 line:',
+              np.column_stack([xdata[ind], ydata[ind]]))
+        vertex_hit = event.vertex_hit
+        print('onpick1 line (vertices):',
+              np.column_stack([xdata[ind[vertex_hit]], ydata[ind[vertex_hit]]]))
     elif isinstance(event.artist, Rectangle):
         patch = event.artist
         print('onpick1 patch:', patch.get_path())

--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -576,8 +576,9 @@ vertices that are within the pick distance tolerance.  Our ``onpick``
 callback function simply prints the data that are under the pick
 location.  Different Matplotlib Artists can attach different data to
 the PickEvent.  For example, ``Line2D`` attaches the ind property,
-which are the indices into the line data under the pick point.  See
-`!.Line2D.pick` for details on the ``PickEvent`` properties of the line.  ::
+which are the indices into the line data under the pick point, and the
+``vertex_hit`` property, which indicates which of the indices are of the vertices.
+See `!.Line2D.pick` for details on the ``PickEvent`` properties of the line.  ::
 
     import numpy as np
     import matplotlib.pyplot as plt
@@ -593,8 +594,10 @@ which are the indices into the line data under the pick point.  See
         xdata = thisline.get_xdata()
         ydata = thisline.get_ydata()
         ind = event.ind
-        points = tuple(zip(xdata[ind], ydata[ind]))
+        vertex_hit = event.vertex_hit
+        points = tuple(zip(xdata[ind[vertex_hit]], ydata[ind[vertex_hit]]))
         print('onpick points:', points)
+        print(f'onpick also hit {sum(~vertex_hit)} line edges')
 
     fig.canvas.mpl_connect('pick_event', onpick)
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -23,12 +23,16 @@ import matplotlib.transforms as mtransforms
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
 
 
-def test_segment_hits():
+@pytest.mark.parametrize(
+    "cx,cy,answer", [(553, 902, ([0], 0)), (553, 95, ([0], 1)), (553, 947, ([1], 1))]
+)
+def test_segment_hits(cx, cy, answer):
     """Test a problematic case."""
-    cx, cy = 553, 902
-    x, y = np.array([553., 553.]), np.array([95., 947.])
+    x, y = np.array([553.0, 553.0]), np.array([95.0, 947.0])
     radius = 6.94
-    assert_array_equal(mlines.segment_hits(cx, cy, x, y, radius), [0])
+    res = mlines._segment_hits(cx, cy, x, y, radius)
+    assert_array_equal(res[0],answer[0])
+    assert res[1]==answer[1]
 
 
 # Runtimes on a loaded system are inherently flaky. Not so much that a rerun
@@ -363,6 +367,7 @@ def test_picking():
     found, indices = l1.contains(mouse_event)
     assert found
     assert_array_equal(indices['ind'], [0])
+    assert_array_equal(indices['vertex_hit'], [False])
 
     # And if we modify the pickradius after creation, it should work as well.
     l2, = ax.plot([0, 1], [0, 1], picker=True)
@@ -372,6 +377,21 @@ def test_picking():
     found, indices = l2.contains(mouse_event)
     assert found
     assert_array_equal(indices['ind'], [0])
+    assert_array_equal(indices['vertex_hit'], [False])
+
+    # test the vertex check
+    mouse_event = SimpleNamespace(x=80, y=48)
+    found, indices = l2.contains(mouse_event)
+    assert found
+    assert_array_equal(indices['ind'], [0])
+    assert_array_equal(indices['vertex_hit'], [True])
+
+    # test the vertex check when no edges are shown
+    l3, = ax.plot([0, 1], [0, 1], picker=True, ls='none')
+    found, indices = l3.contains(mouse_event)
+    assert found
+    assert_array_equal(indices['ind'], [0])
+    assert_array_equal(indices['vertex_hit'], [True])
 
 
 @check_figures_equal()


### PR DESCRIPTION
## PR summary

This PR addresses and closes Issue #30944 that I posted earlier. In short, returning more details from the `Line2D.contains()` hit test could eliminate additional computational needs during time-constrained mouse events. Specifically, the PR adds `'is_vert'` boolean array item to the `details` output dict. This item has the same size as the existing `'ind'` item and its element indicates whether the corresponding `'ind'` element. Having `'is_vert'` is handy when the UI requires a different action when user click on a vertex or on an edge. While this check can be done by user later, `Line2D.contains()` already performs this test internally (via `lines.segment_hits()` function). So, why not eliminate the redundant geometric computations.

This PR implements this change by minimally touching `lines.Line2D.contains()` and `lines.segment_hits()` functions without breaking their backward compatibility:

* `lines.segment_hits()` returns the number of vertex hits as an additional `int` value. This value is only returned if the optional `return_is_vert` boolean argument is set to `True`. 
* Given this vertex hit count, `lines.Line2D.contains()` composes the `is_vert` array and adds it to its `details` return dict.

Usage example:

```python

from matplotlib import pyplot as plt

fig, ax = plt.subplots()
line = ax.plot([0,1], [0,1], 'o-')[0]

def on_click(event):

    hit, details = line.contains(event)

    if hit:
        if details['is_vert'][0]:
            print('grab and move only the clicked vertex')
        else:
            print('move the line as a whole without changing shape')

plt.connect('button_press_event', on_click)

plt.show()

```

I have also modified the `pick_event_demo.py` in `galleries/example/event_handling` to demonstrate the new feature.

Documentation and docstrings have been updated to best of my ability. The docstring of `lines.segment_hits()` is not a full-fledged one. So, I just expanded it in the same style.

## PR checklist

- [x] "closes #30944" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
