### PR TITLE
feat: reduce file size of fill_between by enabling path simplification

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -211,6 +211,7 @@ class Collection(mcolorizer.ColorizingArtist):
         self._offset_transform = offset_transform
 
         self._path_effects = None
+        self._simplify = False
         self._internal_update(kwargs)
         self._paths = None
 
@@ -219,6 +220,22 @@ class Collection(mcolorizer.ColorizingArtist):
 
     def set_paths(self, paths):
         self._paths = paths
+        self.stale = True
+
+    def get_simplify(self):
+        """Return whether this Artist should simplify its path."""
+        return self._simplify
+
+    def set_simplify(self, simplify):
+        """
+        Set whether this Artist should simplify its path.
+
+        Parameters
+        ----------
+        simplify : bool
+            Whether to simplify the path.
+        """
+        self._simplify = simplify
         self.stale = True
 
     def get_transforms(self):
@@ -363,6 +380,9 @@ class Collection(mcolorizer.ColorizingArtist):
         self.update_scalarmappable()
 
         transform, offset_trf, offsets, paths = self._prepare_points()
+
+        if self.get_simplify():
+            paths = [path.cleaned(simplify=True) for path in paths]
 
         gc = renderer.new_gc()
         self._set_gc_clip(gc)
@@ -1443,6 +1463,7 @@ class FillBetweenPolyCollection(PolyCollection):
         self._step = step
         verts = self._make_verts(t, f1, f2, where)
         super().__init__(verts, **kwargs)
+        self.set_simplify(True)
 
     @staticmethod
     def _f_dir_from_t(t_direction):


### PR DESCRIPTION
### Description
This PR addresses issue #22803 by introducing path simplification support to the \Collection\ class and enabling it by default for \FillBetweenPolyCollection\.

### Problem
Previously, \ill_between()\ generated vector files (PDF/SVG) that were significantly larger than equivalent \plot()\ calls. This was because \Line2D\ supports path simplification while \PolyCollection\ (the base for \ill_between\) did not, resulting in every single vertex being recorded in the output file, even if they were visually redundant.

### Solution
- **Enhanced \Collection\**: Added \set_simplify()\ and \get_simplify()\ to the base \Collection\ class to align its interface with other Artists like \Line2D\.
- **Refactored \draw()\**: Updated the rendering pipeline in \Collection.draw()\ to perform path cleaning using \path.cleaned(simplify=True)\ when simplification is enabled.
- **Default Optimization**: Enabled simplification by default for \FillBetweenPolyCollection\. This maintains high visual fidelity while drastically reducing the data entropy and resulting file size for high-density plots.

### Impact
For a plot with 100,000 data points, this change can reduce the resulting SVG/PDF file size by several folds, improving both storage efficiency and rendering performance in document viewers.