### PR TITLE
ENH: Support Figure.add_axes() without parameters

### DIFF
--- a/doc/release/next_whats_new/add_axes.rst
+++ b/doc/release/next_whats_new/add_axes.rst
@@ -1,0 +1,7 @@
+``Figure.add_axes()`` without parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+`.Figure.add_axes` can now be called without parameters to add a full-figure
+`~.axes.Axes`. This is equivalent to calling ``fig.add_subplot()`` without
+parameters. This also creates the same Axes as ``fig, ax = plt.subplots()``
+does.

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -535,8 +535,19 @@ default: %(va)s
 
         Call signatures::
 
+            add_axes()
             add_axes(rect, projection=None, polar=False, **kwargs)
             add_axes(ax)
+
+        Without parameters a "standard" Axes is created that fills the figure.
+        ``fig = plt.figure(), ax = fig.add_axes()`` is equivalent to
+        ``fig, ax = plt.subplots()``.
+
+        If a *rect* tuple is passed, a new Axes is created at the given figure
+        coordinates.
+
+        Passing an existing `~.axes.Axes` instance *ax* adds it to the figure.
+        This is only for rare use cases. See the notes section below.
 
         Parameters
         ----------
@@ -613,15 +624,17 @@ default: %(va)s
             fig.delaxes(ax)
             fig.add_axes(ax)
         """
-
-        if not len(args) and 'rect' not in kwargs:
-            raise TypeError("add_axes() missing 1 required positional argument: 'rect'")
-        elif 'rect' in kwargs:
+        if 'rect' in kwargs:
+            # handle add_axes(rect=[...]) as add_axes([...])
             if len(args):
                 raise TypeError("add_axes() got multiple values for argument 'rect'")
             args = (kwargs.pop('rect'), )
-        if len(args) != 1:
-            raise _api.nargs_error("add_axes", 1, len(args))
+
+        if len(args) > 1:
+            raise _api.nargs_error("add_axes", "0 or 1", len(args))
+
+        if not args:
+            return self.add_subplot()
 
         if isinstance(args[0], Axes):
             a, = args
@@ -648,10 +661,10 @@ default: %(va)s
 
         Call signatures::
 
+           add_subplot()
            add_subplot(nrows, ncols, index, **kwargs)
            add_subplot(pos, **kwargs)
            add_subplot(ax)
-           add_subplot()
 
         Parameters
         ----------

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -10,6 +10,7 @@ import warnings
 import numpy as np
 import pytest
 from PIL import Image
+from numpy.testing import assert_array_equal
 
 import matplotlib as mpl
 from matplotlib import gridspec
@@ -534,11 +535,14 @@ def test_invalid_figure_size(width, height):
         fig.set_size_inches(width, height)
 
 
+def test_add_axes():
+    fig, ax = plt.subplots()
+    ax2 = plt.figure(2).add_axes()
+    assert_array_equal(ax2.get_position().get_points(), ax.get_position().get_points())
+
+
 def test_invalid_figure_add_axes():
     fig = plt.figure()
-    with pytest.raises(TypeError,
-                       match="missing 1 required positional argument: 'rect'"):
-        fig.add_axes()
 
     with pytest.raises(ValueError):
         fig.add_axes((.1, .1, .5, np.nan))
@@ -553,10 +557,10 @@ def test_invalid_figure_add_axes():
         fig.add_axes(ax)
 
     fig2.delaxes(ax)
-    with pytest.raises(TypeError, match=r"add_axes\(\) takes 1 positional arguments"):
+    with pytest.raises(TypeError, match=r"add_axes\(\) takes 0 or 1 positional"):
         fig2.add_axes(ax, "extra positional argument")
 
-    with pytest.raises(TypeError, match=r"add_axes\(\) takes 1 positional arguments"):
+    with pytest.raises(TypeError, match=r"add_axes\(\) takes 0 or 1 positional"):
         fig.add_axes((0, 0, 1, 1), "extra positional argument")
 
 


### PR DESCRIPTION
This extends `Figure.add_axes()` so that it works without parameters and creates a single subplot Axes. So far, you'd have to pass a `rect` tuple or and `Axes`.

In particular:
- `fig.add_axes()` is equivalent to `fig.add_subplot()`; in the limiting case without parameters.
- `plt.figure().add_axes()` creates the same figure and axes objects as `fig, ax = plt.subplots()`
- `plt.figure().add_axes()` creates the same figure and axes objects as `plt.axes()`

**Why is this addition reasonable?**
This provides yet another way to create an Axes. We already have so many ways, doesn't this add more to the confusion?

The arguments are:
1) Expected behavior: If I have an `add_axes()` function, it's natural to expect that a can add a "default" Axes with out having to specify additional parameters. 
2) API consistency: `plt.axes()` already has this behavior. By extending `fig.add_axes()` we gain identical behavior on both methods.
3) One could argue that `add_subplot()` already does this, so people should use it instead. The point here is that I don't think we should stress formal distinction between subplot and Axes for one figure-filling Axes. In particular I would like to de-emphasize subplot as written in https://github.com/matplotlib/matplotlib/pull/30952#issuecomment-3751861464

   *Edit* Somehow the link to the comment does not work, but it's this one; please go there manually if needd:
   
   <img width="799" height="172" alt="grafik" src="https://github.com/user-attachments/assets/4307a564-d66c-4e30-a29d-d80108559c16" />


    This would also make the shortcut sequence from #30952 more consistent:
    - `fig, ax = plt.subplots()`
    - `ax = plt.figure().add_axes()`
    - `ax = plt.axes()`
    As soon as the function changes from potentially creating multiple Axes to creating only one Axes, we switch terminology from "subplots" to "axes".

Overall, since the ship on minimal axes creation API has sailed, adding one more way does not significantly worsen the complexity situation. But as a positive effect, we gain more consistency and can tell a better story on Axes creation using a subset of all that is possible.

