### PR TITLE
MNT: remove redundant normalization from set

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1253,8 +1253,8 @@ Supported properties are
 
     def _internal_update(self, kwargs):
         """
-        Update artist properties without prenormalizing them, but generating
-        errors as if calling `set`.
+        Update artist properties generating errors as if calling `set`, but
+        without unpacking the dictionary to **kwargs.
 
         The lack of prenormalization is to maintain backcompatibility.
         """
@@ -1266,7 +1266,7 @@ Supported properties are
         # docstring and signature are auto-generated via
         # Artist._update_set_signature_and_docstring() at the end of the
         # module.
-        return self._internal_update(cbook.normalize_kwargs(kwargs, self))
+        return self._internal_update(kwargs)
 
     @contextlib.contextmanager
     def _cm_set(self, **kwargs):

--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -377,6 +377,16 @@ def test_set_is_overwritten():
     assert MyArtist4.set is MyArtist3.set
 
 
+def test_set():
+    line = mlines.Line2D([], [])
+    line.set(linewidth=7)
+    assert line.get_linewidth() == 7
+
+    # Property aliases should work
+    line.set(lw=5)
+    assert line.get_linewidth() == 5
+
+
 def test_format_cursor_data_BoundaryNorm():
     """Test if cursor data is correct when using BoundaryNorm."""
     X = np.empty((3, 3))


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
Inspired by #30957

The normalization is not needed here because the alias forms of the `set_*` methods can be called.  So we can save ourselves microseconds :rocket: 

Before:

```python
In [5]: %timeit line.set(lw=3, color='r', ls='--')
12.3 μs ± 116 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
After:
```python
In [8]: %timeit line.set(lw=3, color='r', ls='--')
10.9 μs ± 76.5 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```