### PR TITLE
PERF: Skip kwargs normalization in Artist._cm_set

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1292,13 +1292,11 @@ Supported properties are
     @contextlib.contextmanager
     def _cm_set(self, **kwargs):
         """
-        `.Artist.set` context-manager that restores original values at exit.
-        This skips the `normalize_kwargs` check, for performance.
-        """
-        if not kwargs:
-            yield
-            return
+        A context manager to temporarily set artist properties.
 
+        In contrast to `.Artist.set` and for performance, this skips the
+        `normalize_kwargs` check.
+        """
         orig_vals = {k: getattr(self, f"get_{k}")() for k in kwargs}
         try:
             self._internal_update({k: kwargs[k] for k in orig_vals})


### PR DESCRIPTION
## PR summary
`_cm_set` is called during every `Text.draw()` to handle text wrapping, but most text has wrapping disabled so `_get_wrapped_text()` returns the original text unchanged. The old code would always set and restore the value, but we can safely bypass that if the updated value is identical to the current.

This bit of code was using 5.5% of total draw time in my benchmark script that renders an empty plot, now dropped down to 1%
<img width="1916" height="372" alt="image" src="https://github.com/user-attachments/assets/bec03086-b03d-4dc2-b40f-673faf50a55c" />

```python
import time
import matplotlib.pyplot as plt

print("Starting...")

fig = plt.figure()
ax = fig.add_subplot(111, projection='3d')

print("Timing...")

start_time = time.perf_counter()
for i in range(100):
    ax.view_init(elev=i, azim=i)
    fig.canvas.draw()
end_time = time.perf_counter()
plt.close()

print(f"Time taken: {end_time - start_time:.4f} seconds")

```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines