### PR TITLE
Improve findfont cache invalidation.

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -1344,9 +1344,11 @@ class FontManager:
         # Pass the relevant rcParams (and the font manager, as `self`) to
         # _findfont_cached so to prevent using a stale cache entry after an
         # rcParam was changed.
-        rc_params = tuple(tuple(mpl.rcParams[key]) for key in [
-            "font.serif", "font.sans-serif", "font.cursive", "font.fantasy",
-            "font.monospace"])
+        rc_params = [mpl.rcParams[f"font.{key}"] for key in [
+            "family", "style", "variant", "weight", "stretch", "size",
+            "serif", "sans-serif", "cursive", "fantasy", "monospace"]]
+        rc_params = tuple(tuple(e) if isinstance(e, list) else e
+                          for e in rc_params)  # Make this hashable.
         ret = self._findfont_cached(
             prop, fontext, directory, fallback_to_default, rebuild_if_missing,
             rc_params)

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -434,3 +434,17 @@ def test_font_match_warning(caplog):
     findfont(FontProperties(family=["DejaVu Sans"], weight=750))
     logs = [rec.message for rec in caplog.records]
     assert 'findfont: Failed to find font weight 750, now using 700.' in logs
+
+
+def test_mutable_fontproperty_cache_invalidation():
+    fp = FontProperties()
+    assert findfont(fp).endswith("DejaVuSans.ttf")
+    fp.set_weight("bold")
+    assert findfont(fp).endswith("DejaVuSans-Bold.ttf")
+
+
+def test_fontproperty_default_cache_invalidation():
+    mpl.rcParams["font.weight"] = "normal"
+    assert findfont("DejaVu Sans").endswith("DejaVuSans.ttf")
+    mpl.rcParams["font.weight"] = "bold"
+    assert findfont("DejaVu Sans").endswith("DejaVuSans-Bold.ttf")


### PR DESCRIPTION
Resolution of fontproperties also depends on the default values of FontProperties attributes.  This fix is tested by the new test_fontproperty_default_cache_invalidation.

test_mutable_fontproperty_cache_invalidation is a separate test (which was already passing before), but also checks a useful property: mutating a FontProperty instance should invalidate its corresponding cache.

Closes #23860.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
