### PR TITLE
Fix: prevent imshow pixel overlap with grid lines

### DIFF
--- a/doc/api/next_api_changes/behavior/31009-TK.rst
+++ b/doc/api/next_api_changes/behavior/31009-TK.rst
@@ -1,0 +1,6 @@
+imshow pixel alignment
+~~~~~~~~~~~~~~~~~~~~~~
+``imshow`` now rounds the output image dimensions to the nearest integer pixel
+rather than always using ``math.ceil``. This ensures that the edges of raster
+pixels align correctly with vector grid lines and patches, preventing 1-pixel
+overlaps or gaps when the image is small or pixels are large.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Closes #31009

### Why is this change necessary?
This change is necessary to fix a visual misalignment where `imshow` pixels slightly overlap or leave gaps relative to vector grid lines. This becomes particularly evident when using small arrays with large pixels.

### What problem does it solve?
The original implementation in `_make_image` used `math.ceil()` to determine output pixel dimensions. This forced the image to always round up to the next integer pixel, causing it to grow slightly beyond its intended mathematical extent. By switching to `round()`, the raster image edges now snap to the nearest pixel boundary, which is consistent with how vector artists like grid lines are rendered.

### What is the reasoning for this implementation?
The reasoning is to ensure coordinate consistency between raster and vector rendering. Using `round()` allows the image to snap to the pixel grid in the same manner as other Matplotlib artists, preventing the 1-pixel artifacts reported in the issue.

### Minimum self-contained example
```python
import matplotlib.pyplot as plt
import numpy as np
fig, ax = plt.subplots()
N = 12
ax.imshow(np.random.rand(N, N))
seps = np.arange(-0.5, N)
ax.vlines(seps, -0.5, N - 0.5, linewidth=1)
ax.hlines(seps, -0.5, N - 0.5, linewidth=1)
plt.show()