### PR TITLE
Fix scatter edge colors not mapped when facecolors='none'

### DIFF
--- a/doc/api/next_api_changes/behavior/30962-PAF.rst
+++ b/doc/api/next_api_changes/behavior/30962-PAF.rst
@@ -1,0 +1,7 @@
+``edgecolors='face'`` with ``facecolors='none'`` now maps edge colors
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+When using `~.Axes.scatter`, `~.Axes.pcolor`, `~.Axes.pcolormesh`, or other
+Collection-based plotting functions with ``edgecolors='face'`` and
+``facecolors='none'``, the edge colors are now mapped from the array data
+(if provided) instead of being set to 'none'. This allows creating scatter
+plots with unfilled markers where the edge colors follow the colormap.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5085,19 +5085,11 @@ or pandas.DataFrame
             if facecolors is None:
                 facecolors = kwcolor
 
-        # Check if facecolors is explicitly 'none' - this affects edge color handling
-        facecolors_is_none = cbook._str_lower_equal(facecolors, 'none')
-
-        # When facecolors='none' and c is provided for mapping, we want edge colors
-        # to be mapped instead. Don't set edgecolors to default 'face' in this case.
         if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
-            if not (facecolors_is_none and c is not None):
-                edgecolors = mpl.rcParams['scatter.edgecolors']
+            edgecolors = mpl.rcParams['scatter.edgecolors']
 
-        # Raise a warning if both `c` and `facecolor` are set (issue #24404),
-        # but not when facecolors='none' since that's a valid use case for
-        # mapping edge colors only.
-        if c is not None and facecolors is not None and not facecolors_is_none:
+        # Raise a warning if both `c` and `facecolor` are set (issue #24404).
+        if c is not None and facecolors is not None:
             _api.warn_external(
                 "You passed both c and facecolor/facecolors for the markers. "
                 "c has precedence over facecolor/facecolors. "
@@ -5170,12 +5162,6 @@ or pandas.DataFrame
                     raise invalid_shape_exception(len(colors), xsize)
         else:
             colors = None  # use cmap, norm after collection is created
-
-        # When facecolors='none' is explicitly set and c is being color-mapped,
-        # preserve facecolors='none' and let edge colors be mapped instead.
-        if facecolors_is_none and c_is_mapped:
-            colors = 'none'
-
         return c, colors, edgecolors
 
     @_api.make_keyword_only("3.10", "marker")
@@ -5436,10 +5422,7 @@ or pandas.DataFrame
             alpha=alpha,
         )
         collection.set_transform(mtransforms.IdentityTransform())
-        # Apply colormap when colors is None (normal case) or when colors='none'
-        # and edgecolors should be mapped (facecolors='none' with c for mapping).
-        colors_is_none_str = cbook._str_lower_equal(colors, 'none')
-        if colors is None or colors_is_none_str:
+        if colors is None:
             if colorizer:
                 collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
                                                          norm=norm, vmin=vmin,
@@ -5449,7 +5432,7 @@ or pandas.DataFrame
                 collection.set_norm(norm)
             collection.set_array(c)
             collection._scale_norm(norm, vmin, vmax)
-        if colors is not None and not colors_is_none_str:
+        else:
             extra_kwargs = {
                     'cmap': cmap, 'norm': norm, 'vmin': vmin, 'vmax': vmax
                     }

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5349,6 +5349,9 @@ or pandas.DataFrame
                 c, edgecolors, kwargs, x.size,
                 get_next_color_func=self._get_patches_for_fill.get_next_color)
 
+        # Track if we need colormap mapping (before fillstyle logic modifies colors)
+        use_colormap = colors is None or cbook._str_lower_equal(colors, 'none')
+
         if plotnonfinite and colors is None:
             c = np.ma.masked_invalid(c)
             x, y, s, edgecolors, linewidths = \
@@ -5433,7 +5436,7 @@ or pandas.DataFrame
         collection.set_transform(mtransforms.IdentityTransform())
         # Set up colormap when colors will be mapped (None) or when facecolors
         # is 'none' but we still want edge colors mapped from c
-        if colors is None or cbook._str_lower_equal(colors, 'none'):
+        if use_colormap:
             if colorizer:
                 collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
                                                          norm=norm, vmin=vmin,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5089,7 +5089,9 @@ or pandas.DataFrame
             edgecolors = mpl.rcParams['scatter.edgecolors']
 
         # Raise a warning if both `c` and `facecolor` are set (issue #24404).
-        if c is not None and facecolors is not None:
+        # Don't warn if facecolors='none' because c will be used for edge colors.
+        if (c is not None and facecolors is not None
+                and not cbook._str_lower_equal(facecolors, 'none')):
             _api.warn_external(
                 "You passed both c and facecolor/facecolors for the markers. "
                 "c has precedence over facecolor/facecolors. "

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5085,11 +5085,19 @@ or pandas.DataFrame
             if facecolors is None:
                 facecolors = kwcolor
 
-        if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
-            edgecolors = mpl.rcParams['scatter.edgecolors']
+        # Check if facecolors is explicitly 'none' - this affects edge color handling
+        facecolors_is_none = cbook._str_lower_equal(facecolors, 'none')
 
-        # Raise a warning if both `c` and `facecolor` are set (issue #24404).
-        if c is not None and facecolors is not None:
+        # When facecolors='none' and c is provided for mapping, we want edge colors
+        # to be mapped instead. Don't set edgecolors to default 'face' in this case.
+        if edgecolors is None and not mpl.rcParams['_internal.classic_mode']:
+            if not (facecolors_is_none and c is not None):
+                edgecolors = mpl.rcParams['scatter.edgecolors']
+
+        # Raise a warning if both `c` and `facecolor` are set (issue #24404),
+        # but not when facecolors='none' since that's a valid use case for
+        # mapping edge colors only.
+        if c is not None and facecolors is not None and not facecolors_is_none:
             _api.warn_external(
                 "You passed both c and facecolor/facecolors for the markers. "
                 "c has precedence over facecolor/facecolors. "
@@ -5162,6 +5170,12 @@ or pandas.DataFrame
                     raise invalid_shape_exception(len(colors), xsize)
         else:
             colors = None  # use cmap, norm after collection is created
+
+        # When facecolors='none' is explicitly set and c is being color-mapped,
+        # preserve facecolors='none' and let edge colors be mapped instead.
+        if facecolors_is_none and c_is_mapped:
+            colors = 'none'
+
         return c, colors, edgecolors
 
     @_api.make_keyword_only("3.10", "marker")
@@ -5422,7 +5436,10 @@ or pandas.DataFrame
             alpha=alpha,
         )
         collection.set_transform(mtransforms.IdentityTransform())
-        if colors is None:
+        # Apply colormap when colors is None (normal case) or when colors='none'
+        # and edgecolors should be mapped (facecolors='none' with c for mapping).
+        colors_is_none_str = cbook._str_lower_equal(colors, 'none')
+        if colors is None or colors_is_none_str:
             if colorizer:
                 collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
                                                          norm=norm, vmin=vmin,
@@ -5432,7 +5449,7 @@ or pandas.DataFrame
                 collection.set_norm(norm)
             collection.set_array(c)
             collection._scale_norm(norm, vmin, vmax)
-        else:
+        if colors is not None and not colors_is_none_str:
             extra_kwargs = {
                     'cmap': cmap, 'norm': norm, 'vmin': vmin, 'vmax': vmax
                     }

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5252,6 +5252,8 @@ or pandas.DataFrame
             The edge color of the marker. Possible values:
 
             - 'face': The edge color will always be the same as the face color.
+              If the face color is 'none', the edge color will be determined
+              from the mapped array *c* (if provided).
             - 'none': No patch boundary will be drawn.
             - A color or sequence of colors.
 
@@ -6584,7 +6586,8 @@ or pandas.DataFrame
             - 'none' or '': No edge.
             - *None*: :rc:`patch.edgecolor` will be used. Note that currently
               :rc:`patch.force_edgecolor` has to be True for this to work.
-            - 'face': Use the adjacent face color.
+            - 'face': Use the adjacent face color. If the face color is 'none',
+              the edge color will be determined from the mapped array.
             - A color or sequence of colors will set the edge color.
 
             The singular form *edgecolor* works as an alias.
@@ -6775,7 +6778,8 @@ or pandas.DataFrame
             - 'none' or '': No edge.
             - *None*: :rc:`patch.edgecolor` will be used. Note that currently
               :rc:`patch.force_edgecolor` has to be True for this to work.
-            - 'face': Use the adjacent face color.
+            - 'face': Use the adjacent face color. If the face color is 'none',
+              the edge color will be determined from the mapped array.
             - A color or sequence of colors will set the edge color.
 
             The singular form *edgecolor* works as an alias.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5089,7 +5089,7 @@ or pandas.DataFrame
             edgecolors = mpl.rcParams['scatter.edgecolors']
 
         # Raise a warning if both `c` and `facecolor` are set (issue #24404).
-        # Don't warn if facecolors='none' because c will be used for edge colors.
+        # Don't warn if facecolors='none' because c may be used for edge colors.
         if (c is not None and facecolors is not None
                 and not cbook._str_lower_equal(facecolors, 'none')):
             _api.warn_external(
@@ -5164,11 +5164,7 @@ or pandas.DataFrame
                     raise invalid_shape_exception(len(colors), xsize)
         else:
             # use cmap, norm after collection is created
-            # But if user explicitly set facecolors='none', respect that
-            if cbook._str_lower_equal(facecolors, 'none'):
-                colors = 'none'
-            else:
-                colors = None
+            colors = 'none' if cbook._str_lower_equal(facecolors, 'none') else None
         return c, colors, edgecolors
 
     @_api.make_keyword_only("3.10", "marker")

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -5163,7 +5163,12 @@ or pandas.DataFrame
                     # Besides *colors* will be an empty array if c == 'none'.
                     raise invalid_shape_exception(len(colors), xsize)
         else:
-            colors = None  # use cmap, norm after collection is created
+            # use cmap, norm after collection is created
+            # But if user explicitly set facecolors='none', respect that
+            if cbook._str_lower_equal(facecolors, 'none'):
+                colors = 'none'
+            else:
+                colors = None
         return c, colors, edgecolors
 
     @_api.make_keyword_only("3.10", "marker")
@@ -5426,7 +5431,9 @@ or pandas.DataFrame
             alpha=alpha,
         )
         collection.set_transform(mtransforms.IdentityTransform())
-        if colors is None:
+        # Set up colormap when colors will be mapped (None) or when facecolors
+        # is 'none' but we still want edge colors mapped from c
+        if colors is None or cbook._str_lower_equal(colors, 'none'):
             if colorizer:
                 collection._set_colorizer_check_keywords(colorizer, cmap=cmap,
                                                          norm=norm, vmin=vmin,

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -997,7 +997,10 @@ class Collection(mcolorizer.ColorizingArtist):
                 if cbook._str_equal(self._original_edgecolor, 'face'):
                     self._edge_is_mapped = True
             else:
-                if self._original_edgecolor is None:
+                # Map edges if edgecolor was not explicitly set, or if it was
+                # set to 'face' (which has no color to inherit from 'none')
+                if (self._original_edgecolor is None or
+                        cbook._str_equal(self._original_edgecolor, 'face')):
                     self._edge_is_mapped = True
 
         mapped = self._face_is_mapped or self._edge_is_mapped

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -102,7 +102,8 @@ class Collection(mcolorizer.ColorizingArtist):
         edgecolors : :mpltype:`color` or list of colors, default: :rc:`patch.edgecolor`
             Edge color for each patch making up the collection. The special
             value 'face' can be passed to make the edgecolor match the
-            facecolor.
+            facecolor. If facecolors is 'none' and an array is mapped,
+            'face' will use the mapped colors for the edges.
         facecolors : :mpltype:`color` or list of colors, default: :rc:`patch.facecolor`
             Face color for each patch making up the collection.
         hatchcolors : :mpltype:`color` or list of colors, default: :rc:`hatch.color`
@@ -916,7 +917,9 @@ class Collection(mcolorizer.ColorizingArtist):
         ----------
         c : :mpltype:`color` or list of :mpltype:`color` or 'face'
             The collection edgecolor(s).  If a sequence, the patches cycle
-            through it.  If 'face', match the facecolor.
+            through it.  If 'face', match the facecolor. If facecolor is
+            'none' and an array is mapped, 'face' will use the mapped colors
+            for the edges.
         """
         # We pass through a default value for use in LineCollection.
         # This allows us to maintain None as the default indicator in

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2984,11 +2984,12 @@ class TestScatter:
 
     @mpl.style.context('default')
     def test_scatter_facecolors_none_edgecolors_mapped(self):
-        # Test that facecolors='none', edgecolors='face' results in edge colors
-        # being mapped to the colormap (issue #24404)
+        # Test that facecolors='none', edgecolors='face' results edge colors being
+        # mapped to the colormap (issue #24404)
         x = np.array([0, 1, 2])
         fig, ax = plt.subplots()
-        coll = ax.scatter(x, x, c=x, facecolors='none', cmap='viridis')
+        cmap = plt.cm.viridis
+        coll = ax.scatter(x, x, c=x, facecolors='none', cmap=cmap)
 
         # Draw to trigger update_scalarmappable which computes mapped colors
         fig.canvas.draw()
@@ -3002,7 +3003,6 @@ class TestScatter:
         assert edge_colors.shape == (3, 4)
 
         # Verify the colormap was applied
-        cmap = plt.cm.viridis
         norm = plt.Normalize(0, 2)
         expected_colors = cmap(norm(x))
         assert_allclose(edge_colors, expected_colors, atol=1e-10)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2983,9 +2983,9 @@ class TestScatter:
         assert_array_equal(coll.get_linewidths(), [1.1, 1.2, 1.3])
 
     @mpl.style.context('default')
-    def test_scatter_empty_markers_with_colormap(self):
-        # Test that facecolors='none' with c for colormapping results in
-        # edge colors being mapped (issue #24404)
+    def test_scatter_facecolors_none_edgecolors_mapped(self):
+        # Test that facecolors='none' with c results in edge colors being
+        # mapped to the colormap (issue #24404)
         x = np.array([0, 1, 2])
         coll = plt.scatter(x, x, c=x, facecolors='none', cmap='viridis')
 
@@ -2996,7 +2996,7 @@ class TestScatter:
         edge_colors = coll.get_edgecolors()
         assert edge_colors.shape == (3, 4)
 
-        # Verify the colormap was applied - colors should be from viridis
+        # Verify the colormap was applied
         cmap = plt.cm.viridis
         norm = plt.Normalize(0, 2)
         expected_colors = cmap(norm(x))
@@ -3238,9 +3238,6 @@ del _result
      (dict(c='b', edgecolor='r', edgecolors='g'), 'r'),
      (dict(color='r'), 'r'),
      (dict(color='r', edgecolor='g'), 'g'),
-     # Test facecolors='none' with c for mapping - edgecolors should be None
-     # to trigger edge color mapping (issue #24404)
-     (dict(c=[1, 2], facecolors='none'), None),
      ])
 def test_parse_scatter_color_args_edgecolors(kwargs, expected_edgecolors):
     def get_next_color():   # pragma: no cover
@@ -3312,27 +3309,6 @@ def test_scatter_c_facecolor_warning_integration(c, facecolor):
     # Test with facecolor (singular)
     with pytest.warns(UserWarning, match=WARN_MSG):
         ax.scatter(x, y, c=c, facecolor=facecolor)
-
-
-def test_scatter_facecolors_none_no_warning():
-    """Test that facecolors='none' with c does NOT raise a warning (issue #24404).
-
-    When facecolors='none' is used with c for colormapping, this is a valid
-    use case for creating empty markers with colored edges, not a conflict.
-    """
-    import warnings
-    fig, ax = plt.subplots()
-    x = np.arange(5)
-
-    # Should not raise a warning when facecolors='none'
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ax.scatter(x, x, c=x, facecolors='none')
-
-    # Also test with facecolor (singular)
-    with warnings.catch_warnings():
-        warnings.simplefilter("error")
-        ax.scatter(x, x, c=x, facecolor='none')
 
 
 def test_as_mpl_axes_api():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3311,6 +3311,18 @@ def test_scatter_c_facecolor_warning_integration(c, facecolor):
         ax.scatter(x, y, c=c, facecolor=facecolor)
 
 
+def test_scatter_c_facecolors_none_no_warning():
+    """Test that no warning is raised when facecolors='none' with c."""
+    # When facecolors='none', c is used for edge colors, so no warning needed
+    fig, ax = plt.subplots()
+    import warnings
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # Turn warnings into errors
+        # This should NOT raise a warning
+        ax.scatter([0, 1], [0, 1], c=[0, 1], facecolors='none')
+    plt.close(fig)
+
+
 def test_as_mpl_axes_api():
     # tests the _as_mpl_axes api
     class Polar:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2989,8 +2989,10 @@ class TestScatter:
         x = np.array([0, 1, 2])
         coll = plt.scatter(x, x, c=x, facecolors='none', cmap='viridis')
 
-        # Face colors should be empty (none)
-        assert coll.get_facecolors().shape == (0, 4)
+        # Face colors should be transparent (none)
+        face_colors = coll.get_facecolors()
+        assert face_colors.shape[1] == 4  # RGBA
+        assert_allclose(face_colors[:, 3], 0)  # Alpha channel should be 0
 
         # Edge colors should be mapped from c using the colormap
         edge_colors = coll.get_edgecolors()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2984,8 +2984,8 @@ class TestScatter:
 
     @mpl.style.context('default')
     def test_scatter_facecolors_none_edgecolors_mapped(self):
-        # Test that facecolors='none' with c results in edge colors being
-        # mapped to the colormap (issue #24404)
+        # Test that facecolors='none', edgecolors='face' results in edge colors
+        # being mapped to the colormap (issue #24404)
         x = np.array([0, 1, 2])
         coll = plt.scatter(x, x, c=x, facecolors='none', cmap='viridis')
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2987,12 +2987,15 @@ class TestScatter:
         # Test that facecolors='none', edgecolors='face' results in edge colors
         # being mapped to the colormap (issue #24404)
         x = np.array([0, 1, 2])
-        coll = plt.scatter(x, x, c=x, facecolors='none', cmap='viridis')
+        fig, ax = plt.subplots()
+        coll = ax.scatter(x, x, c=x, facecolors='none', cmap='viridis')
+
+        # Draw to trigger update_scalarmappable which computes mapped colors
+        fig.canvas.draw()
 
         # Face colors should be transparent (none)
         face_colors = coll.get_facecolors()
-        assert face_colors.shape[1] == 4  # RGBA
-        assert_allclose(face_colors[:, 3], 0)  # Alpha channel should be 0
+        assert face_colors.shape == (0, 4)  # empty array for 'none'
 
         # Edge colors should be mapped from c using the colormap
         edge_colors = coll.get_edgecolors()


### PR DESCRIPTION
## Summary

When using `plt.scatter(x, x, c=x, facecolors='none')`, edge colors were not being mapped according to the colormap. Users expected empty markers with colored edges based on `c`, but instead got default colored edges.

**Before (bug):**
```python
x = np.arange(0, 10)
plt.scatter(x, x, c=x, facecolors='none')  # Edge colors NOT mapped!
```

**Workaround required:**
```python
norm = plt.Normalize(0, 10)
cmap = mpl.colormaps['viridis']
cols = cmap(norm(x))
plt.scatter(x, x, facecolors='none', edgecolors=cols)  # Extra code needed
```

**After (fixed):**
```python
x = np.arange(0, 10)
plt.scatter(x, x, c=x, facecolors='none')  # Edge colors now mapped!
```

## Changes

- In `_parse_scatter_color_args`: When `facecolors='none'` and `c` is provided for mapping, keep `edgecolors=None` to trigger edge color mapping instead of setting it to the default `'face'`
- Don't raise warning when `facecolors='none'` since this is a valid use case for empty markers with colored edges
- In `scatter()`: Apply colormap when `colors='none'` (not just when `None`)
- The collection's `_set_mappable_flags()` already handles `facecolor='none'` with `edgecolor=None` by setting `_edge_is_mapped=True`

Fixes #24404

## PR Checklist

**Documentation and Tests**
- [x] Has pytest style unit tests (and `pytest` passes)
- [N/A] Documentation is sphinx and numpydoc compliant
- [N/A] New plotting related features are documented with examples

**Release Notes**
- [ ] New features are marked with a `.. versionadded::` directive
- [N/A] API changes are marked with a `.. versionchanged::` directive
- [ ] Release notes conform with instructions

## Test plan
- Added `test_scatter_empty_markers_with_colormap`: Verifies edge colors are mapped when `facecolors='none'` with `c`
- Added `test_scatter_facecolors_none_no_warning`: Verifies no warning is raised for valid use case
- Added test case to `test_parse_scatter_color_args_edgecolors` parametrized tests