### PR TITLE
DOC: Simplify barh() example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/barh.py
+++ b/galleries/examples/lines_bars_and_markers/barh.py
@@ -15,12 +15,10 @@ fig, ax = plt.subplots()
 
 # Example data
 people = ('Tom', 'Dick', 'Harry', 'Slim', 'Jim')
-y_pos = np.arange(len(people))
 performance = 3 + 10 * np.random.rand(len(people))
 error = np.random.rand(len(people))
 
-ax.barh(y_pos, performance, xerr=error, align='center')
-ax.set_yticks(y_pos, labels=people)
+ax.barh(people, performance, xerr=error, align='center')
 ax.invert_yaxis()  # labels read top-to-bottom
 ax.set_xlabel('Performance')
 ax.set_title('How fast do you want to go today?')


### PR DESCRIPTION
Directly use categorical data as positions instead of numeric data + tick adjustment
