### PR TITLE
TST: Fix warnings from Pillow for unavailable features

### DIFF
--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -1,4 +1,5 @@
 import io
+import warnings
 
 import numpy as np
 from numpy.testing import assert_array_almost_equal
@@ -15,6 +16,13 @@ from matplotlib.image import imread
 from matplotlib.path import Path
 from matplotlib.testing.decorators import image_comparison
 from matplotlib.transforms import IdentityTransform
+
+
+def require_pillow_feature(name):
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore')
+        available = features.check(name.lower())
+    return pytest.mark.skipif(not available, reason=f"{name} support not available")
 
 
 def test_repeated_save_with_alpha():
@@ -249,7 +257,7 @@ def test_pil_kwargs_tiff():
     assert tags["ImageDescription"] == "test image"
 
 
-@pytest.mark.skipif(not features.check("webp"), reason="WebP support not available")
+@require_pillow_feature('WebP')
 def test_pil_kwargs_webp():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf_small = io.BytesIO()
@@ -263,7 +271,7 @@ def test_pil_kwargs_webp():
     assert buf_large.getbuffer().nbytes > buf_small.getbuffer().nbytes
 
 
-@pytest.mark.skipif(not features.check("avif"), reason="AVIF support not available")
+@require_pillow_feature('AVIF')
 def test_pil_kwargs_avif():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf_small = io.BytesIO()
@@ -295,7 +303,7 @@ def test_gif_alpha():
     assert im.info["transparency"] < len(im.palette.colors)
 
 
-@pytest.mark.skipif(not features.check("webp"), reason="WebP support not available")
+@require_pillow_feature('WebP')
 def test_webp_alpha():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf = io.BytesIO()
@@ -304,7 +312,7 @@ def test_webp_alpha():
     assert im.mode == "RGBA"
 
 
-@pytest.mark.skipif(not features.check("avif"), reason="AVIF support not available")
+@require_pillow_feature('AVIF')
 def test_avif_alpha():
     plt.plot([0, 1, 2], [0, 1, 0])
     buf = io.BytesIO()


### PR DESCRIPTION
## PR summary

If Pillow is old enough to not support a feature _at all_, then it will warn about it (e.g., https://github.com/matplotlib/matplotlib/actions/runs/21232201791/job/61092807364#step:13:182). If you're running the whole test suite, then something else seems to cause pytest to treat it as benign. But if you run only `test_agg.py`, then our `-Werror` setting will cause it to fail test collection.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines