### PR TITLE
DOC: Move spectral plot examples from lines to statistics

### DIFF
--- a/doc/release/prev_whats_new/whats_new_0.98.4.rst
+++ b/doc/release/prev_whats_new/whats_new_0.98.4.rst
@@ -138,7 +138,7 @@ psd amplitude scaling
 
 Ryan May did a lot of work to rationalize the amplitude scaling of
 :func:`~matplotlib.pyplot.psd` and friends.  See
-:doc:`/gallery/lines_bars_and_markers/psd_demo`.
+:doc:`/gallery/statistics/psd_demo`.
 The changes should increase MATLAB
 compatibility and increase scaling options.
 

--- a/galleries/examples/statistics/cohere.py
+++ b/galleries/examples/statistics/cohere.py
@@ -4,6 +4,8 @@ Plotting the coherence of two signals
 =====================================
 
 An example showing how to plot the coherence of two signals using `~.Axes.cohere`.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/cohere
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/galleries/examples/statistics/csd_demo.py
+++ b/galleries/examples/statistics/csd_demo.py
@@ -4,6 +4,8 @@ Cross spectral density (CSD)
 ============================
 
 Plot the cross spectral density (CSD) of two signals using `~.Axes.csd`.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/csd_demo
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/galleries/examples/statistics/psd_demo.py
+++ b/galleries/examples/statistics/psd_demo.py
@@ -8,6 +8,8 @@ Plotting power spectral density (PSD) using `~.Axes.psd`.
 The PSD is a common plot in the field of signal processing. NumPy has
 many useful libraries for computing a PSD. Below we demo a few examples
 of how this can be accomplished and visualized with Matplotlib.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/psd_demo
 """
 import matplotlib.pyplot as plt
 import numpy as np

--- a/galleries/examples/statistics/xcorr_acorr_demo.py
+++ b/galleries/examples/statistics/xcorr_acorr_demo.py
@@ -5,6 +5,8 @@ Cross- and auto-correlation
 
 Example use of cross-correlation (`~.Axes.xcorr`) and auto-correlation
 (`~.Axes.acorr`) plots.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/xcorr_acorr_demo
 """
 import matplotlib.pyplot as plt
 import numpy as np


### PR DESCRIPTION
In fact these are statistical quantities, and with hist, boxplot etc.
they share the property that they do not directly visualize the input
data but some quantity derived from them.

Please keep both commits separate, so that git understands that the files were moved and subsequently edited and not deleted and re-created.