### PR TITLE
Use LOCALAPPDATA for config/cache directories on Windows

### DIFF
--- a/doc/api/next_api_changes/behavior/30975-VM.rst
+++ b/doc/api/next_api_changes/behavior/30975-VM.rst
@@ -1,0 +1,9 @@
+Windows configuration directory location
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On Windows, the default configuration and cache directories now use
+``%LOCALAPPDATA%\matplotlib`` instead of ``%USERPROFILE%\.matplotlib``.
+This follows Windows application data storage conventions.
+
+The ``MPLCONFIGDIR`` environment variable can still be used to override
+this default.


### PR DESCRIPTION
## Summary

On Windows, the default configuration and cache directories now use `%LOCALAPPDATA%\matplotlib` instead of `%USERPROFILE%\.matplotlib`, following Windows application data storage conventions.

This addresses the issue where matplotlib was placing its config folder directly in the user's home directory (`%USERPROFILE%`), which is not the recommended location on Windows.

## Changes

- Modified `_get_config_or_cache_dir()` to check for Windows (`sys.platform == 'win32'`) and use `%LOCALAPPDATA%` when available
- Falls back to `%USERPROFILE%\.matplotlib` if `LOCALAPPDATA` is not set
- Updated docstrings for `get_configdir()` and `get_cachedir()` to document the Windows behavior
- Added a test for the Windows-specific behavior
- Added behavior change documentation

## References

- Windows app data storage: https://docs.microsoft.com/en-us/windows/apps/design/app-settings/store-and-retrieve-app-data
- Discussion in issue about using proper Windows paths

Closes #20779