### PR TITLE
PERF: Cache ticks and ticklabel bboxes within each draw cycle

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3224,8 +3224,7 @@ class _AxesBase(martist.Artist):
 
         # Clear axis tick caches for this draw cycle
         for _axis in self._axis_map.values():
-            _axis._cached_ticks_to_draw = None
-            _axis._cached_ticklabel_bboxes = None
+            _axis._clear_ticks_cache()
 
         if not self.axison:
             for _axis in self._axis_map.values():

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3222,6 +3222,11 @@ class _AxesBase(martist.Artist):
 
         self._update_title_position(renderer)
 
+        # Clear axis tick caches for this draw cycle
+        for _axis in self._axis_map.values():
+            _axis._cached_ticks_to_draw = None
+            _axis._cached_ticklabel_bboxes = None
+
         if not self.axison:
             for _axis in self._axis_map.values():
                 artists.remove(_axis)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1415,17 +1415,18 @@ class Axis(martist.Artist):
             return
         if renderer is None:
             renderer = self.get_figure(root=True)._get_renderer()
-        # Don't use cached values here - get_tightbbox() is called during
-        # layout calculations (e.g., constrained_layout) outside of draw(),
-        # and must always recalculate to reflect current state.
+        # We need to reset the ticks cache here - get_tightbbox() is called
+        # during layout calculations (e.g., constrained_layout) outside of
+        # draw(), and must always recalculate to reflect current state.
         self._clear_ticks_cache()
-        ticks_to_draw = self._update_ticks(_use_cache=False)
 
-        self._update_label_position(renderer, _use_cache=False)
+        ticks_to_draw = self._update_ticks(_use_cache=True)
+
+        self._update_label_position(renderer, _use_cache=True)
 
         # go back to just this axis's tick labels
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
-                                                _use_cache=False)
+                                                _use_cache=True)
 
         self._update_offset_text_position(tlb1, tlb2)
         self.offsetText.set_text(self.major.formatter.get_offset())
@@ -1451,6 +1452,8 @@ class Axis(martist.Artist):
                     bb.y1 = bb.y0 + 1.0
             bboxes.append(bb)
         bboxes = [b for b in bboxes if b._is_finite()]
+        self._clear_ticks_cache()
+
         if bboxes:
             return mtransforms.Bbox.union(bboxes)
         else:
@@ -1472,6 +1475,8 @@ class Axis(martist.Artist):
             return
         renderer.open_group(__name__, gid=self.get_gid())
 
+        self._clear_ticks_cache()
+
         ticks_to_draw = self._update_ticks(_use_cache=True)
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
                                                 _use_cache=True)
@@ -1488,10 +1493,8 @@ class Axis(martist.Artist):
         self.offsetText.draw(renderer)
 
         renderer.close_group(__name__)
-        self.stale = False
-
-        # Reset cached values for next draw cycle, in case not called by Axes.draw()
         self._clear_ticks_cache()
+        self.stale = False
 
     def get_gridlines(self):
         r"""Return this Axis' grid lines as a list of `.Line2D`\s."""

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1305,6 +1305,10 @@ class Axis(martist.Artist):
                 kw.get('label2On') is not False or
                 kw.get('gridOn') is not False)
 
+    def _clear_ticks_cache(self):
+        self._cached_ticks_to_draw = None
+        self._cached_ticklabel_bboxes = None
+
     def _update_ticks(self, *, _use_cache=False):
         """
         Update ticks (position and labels) using the current data interval of
@@ -1414,6 +1418,7 @@ class Axis(martist.Artist):
         # Don't use cached values here - get_tightbbox() is called during
         # layout calculations (e.g., constrained_layout) outside of draw(),
         # and must always recalculate to reflect current state.
+        self._clear_ticks_cache()
         ticks_to_draw = self._update_ticks(_use_cache=False)
 
         self._update_label_position(renderer, _use_cache=False)
@@ -1486,8 +1491,7 @@ class Axis(martist.Artist):
         self.stale = False
 
         # Reset cached values for next draw cycle, in case not called by Axes.draw()
-        self._cached_ticks_to_draw = None
-        self._cached_ticklabel_bboxes = None
+        self._clear_ticks_cache()
 
     def get_gridlines(self):
         r"""Return this Axis' grid lines as a list of `.Line2D`\s."""

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1529,7 +1529,7 @@ class Axis(martist.Artist):
 
     def get_majorticklabels(self):
         """Return this Axis' major tick labels, as a list of `~.text.Text`."""
-        self._update_ticks()
+        self._update_ticks(_use_cache=False)
         ticks = self.get_major_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]
@@ -1537,7 +1537,7 @@ class Axis(martist.Artist):
 
     def get_minorticklabels(self):
         """Return this Axis' minor tick labels, as a list of `~.text.Text`."""
-        self._update_ticks()
+        self._update_ticks(_use_cache=False)
         ticks = self.get_minor_ticks()
         labels1 = [tick.label1 for tick in ticks if tick.label1.get_visible()]
         labels2 = [tick.label2 for tick in ticks if tick.label2.get_visible()]

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -674,6 +674,7 @@ class Axis(martist.Artist):
         self._minor_tick_kw = dict()
 
         self._cached_ticks_to_draw = None
+        self._cached_ticklabel_bboxes = None
 
         if clear:
             self.clear()
@@ -1377,14 +1378,22 @@ class Axis(martist.Artist):
         self._cached_ticks_to_draw = ticks_to_draw
         return ticks_to_draw
 
-    def _get_ticklabel_bboxes(self, ticks, renderer):
+    def _get_ticklabel_bboxes(self, ticks, renderer, *, _use_cached=False):
         """Return lists of bboxes for ticks' label1's and label2's."""
-        return ([tick.label1.get_window_extent(renderer)
-                 for tick in ticks
-                 if tick.label1.get_visible() and tick.label1.get_in_layout()],
-                [tick.label2.get_window_extent(renderer)
-                 for tick in ticks
-                 if tick.label2.get_visible() and tick.label2.get_in_layout()])
+        # Return cached result if available and requested
+        if _use_cached and self._cached_ticklabel_bboxes is not None:
+            return self._cached_ticklabel_bboxes
+
+        result = ([tick.label1.get_window_extent(renderer)
+                   for tick in ticks
+                   if tick.label1.get_visible() and tick.label1.get_in_layout()],
+                  [tick.label2.get_window_extent(renderer)
+                   for tick in ticks
+                   if tick.label2.get_visible() and tick.label2.get_in_layout()])
+
+        # Cache the result before returning
+        self._cached_ticklabel_bboxes = result
+        return result
 
     def get_tightbbox(self, renderer=None, *, for_layout_only=False):
         """
@@ -1408,7 +1417,8 @@ class Axis(martist.Artist):
         self._update_label_position(renderer)
 
         # go back to just this axis's tick labels
-        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
+        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
+                                                _use_cached=False)
 
         self._update_offset_text_position(tlb1, tlb2)
         self.offsetText.set_text(self.major.formatter.get_offset())
@@ -1455,11 +1465,13 @@ class Axis(martist.Artist):
             return
         renderer.open_group(__name__, gid=self.get_gid())
 
-        # Clear tick cache for this draw cycle
+        # Clear caches for this draw cycle
         self._cached_ticks_to_draw = None
+        self._cached_ticklabel_bboxes = None
 
         ticks_to_draw = self._update_ticks(_use_cached=True)
-        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
+        tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
+                                                _use_cached=True)
 
         for tick in ticks_to_draw:
             tick.draw(renderer)
@@ -2296,7 +2308,8 @@ class Axis(martist.Artist):
         for ax in grouper.get_siblings(self.axes):
             axis = ax._axis_map[name]
             ticks_to_draw = axis._update_ticks(_use_cached=True)
-            tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer)
+            tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer,
+                                                   _use_cached=True)
             bboxes.extend(tlb)
             bboxes2.extend(tlb2)
         return bboxes, bboxes2

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -673,6 +673,8 @@ class Axis(martist.Artist):
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
 
+        self._cached_ticks_to_draw = None
+
         if clear:
             self.clear()
         else:
@@ -1302,11 +1304,15 @@ class Axis(martist.Artist):
                 kw.get('label2On') is not False or
                 kw.get('gridOn') is not False)
 
-    def _update_ticks(self):
+    def _update_ticks(self, *, _use_cached=False):
         """
         Update ticks (position and labels) using the current data interval of
         the axes.  Return the list of ticks that will be drawn.
         """
+        # Return cached result if available and requested
+        if _use_cached and self._cached_ticks_to_draw is not None:
+            return self._cached_ticks_to_draw
+
         # Check if major ticks should be computed.
         # Skip if using NullLocator or if all visible components are off.
         if (self._tick_group_visible(self._major_tick_kw)
@@ -1367,6 +1373,8 @@ class Axis(martist.Artist):
                 if mtransforms._interval_contains_close(interval_t, loc_t):
                     ticks_to_draw.append(tick)
 
+        # Cache the result before returning
+        self._cached_ticks_to_draw = ticks_to_draw
         return ticks_to_draw
 
     def _get_ticklabel_bboxes(self, ticks, renderer):
@@ -1392,7 +1400,10 @@ class Axis(martist.Artist):
             return
         if renderer is None:
             renderer = self.get_figure(root=True)._get_renderer()
-        ticks_to_draw = self._update_ticks()
+        # Don't use cached values here - get_tightbbox() is called during
+        # layout calculations (e.g., constrained_layout) outside of draw(),
+        # and must always recalculate to reflect current state.
+        ticks_to_draw = self._update_ticks(_use_cached=False)
 
         self._update_label_position(renderer)
 
@@ -1444,7 +1455,10 @@ class Axis(martist.Artist):
             return
         renderer.open_group(__name__, gid=self.get_gid())
 
-        ticks_to_draw = self._update_ticks()
+        # Clear tick cache for this draw cycle
+        self._cached_ticks_to_draw = None
+
+        ticks_to_draw = self._update_ticks(_use_cached=True)
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
 
         for tick in ticks_to_draw:
@@ -2281,7 +2295,7 @@ class Axis(martist.Artist):
         # If we want to align labels from other Axes:
         for ax in grouper.get_siblings(self.axes):
             axis = ax._axis_map[name]
-            ticks_to_draw = axis._update_ticks()
+            ticks_to_draw = axis._update_ticks(_use_cached=True)
             tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer)
             bboxes.extend(tlb)
             bboxes2.extend(tlb2)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1305,13 +1305,13 @@ class Axis(martist.Artist):
                 kw.get('label2On') is not False or
                 kw.get('gridOn') is not False)
 
-    def _update_ticks(self, *, _use_cached=False):
+    def _update_ticks(self, *, _use_cache=False):
         """
         Update ticks (position and labels) using the current data interval of
         the axes.  Return the list of ticks that will be drawn.
         """
         # Return cached result if available and requested
-        if _use_cached and self._cached_ticks_to_draw is not None:
+        if _use_cache and self._cached_ticks_to_draw is not None:
             return self._cached_ticks_to_draw
 
         # Check if major ticks should be computed.
@@ -1374,14 +1374,15 @@ class Axis(martist.Artist):
                 if mtransforms._interval_contains_close(interval_t, loc_t):
                     ticks_to_draw.append(tick)
 
-        # Cache the result before returning
-        self._cached_ticks_to_draw = ticks_to_draw
+        # Only cache the result when called from the draw path
+        if _use_cache:
+            self._cached_ticks_to_draw = ticks_to_draw
         return ticks_to_draw
 
-    def _get_ticklabel_bboxes(self, ticks, renderer, *, _use_cached=False):
+    def _get_ticklabel_bboxes(self, ticks, renderer, *, _use_cache=False):
         """Return lists of bboxes for ticks' label1's and label2's."""
         # Return cached result if available and requested
-        if _use_cached and self._cached_ticklabel_bboxes is not None:
+        if _use_cache and self._cached_ticklabel_bboxes is not None:
             return self._cached_ticklabel_bboxes
 
         result = ([tick.label1.get_window_extent(renderer)
@@ -1391,8 +1392,9 @@ class Axis(martist.Artist):
                    for tick in ticks
                    if tick.label2.get_visible() and tick.label2.get_in_layout()])
 
-        # Cache the result before returning
-        self._cached_ticklabel_bboxes = result
+        # Only cache the result when called from the draw path
+        if _use_cache:
+            self._cached_ticklabel_bboxes = result
         return result
 
     def get_tightbbox(self, renderer=None, *, for_layout_only=False):
@@ -1412,13 +1414,13 @@ class Axis(martist.Artist):
         # Don't use cached values here - get_tightbbox() is called during
         # layout calculations (e.g., constrained_layout) outside of draw(),
         # and must always recalculate to reflect current state.
-        ticks_to_draw = self._update_ticks(_use_cached=False)
+        ticks_to_draw = self._update_ticks(_use_cache=False)
 
-        self._update_label_position(renderer)
+        self._update_label_position(renderer, _use_cache=False)
 
         # go back to just this axis's tick labels
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
-                                                _use_cached=False)
+                                                _use_cache=False)
 
         self._update_offset_text_position(tlb1, tlb2)
         self.offsetText.set_text(self.major.formatter.get_offset())
@@ -1465,19 +1467,15 @@ class Axis(martist.Artist):
             return
         renderer.open_group(__name__, gid=self.get_gid())
 
-        # Clear caches for this draw cycle
-        self._cached_ticks_to_draw = None
-        self._cached_ticklabel_bboxes = None
-
-        ticks_to_draw = self._update_ticks(_use_cached=True)
+        ticks_to_draw = self._update_ticks(_use_cache=True)
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer,
-                                                _use_cached=True)
+                                                _use_cache=True)
 
         for tick in ticks_to_draw:
             tick.draw(renderer)
 
         # Shift label away from axes to avoid overlapping ticklabels.
-        self._update_label_position(renderer)
+        self._update_label_position(renderer, _use_cache=True)
         self.label.draw(renderer)
 
         self._update_offset_text_position(tlb1, tlb2)
@@ -1486,6 +1484,10 @@ class Axis(martist.Artist):
 
         renderer.close_group(__name__)
         self.stale = False
+
+        # Reset cached values for next draw cycle, in case not called by Axes.draw()
+        self._cached_ticks_to_draw = None
+        self._cached_ticklabel_bboxes = None
 
     def get_gridlines(self):
         r"""Return this Axis' grid lines as a list of `.Line2D`\s."""
@@ -2290,7 +2292,7 @@ class Axis(martist.Artist):
             self.set_ticklabels(labels, minor=minor, **kwargs)
         return result
 
-    def _get_tick_boxes_siblings(self, renderer):
+    def _get_tick_boxes_siblings(self, renderer, *, _use_cache=False):
         """
         Get the bounding boxes for this `.axis` and its siblings
         as set by `.Figure.align_xlabels` or  `.Figure.align_ylabels`.
@@ -2307,14 +2309,14 @@ class Axis(martist.Artist):
         # If we want to align labels from other Axes:
         for ax in grouper.get_siblings(self.axes):
             axis = ax._axis_map[name]
-            ticks_to_draw = axis._update_ticks(_use_cached=True)
+            ticks_to_draw = axis._update_ticks(_use_cache=_use_cache)
             tlb, tlb2 = axis._get_ticklabel_bboxes(ticks_to_draw, renderer,
-                                                   _use_cached=True)
+                                                   _use_cache=_use_cache)
             bboxes.extend(tlb)
             bboxes2.extend(tlb2)
         return bboxes, bboxes2
 
-    def _update_label_position(self, renderer):
+    def _update_label_position(self, renderer, *, _use_cache=False):
         """
         Update the label position based on the bounding box enclosing
         all the ticklabels and axis spine.
@@ -2511,7 +2513,7 @@ class XAxis(Axis):
         self.label_position = position
         self.stale = True
 
-    def _update_label_position(self, renderer):
+    def _update_label_position(self, renderer, *, _use_cache=False):
         """
         Update the label position based on the bounding box enclosing
         all the ticklabels and axis spine
@@ -2521,7 +2523,8 @@ class XAxis(Axis):
 
         # get bounding boxes for this axis and any siblings
         # that have been set by `fig.align_xlabels()`
-        bboxes, bboxes2 = self._get_tick_boxes_siblings(renderer=renderer)
+        bboxes, bboxes2 = self._get_tick_boxes_siblings(renderer=renderer,
+                                                        _use_cache=_use_cache)
         x, y = self.label.get_position()
 
         if self.label_position == 'bottom':
@@ -2738,7 +2741,7 @@ class YAxis(Axis):
         self.label_position = position
         self.stale = True
 
-    def _update_label_position(self, renderer):
+    def _update_label_position(self, renderer, *, _use_cache=False):
         """
         Update the label position based on the bounding box enclosing
         all the ticklabels and axis spine
@@ -2748,7 +2751,8 @@ class YAxis(Axis):
 
         # get bounding boxes for this axis and any siblings
         # that have been set by `fig.align_ylabels()`
-        bboxes, bboxes2 = self._get_tick_boxes_siblings(renderer=renderer)
+        bboxes, bboxes2 = self._get_tick_boxes_siblings(renderer=renderer,
+                                                        _use_cache=_use_cache)
         x, y = self.label.get_position()
 
         if self.label_position == 'left':

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -155,7 +155,7 @@ class Spine(mpatches.Patch):
         if self.axis is None or not self.axis.get_visible():
             return bb
         bboxes = [bb]
-        drawn_ticks = self.axis._update_ticks(_use_cached=True)
+        drawn_ticks = self.axis._update_ticks(_use_cache=True)
 
         major_tick = next(iter({*drawn_ticks} & {*self.axis.majorTicks}), None)
         minor_tick = next(iter({*drawn_ticks} & {*self.axis.minorTicks}), None)

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -155,7 +155,7 @@ class Spine(mpatches.Patch):
         if self.axis is None or not self.axis.get_visible():
             return bb
         bboxes = [bb]
-        drawn_ticks = self.axis._update_ticks()
+        drawn_ticks = self.axis._update_ticks(_use_cached=True)
 
         major_tick = next(iter({*drawn_ticks} & {*self.axis.majorTicks}), None)
         minor_tick = next(iter({*drawn_ticks} & {*self.axis.minorTicks}), None)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -451,6 +451,9 @@ class Axes3D(Axes):
                 artist.do_3d_projection()
 
         if self._axis3don:
+            for axis in self._axis_map.values():
+                axis._cached_ticks_to_draw = None
+                axis._cached_ticklabel_bboxes = None
             # Draw panes first
             for axis in self._axis_map.values():
                 axis.draw_pane(renderer)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -452,8 +452,7 @@ class Axes3D(Axes):
 
         if self._axis3don:
             for axis in self._axis_map.values():
-                axis._cached_ticks_to_draw = None
-                axis._cached_ticklabel_bboxes = None
+                axis._clear_ticks_cache()
             # Draw panes first
             for axis in self._axis_map.values():
                 axis.draw_pane(renderer)

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -569,6 +569,7 @@ class Axis(maxis.XAxis):
         self.label._transform = self.axes.transData
         self.offsetText._transform = self.axes.transData
         renderer.open_group("axis3d", gid=self.get_gid())
+        self._clear_ticks_cache()
 
         # Get general axis information:
         mins, maxs, tc, highs = self._get_coord_info()
@@ -629,7 +630,6 @@ class Axis(maxis.XAxis):
         renderer.close_group('axis3d')
         self.stale = False
 
-        # Reset cached values for next draw cycle, in case not called by Axes3D.draw()
         self._clear_ticks_cache()
 
     @artist.allow_rasterization

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -630,8 +630,7 @@ class Axis(maxis.XAxis):
         self.stale = False
 
         # Reset cached values for next draw cycle, in case not called by Axes3D.draw()
-        self._cached_ticks_to_draw = None
-        self._cached_ticklabel_bboxes = None
+        self._clear_ticks_cache()
 
     @artist.allow_rasterization
     def draw_grid(self, renderer):

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -435,7 +435,7 @@ class Axis(maxis.XAxis):
 
     def _draw_ticks(self, renderer, edgep1, centers, deltas, highs,
                     deltas_per_point, pos):
-        ticks = self._update_ticks(_use_cached=True)
+        ticks = self._update_ticks(_use_cache=True)
         info = self._axinfo
         index = info["i"]
         juggled = info["juggled"]
@@ -640,7 +640,7 @@ class Axis(maxis.XAxis):
 
         renderer.open_group("grid3d", gid=self.get_gid())
 
-        ticks = self._update_ticks(_use_cached=True)
+        ticks = self._update_ticks(_use_cache=True)
         if len(ticks):
             # Get general axis information:
             info = self._axinfo
@@ -712,7 +712,7 @@ class Axis(maxis.XAxis):
         # Don't use cached values here - get_tightbbox() is called during
         # layout calculations (e.g., constrained_layout) outside of draw(),
         # and must always recalculate to reflect current state.
-        bb_1, bb_2 = self._get_ticklabel_bboxes(ticks, renderer, _use_cached=False)
+        bb_1, bb_2 = self._get_ticklabel_bboxes(ticks, renderer, _use_cache=False)
         other = []
 
         if self.offsetText.get_visible() and self.offsetText.get_text():

--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -435,7 +435,7 @@ class Axis(maxis.XAxis):
 
     def _draw_ticks(self, renderer, edgep1, centers, deltas, highs,
                     deltas_per_point, pos):
-        ticks = self._update_ticks()
+        ticks = self._update_ticks(_use_cached=True)
         info = self._axinfo
         index = info["i"]
         juggled = info["juggled"]
@@ -629,6 +629,10 @@ class Axis(maxis.XAxis):
         renderer.close_group('axis3d')
         self.stale = False
 
+        # Reset cached values for next draw cycle, in case not called by Axes3D.draw()
+        self._cached_ticks_to_draw = None
+        self._cached_ticklabel_bboxes = None
+
     @artist.allow_rasterization
     def draw_grid(self, renderer):
         if not self.axes._draw_grid:
@@ -636,7 +640,7 @@ class Axis(maxis.XAxis):
 
         renderer.open_group("grid3d", gid=self.get_gid())
 
-        ticks = self._update_ticks()
+        ticks = self._update_ticks(_use_cached=True)
         if len(ticks):
             # Get general axis information:
             info = self._axinfo
@@ -705,7 +709,10 @@ class Axis(maxis.XAxis):
 
         ticks = ticks_to_draw
 
-        bb_1, bb_2 = self._get_ticklabel_bboxes(ticks, renderer)
+        # Don't use cached values here - get_tightbbox() is called during
+        # layout calculations (e.g., constrained_layout) outside of draw(),
+        # and must always recalculate to reflect current state.
+        bb_1, bb_2 = self._get_ticklabel_bboxes(ticks, renderer, _use_cached=False)
         other = []
 
         if self.offsetText.get_visible() and self.offsetText.get_text():


### PR DESCRIPTION
## PR summary
Towards https://github.com/matplotlib/matplotlib/issues/5665

Currently we are calling `_update_ticks()` 3 times per axis every draw call, and `_get_ticklabel_bboxes` 2 times per axis. These calls take up about 35% of total draw time for an empty plot.

We can eliminate 25% of total draw time by caching the results of these calculations every draw cycle. This introduces some state, but I think it's decently well guarded and the performance boost is definitely worth it.

**Before & After**
The circled red areas show the before & after runtime of `axis._update_label_position` within `Axis.draw()`. It runs after the cache values have been set by other functions, so we nearly completely eliminate its runtime.

Before:
<img width="2556" height="681" alt="image" src="https://github.com/user-attachments/assets/e42d4fff-56a4-41ad-acac-f91b69c5826a" />

After:
<img width="2556" height="606" alt="image" src="https://github.com/user-attachments/assets/755e247d-ef03-4029-9c41-113ffdfe3114" />


**Profiling script:**
```python
import time
import matplotlib.pyplot as plt

fig, ax = plt.subplots()

print("Timing...")
start_time = time.perf_counter()
for i in range(100):
    fig.canvas.draw()
end_time = time.perf_counter()

plt.close()
print(f"Time taken: {end_time - start_time:.4f} seconds")
```

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
