### PR TITLE
PERF: Speed up ticks processing when not visible or using a NullLocator

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1335,6 +1335,8 @@ class Axis(martist.Artist):
             minor_ticks = []
 
         ticks = [*major_ticks, *minor_ticks]
+        if not ticks:
+            return []
 
         view_low, view_high = self.get_view_interval()
         if view_low > view_high:


### PR DESCRIPTION
## PR summary
Towards https://github.com/matplotlib/matplotlib/issues/5665

This shortcuts major or minor ticks processing when they are set to not visible, or their locators are NullLocators. In theory, NullLocators just return an empty list, but in practice its parent class does a fair amount of work during initialization that we don't need.

Here's a representative profiling run looking at `_update_ticks()`. The red circled bit shows the work done by `get_minorticklocs` which is skipped with this PR, roughly 30% of the function call time. This is pretty significant since `_update_ticks` is called 3x per draw for 2D and 2x per draw for 3D plots. In my test script which draws an empty 3D plot, skipping minor ticks saves 5% of the total draw time.

<img width="2577" height="561" alt="image" src="https://github.com/user-attachments/assets/58ff35d3-2ec2-49c4-8acf-efa42515ac80" />


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines