### PR TITLE
MNT: Deprecate rcParams._get("backend")

### DIFF
--- a/doc/api/next_api_changes/deprecations/30963-TH.rst
+++ b/doc/api/next_api_changes/deprecations/30963-TH.rst
@@ -1,0 +1,7 @@
+``rcParams._get("backend")``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``rcParams._get("backend")`` is deprecated. Instead, use the public API
+``matplotlib.get_backend(auto_select=False)`` to retrieve the current
+backend without triggering backend resolution. This API is available since
+Matplotlib 3.10.


### PR DESCRIPTION
since 3.10 we have the official API `matplotlib.get_backend (auto_select=False)`. No problems have been reported and [matplotlib-inline is using it](https://github.com/ipython/matplotlib-inline/pull/38). Therefore, I remove the provisional status from the auto-select flag.

Additionally, I deprecate the API `rcParams._get('backend')`, which the above is replacing.

It seems that `rcParams._get("backend")` is not used anywhere publically, but let's still be defensive and deprecate.

https://github.com/search?q=%2F%5C._get%5C%28%5B%22%27%5Dbackend%5B%22%27%5D%5C%29%2F+language%3APython+NOT+is%3Afork+NOT+path%3A**%2Fmatplotlib%2F**+NOT+path%3A**%2Fsite-packages**+NOT+path%3A**%2Fpyplot.py&type=code

This is working towards removal of dynamic backend state from rcParams #26406.
Follow-up to #29039.
