### PR TITLE
ENH: Add Axes.colorbar() method

### DIFF
--- a/doc/api/axes_api.rst
+++ b/doc/api/axes_api.rst
@@ -314,8 +314,8 @@ Axis limits and direction
    Axes.set_ybound
    Axes.get_ybound
 
-Axis labels, title, and legend
-------------------------------
+Axis labels and title
+---------------------
 
 .. autosummary::
    :toctree: _as_gen
@@ -330,9 +330,6 @@ Axis labels, title, and legend
 
    Axes.set_title
    Axes.get_title
-   Axes.legend
-   Axes.get_legend
-   Axes.get_legend_handles_labels
 
 Axis scales
 -----------
@@ -436,6 +433,20 @@ Ticks and tick labels
    Axes.tick_params
 
    Axes.locator_params
+
+
+Legend and colorbar
+===================
+
+.. autosummary::
+   :toctree: _as_gen
+   :template: autosummary.rst
+   :nosignatures:
+
+   Axes.legend
+   Axes.get_legend
+   Axes.get_legend_handles_labels
+   Axes.colorbar
 
 
 Units

--- a/galleries/examples/color/colorbar_basics.py
+++ b/galleries/examples/color/colorbar_basics.py
@@ -22,26 +22,20 @@ Zneg = np.ma.masked_greater(Z, 0)
 
 fig, (ax1, ax2, ax3) = plt.subplots(figsize=(13, 3), ncols=3)
 
-# plot just the positive data and save the
-# color "mappable" object returned by ax1.imshow
-pos = ax1.imshow(Zpos, cmap='Blues', interpolation='none')
-
-# add the colorbar using the figure's method,
-# telling which mappable we're talking about and
-# which Axes object it should be near
-fig.colorbar(pos, ax=ax1)
+# plot just the positive data and add a colorbar
+ax1.imshow(Zpos, cmap='Blues', interpolation='none')
+ax1.colorbar()
 
 # repeat everything above for the negative data
 # you can specify location, anchor and shrink the colorbar
-neg = ax2.imshow(Zneg, cmap='Reds_r', interpolation='none')
-fig.colorbar(neg, ax=ax2, location='right', anchor=(0, 0.3), shrink=0.7)
+ax2.imshow(Zneg, cmap='Reds_r', interpolation='none')
+ax2.colorbar(location='right', anchor=(0, 0.3), shrink=0.7)
 
 # Plot both positive and negative values between +/- 1.2
-pos_neg_clipped = ax3.imshow(Z, cmap='RdBu', vmin=-1.2, vmax=1.2,
-                             interpolation='none')
+ax3.imshow(Z, cmap='RdBu', vmin=-1.2, vmax=1.2, interpolation='none')
 # Add minorticks on the colorbar to make it easy to read the
 # values off the colorbar.
-cbar = fig.colorbar(pos_neg_clipped, ax=ax3, extend='both')
+cbar = ax3.colorbar(extend='both')
 cbar.minorticks_on()
 plt.show()
 

--- a/galleries/examples/color/custom_cmap.py
+++ b/galleries/examples/color/custom_cmap.py
@@ -122,9 +122,9 @@ for n_bin, ax in zip(n_bins, axs.flat):
     # Create the colormap
     cmap = LinearSegmentedColormap.from_list(cmap_name, colors, N=n_bin)
     # Fewer bins will result in "coarser" colomap interpolation
-    im = ax.imshow(Z, origin='lower', cmap=cmap)
+    ax.imshow(Z, origin='lower', cmap=cmap)
+    ax.colorbar()
     ax.set_title("N bins: %s" % n_bin)
-    fig.colorbar(im, ax=ax)
 
 
 # %%
@@ -226,11 +226,11 @@ mpl.colormaps.register(LinearSegmentedColormap('BlueRedAlpha', cdict4))
 fig, axs = plt.subplots(2, 2, figsize=(6, 9))
 fig.subplots_adjust(left=0.02, bottom=0.06, right=0.95, top=0.94, wspace=0.05)
 
-im1 = axs[0, 0].imshow(Z, cmap=blue_red1)
-fig.colorbar(im1, ax=axs[0, 0])
+axs[0, 0].imshow(Z, cmap=blue_red1)
+axs[0, 0].colorbar()
 
-im2 = axs[1, 0].imshow(Z, cmap='BlueRed2')
-fig.colorbar(im2, ax=axs[1, 0])
+axs[1, 0].imshow(Z, cmap='BlueRed2')
+axs[1, 0].colorbar()
 
 # Now we will set the third cmap as the default.  One would
 # not normally do this in the middle of a script like this;
@@ -238,8 +238,8 @@ fig.colorbar(im2, ax=axs[1, 0])
 
 plt.rcParams['image.cmap'] = 'BlueRed3'
 
-im3 = axs[0, 1].imshow(Z)
-fig.colorbar(im3, ax=axs[0, 1])
+axs[0, 1].imshow(Z)
+axs[0, 1].colorbar()
 axs[0, 1].set_title("Alpha = 1")
 
 # Or as yet another variation, we can replace the rcParams
@@ -252,12 +252,12 @@ axs[0, 1].set_title("Alpha = 1")
 # Draw a line with low zorder so it will be behind the image.
 axs[1, 1].plot([0, 10 * np.pi], [0, 20 * np.pi], color='c', lw=20, zorder=-1)
 
-im4 = axs[1, 1].imshow(Z)
-fig.colorbar(im4, ax=axs[1, 1])
+im = axs[1, 1].imshow(Z)
+axs[1, 1].colorbar()
 
 # Here it is: changing the colormap for the current image and its
 # colorbar after they have been plotted.
-im4.set_cmap('BlueRedAlpha')
+im.set_cmap('BlueRedAlpha')
 axs[1, 1].set_title("Varying alpha")
 
 fig.suptitle('Custom Blue-Red colormaps', fontsize=16)

--- a/galleries/examples/images_contours_and_fields/colormap_interactive_adjustment.py
+++ b/galleries/examples/images_contours_and_fields/colormap_interactive_adjustment.py
@@ -24,10 +24,9 @@ t = np.linspace(0, 2 * np.pi, 1024)
 data2d = np.sin(t)[:, np.newaxis] * np.cos(t)[np.newaxis, :]
 
 fig, ax = plt.subplots()
-im = ax.imshow(data2d)
+ax.imshow(data2d)
+ax.colorbar(label='Interactive colorbar')
 ax.set_title('Pan on the colorbar to shift the color mapping\n'
              'Zoom on the colorbar to scale the color mapping')
-
-fig.colorbar(im, ax=ax, label='Interactive colorbar')
 
 plt.show()

--- a/galleries/examples/images_contours_and_fields/colormap_normalizations.py
+++ b/galleries/examples/images_contours_and_fields/colormap_normalizations.py
@@ -32,12 +32,12 @@ Z = Z1 + 50 * Z2
 
 fig, ax = plt.subplots(2, 1)
 
-pcm = ax[0].pcolor(X, Y, Z, cmap='PuBu_r', shading='nearest')
-fig.colorbar(pcm, ax=ax[0], extend='max', label='linear scaling')
+ax[0].pcolor(X, Y, Z, cmap='PuBu_r', shading='nearest')
+ax[0].colorbar(extend='max', label='linear scaling')
 
-pcm = ax[1].pcolor(X, Y, Z, cmap='PuBu_r', shading='nearest',
-                   norm=colors.LogNorm(vmin=Z.min(), vmax=Z.max()))
-fig.colorbar(pcm, ax=ax[1], extend='max', label='LogNorm')
+ax[1].pcolor(X, Y, Z, cmap='PuBu_r', shading='nearest',
+             norm=colors.LogNorm(vmin=Z.min(), vmax=Z.max()))
+ax[1].colorbar(extend='max', label='LogNorm')
 
 # %%
 # PowerNorm
@@ -53,12 +53,12 @@ Z = (1 + np.sin(Y * 10)) * X**2
 
 fig, ax = plt.subplots(2, 1)
 
-pcm = ax[0].pcolormesh(X, Y, Z, cmap='PuBu_r', shading='nearest')
-fig.colorbar(pcm, ax=ax[0], extend='max', label='linear scaling')
+ax[0].pcolormesh(X, Y, Z, cmap='PuBu_r', shading='nearest')
+ax[0].colorbar(extend='max', label='linear scaling')
 
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='PuBu_r', shading='nearest',
-                       norm=colors.PowerNorm(gamma=0.5))
-fig.colorbar(pcm, ax=ax[1], extend='max', label='PowerNorm')
+ax[1].pcolormesh(X, Y, Z, cmap='PuBu_r', shading='nearest',
+                 norm=colors.PowerNorm(gamma=0.5))
+ax[1].colorbar(extend='max', label='PowerNorm')
 
 # %%
 # SymLogNorm
@@ -79,14 +79,13 @@ Z = (5 * Z1 - Z2) * 2
 
 fig, ax = plt.subplots(2, 1)
 
-pcm = ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       vmin=-np.max(Z))
-fig.colorbar(pcm, ax=ax[0], extend='both', label='linear scaling')
+ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest', vmin=-np.max(Z))
+ax[0].colorbar(extend='both', label='linear scaling')
 
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       norm=colors.SymLogNorm(linthresh=0.015,
-                                              vmin=-10.0, vmax=10.0, base=10))
-fig.colorbar(pcm, ax=ax[1], extend='both', label='SymLogNorm')
+ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
+                 norm=colors.SymLogNorm(linthresh=0.015,
+                                        vmin=-10.0, vmax=10.0, base=10))
+ax[1].colorbar(extend='both', label='SymLogNorm')
 
 # %%
 # Custom Norm
@@ -112,13 +111,12 @@ class MidpointNormalize(colors.Normalize):
 # %%
 fig, ax = plt.subplots(2, 1)
 
-pcm = ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       vmin=-np.max(Z))
-fig.colorbar(pcm, ax=ax[0], extend='both', label='linear scaling')
+ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest', vmin=-np.max(Z))
+ax[0].colorbar(extend='both', label='linear scaling')
 
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       norm=MidpointNormalize(midpoint=0))
-fig.colorbar(pcm, ax=ax[1], extend='both', label='Custom norm')
+ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
+                 norm=MidpointNormalize(midpoint=0))
+ax[1].colorbar(extend='both', label='Custom norm')
 
 # %%
 # BoundaryNorm
@@ -129,25 +127,22 @@ fig.colorbar(pcm, ax=ax[1], extend='both', label='Custom norm')
 
 fig, ax = plt.subplots(3, 1, layout='constrained')
 
-pcm = ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       vmin=-np.max(Z))
-fig.colorbar(pcm, ax=ax[0], extend='both', orientation='vertical',
-             label='linear scaling')
+ax[0].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest', vmin=-np.max(Z))
+ax[0].colorbar(extend='both', orientation='vertical', label='linear scaling')
 
 # Evenly-spaced bounds gives a contour-like effect.
 bounds = np.linspace(-2, 2, 11)
 norm = colors.BoundaryNorm(boundaries=bounds, ncolors=256)
-pcm = ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
+ax[1].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
                        norm=norm)
-fig.colorbar(pcm, ax=ax[1], extend='both', orientation='vertical',
-             label='BoundaryNorm\nlinspace(-2, 2, 11)')
+ax[1].colorbar(extend='both', orientation='vertical',
+               label='BoundaryNorm\nlinspace(-2, 2, 11)')
 
 # Unevenly-spaced bounds changes the colormapping.
 bounds = np.array([-1, -0.5, 0, 2.5, 5])
 norm = colors.BoundaryNorm(boundaries=bounds, ncolors=256)
-pcm = ax[2].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest',
-                       norm=norm)
-fig.colorbar(pcm, ax=ax[2], extend='both', orientation='vertical',
-             label='BoundaryNorm\n[-1, -0.5, 0, 2.5, 5]')
+ax[2].pcolormesh(X, Y, Z, cmap='RdBu_r', shading='nearest', norm=norm)
+ax[2].colorbar(extend='both', orientation='vertical',
+               label='BoundaryNorm\n[-1, -0.5, 0, 2.5, 5]')
 
 plt.show()

--- a/galleries/examples/images_contours_and_fields/colormap_normalizations_symlognorm.py
+++ b/galleries/examples/images_contours_and_fields/colormap_normalizations_symlognorm.py
@@ -40,16 +40,14 @@ lnrwidth = 0.5
 
 fig, ax = plt.subplots(2, 1, sharex=True, sharey=True)
 
-pcm = ax[0].pcolormesh(X, Y, Z,
-                       norm=colors.SymLogNorm(linthresh=lnrwidth, linscale=1,
-                                              vmin=-gain, vmax=gain, base=10),
-                       **shadeopts)
-fig.colorbar(pcm, ax=ax[0], extend='both')
+ax[0].pcolormesh(X, Y, Z, norm=colors.SymLogNorm(linthresh=lnrwidth, linscale=1,
+                                                 vmin=-gain, vmax=gain, base=10),
+                 **shadeopts)
+ax[0].colorbar(extend='both')
 ax[0].text(-2.5, 1.5, 'symlog')
 
-pcm = ax[1].pcolormesh(X, Y, Z, vmin=-gain, vmax=gain,
-                       **shadeopts)
-fig.colorbar(pcm, ax=ax[1], extend='both')
+ax[1].pcolormesh(X, Y, Z, vmin=-gain, vmax=gain, **shadeopts)
+ax[1].colorbar(extend='both')
 ax[1].text(-2.5, 1.5, 'linear')
 
 
@@ -67,18 +65,17 @@ ax[1].text(-2.5, 1.5, 'linear')
 
 fig, ax = plt.subplots(2, 1, sharex=True, sharey=True)
 
-pcm = ax[0].pcolormesh(X, Y, Z,
-                       norm=colors.SymLogNorm(linthresh=lnrwidth, linscale=1,
-                                              vmin=-gain, vmax=gain, base=10),
-                       **shadeopts)
-fig.colorbar(pcm, ax=ax[0], extend='both')
+ax[0].pcolormesh(X, Y, Z,
+                 norm=colors.SymLogNorm(linthresh=lnrwidth, linscale=1,
+                                        vmin=-gain, vmax=gain, base=10),
+                 **shadeopts)
+ax[0].colorbar(extend='both')
 ax[0].text(-2.5, 1.5, 'symlog')
 
-pcm = ax[1].pcolormesh(X, Y, Z,
-                       norm=colors.AsinhNorm(linear_width=lnrwidth,
-                                             vmin=-gain, vmax=gain),
-                       **shadeopts)
-fig.colorbar(pcm, ax=ax[1], extend='both')
+ax[1].pcolormesh(X, Y, Z,
+                 norm=colors.AsinhNorm(linear_width=lnrwidth, vmin=-gain, vmax=gain),
+                 **shadeopts)
+ax[1].colorbar(extend='both')
 ax[1].text(-2.5, 1.5, 'asinh')
 
 

--- a/galleries/examples/images_contours_and_fields/contour_image.py
+++ b/galleries/examples/images_contours_and_fields/contour_image.py
@@ -65,8 +65,7 @@ cset2.set_linestyle('solid')
 
 cset3 = axs[0].contour(X, Y, Z, (0,), colors='g', linewidths=2)
 axs[0].set_title('Filled contours')
-fig.colorbar(cset1, ax=axs[0])
-
+axs[0].colorbar(cset1)
 
 axs[1].imshow(Z, extent=extent, cmap=cmap, norm=norm)
 axs[1].contour(Z, levels, colors='k', origin='upper', extent=extent)
@@ -82,13 +81,12 @@ axs[2].set_title("Image, origin 'lower'")
 # This is intentional. The Z values are defined at the center of each
 # image pixel (each color block on the following subplot), so the
 # domain that is contoured does not extend beyond these pixel centers.
-im = axs[3].imshow(Z, interpolation='nearest', extent=extent,
-                   cmap=cmap, norm=norm)
+im = axs[3].imshow(Z, interpolation='nearest', extent=extent, cmap=cmap, norm=norm)
 axs[3].contour(Z, levels, colors='k', origin='image', extent=extent)
 ylim = axs[3].get_ylim()
 axs[3].set_ylim(ylim[::-1])
 axs[3].set_title("Origin from rc, reversed y-axis")
-fig.colorbar(im, ax=axs[3])
+axs[3].colorbar(im)
 
 fig.tight_layout()
 plt.show()

--- a/galleries/examples/images_contours_and_fields/contourf_demo.py
+++ b/galleries/examples/images_contours_and_fields/contourf_demo.py
@@ -96,8 +96,8 @@ cmap = plt.colormaps["winter"].with_extremes(under="magenta", over="yellow")
 fig, axs = plt.subplots(2, 2, layout="constrained")
 
 for ax, extend in zip(axs.flat, extends):
-    cs = ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend)
-    fig.colorbar(cs, ax=ax, shrink=0.9)
+    ax.contourf(X, Y, Z, levels, cmap=cmap, extend=extend)
+    ax.colorbar(shrink=0.9)
     ax.set_title("extend = %s" % extend)
     ax.locator_params(nbins=4)
 

--- a/galleries/examples/images_contours_and_fields/contourf_log.py
+++ b/galleries/examples/images_contours_and_fields/contourf_log.py
@@ -36,16 +36,16 @@ z = ma.masked_where(z <= 0, z)
 # Automatic selection of levels works; setting the
 # log locator tells contourf to use a log scale:
 fig, ax = plt.subplots()
-cs = ax.contourf(X, Y, z, locator=ticker.LogLocator(), cmap="PuBu_r")
+ax.contourf(X, Y, z, locator=ticker.LogLocator(), cmap="PuBu_r")
 
 # Alternatively, you can manually set the levels
 # and the norm:
 # lev_exp = np.arange(np.floor(np.log10(z.min())-1),
 #                    np.ceil(np.log10(z.max())+1))
 # levs = np.power(10, lev_exp)
-# cs = ax.contourf(X, Y, z, levs, norm=colors.LogNorm())
+# ax.contourf(X, Y, z, levs, norm=colors.LogNorm())
 
-cbar = fig.colorbar(cs)
+ax.colorbar()
 
 plt.show()
 

--- a/galleries/examples/images_contours_and_fields/image_masked.py
+++ b/galleries/examples/images_contours_and_fields/image_masked.py
@@ -42,29 +42,26 @@ Zm = np.ma.masked_where(Z > 1.2, Z)
 fig, (ax1, ax2) = plt.subplots(nrows=2, figsize=(6, 5.4))
 
 # plot using 'continuous' colormap
-im = ax1.imshow(Zm, interpolation='bilinear',
-                cmap=palette,
-                norm=colors.Normalize(vmin=-1.0, vmax=1.0),
-                aspect='auto',
-                origin='lower',
-                extent=[x0, x1, y0, y1])
+ax1.imshow(Zm, interpolation='bilinear',
+           cmap=palette,
+           norm=colors.Normalize(vmin=-1.0, vmax=1.0),
+           aspect='auto',
+           origin='lower',
+           extent=[x0, x1, y0, y1])
+ax1.colorbar(extend='both', shrink=0.9, label='uniform')
 ax1.set_title('Green=low, Red=high, Blue=masked')
-cbar = fig.colorbar(im, extend='both', shrink=0.9, ax=ax1)
-cbar.set_label('uniform')
 ax1.tick_params(axis='x', labelbottom=False)
 
 # Plot using a small number of colors, with unevenly spaced boundaries.
-im = ax2.imshow(Zm, interpolation='nearest',
-                cmap=palette,
-                norm=colors.BoundaryNorm([-1, -0.5, -0.2, 0, 0.2, 0.5, 1],
-                                         ncolors=palette.N),
-                aspect='auto',
-                origin='lower',
-                extent=[x0, x1, y0, y1])
+ax2.imshow(Zm, interpolation='nearest',
+           cmap=palette,
+           norm=colors.BoundaryNorm([-1, -0.5, -0.2, 0, 0.2, 0.5, 1],
+                                    ncolors=palette.N),
+           aspect='auto',
+           origin='lower',
+           extent=[x0, x1, y0, y1])
+ax2.colorbar(extend='both', spacing='proportional', shrink=0.9, label='proportional')
 ax2.set_title('With BoundaryNorm')
-cbar = fig.colorbar(im, extend='both', spacing='proportional',
-                    shrink=0.9, ax=ax2)
-cbar.set_label('proportional')
 
 fig.suptitle('imshow, with out-of-range and masked data')
 plt.show()

--- a/galleries/examples/images_contours_and_fields/irregulardatagrid.py
+++ b/galleries/examples/images_contours_and_fields/irregulardatagrid.py
@@ -59,7 +59,7 @@ zi = interpolator(Xi, Yi)
 ax1.contour(xi, yi, zi, levels=14, linewidths=0.5, colors='k')
 cntr1 = ax1.contourf(xi, yi, zi, levels=14, cmap="RdBu_r")
 
-fig.colorbar(cntr1, ax=ax1)
+ax1.colorbar(cntr1)
 ax1.plot(x, y, 'ko', ms=3)
 ax1.set(xlim=(-2, 2), ylim=(-2, 2))
 ax1.set_title('grid and contour (%d points, %d grid points)' %
@@ -74,7 +74,7 @@ ax1.set_title('grid and contour (%d points, %d grid points)' %
 ax2.tricontour(x, y, z, levels=14, linewidths=0.5, colors='k')
 cntr2 = ax2.tricontourf(x, y, z, levels=14, cmap="RdBu_r")
 
-fig.colorbar(cntr2, ax=ax2)
+ax2.colorbar(cntr2)
 ax2.plot(x, y, 'ko', ms=3)
 ax2.set(xlim=(-2, 2), ylim=(-2, 2))
 ax2.set_title('tricontour (%d points)' % npts)

--- a/galleries/examples/images_contours_and_fields/pcolor_demo.py
+++ b/galleries/examples/images_contours_and_fields/pcolor_demo.py
@@ -55,26 +55,26 @@ z_min, z_max = -abs(z).max(), abs(z).max()
 fig, axs = plt.subplots(2, 2)
 
 ax = axs[0, 0]
-c = ax.pcolor(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.pcolor(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.colorbar()
 ax.set_title('pcolor')
-fig.colorbar(c, ax=ax)
 
 ax = axs[0, 1]
-c = ax.pcolormesh(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.pcolormesh(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.colorbar()
 ax.set_title('pcolormesh')
-fig.colorbar(c, ax=ax)
 
 ax = axs[1, 0]
-c = ax.imshow(z, cmap='RdBu', vmin=z_min, vmax=z_max,
-              extent=[x.min(), x.max(), y.min(), y.max()],
-              interpolation='nearest', origin='lower', aspect='auto')
+ax.imshow(z, cmap='RdBu', vmin=z_min, vmax=z_max,
+          extent=[x.min(), x.max(), y.min(), y.max()],
+          interpolation='nearest', origin='lower', aspect='auto')
+ax.colorbar()
 ax.set_title('image (nearest, aspect="auto")')
-fig.colorbar(c, ax=ax)
 
 ax = axs[1, 1]
-c = ax.pcolorfast(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.pcolorfast(x, y, z, cmap='RdBu', vmin=z_min, vmax=z_max)
+ax.colorbar()
 ax.set_title('pcolorfast')
-fig.colorbar(c, ax=ax)
 
 fig.tight_layout()
 plt.show()
@@ -98,12 +98,12 @@ Z = Z1 + 50 * Z2
 
 fig, (ax0, ax1) = plt.subplots(2, 1)
 
-c = ax0.pcolor(X, Y, Z, shading='auto',
-               norm=LogNorm(vmin=Z.min(), vmax=Z.max()), cmap='PuBu_r')
-fig.colorbar(c, ax=ax0)
+ax0.pcolor(X, Y, Z, shading='auto',
+           norm=LogNorm(vmin=Z.min(), vmax=Z.max()), cmap='PuBu_r')
+ax0.colorbar()
 
-c = ax1.pcolor(X, Y, Z, cmap='PuBu_r', shading='auto')
-fig.colorbar(c, ax=ax1)
+ax1.pcolor(X, Y, Z, cmap='PuBu_r', shading='auto')
+ax1.colorbar()
 
 plt.show()
 

--- a/galleries/examples/images_contours_and_fields/pcolormesh_levels.py
+++ b/galleries/examples/images_contours_and_fields/pcolormesh_levels.py
@@ -99,17 +99,17 @@ norm = BoundaryNorm(levels, ncolors=cmap.N, clip=True)
 
 fig, (ax0, ax1) = plt.subplots(nrows=2)
 
-im = ax0.pcolormesh(x, y, z, cmap=cmap, norm=norm)
-fig.colorbar(im, ax=ax0)
+ax0.pcolormesh(x, y, z, cmap=cmap, norm=norm)
+ax0.colorbar()
 ax0.set_title('pcolormesh with levels')
 
 
 # contours are *point* based plots, so convert our bound into point
 # centers
-cf = ax1.contourf(x[:-1, :-1] + dx/2.,
-                  y[:-1, :-1] + dy/2., z, levels=levels,
-                  cmap=cmap)
-fig.colorbar(cf, ax=ax1)
+ax1.contourf(x[:-1, :-1] + dx/2.,
+             y[:-1, :-1] + dy/2., z, levels=levels,
+             cmap=cmap)
+ax1.colorbar()
 ax1.set_title('contourf with levels')
 
 # adjust spacing between subplots so `ax1` title and `ax0` tick labels

--- a/galleries/examples/images_contours_and_fields/plot_streamplot.py
+++ b/galleries/examples/images_contours_and_fields/plot_streamplot.py
@@ -33,8 +33,8 @@ axs[0].streamplot(X, Y, U, V, density=[0.5, 1])
 axs[0].set_title('Varying Density')
 
 # Varying color along a streamline
-strm = axs[1].streamplot(X, Y, U, V, color=U, linewidth=2, cmap='autumn')
-fig.colorbar(strm.lines)
+axs[1].streamplot(X, Y, U, V, color=U, linewidth=2, cmap='autumn')
+axs[1].colorbar()
 axs[1].set_title('Varying Color')
 
 #  Varying line width along a streamline
@@ -45,9 +45,9 @@ axs[2].set_title('Varying Line Width')
 # Controlling the starting points of the streamlines
 seed_points = np.array([[-2, -1, 0, 1, 2, -1], [-2, -1,  0, 1, 2, 2]])
 
-strm = axs[3].streamplot(X, Y, U, V, color=U, linewidth=2,
-                         cmap='autumn', start_points=seed_points.T)
-fig.colorbar(strm.lines)
+axs[3].streamplot(X, Y, U, V, color=U, linewidth=2,
+                  cmap='autumn', start_points=seed_points.T)
+axs[3].colorbar()
 axs[3].set_title('Controlling Starting Points')
 
 # Displaying the starting points with blue symbols.

--- a/galleries/examples/lines_bars_and_markers/multivariate_marker_plot.py
+++ b/galleries/examples/lines_bars_and_markers/multivariate_marker_plot.py
@@ -39,8 +39,8 @@ for skill, takeoff, thrust, mood, pos in data:
     t = Affine2D().scale(skill).rotate_deg(takeoff)
     m = MarkerStyle(SUCCESS_SYMBOLS[mood], transform=t)
     ax.plot(pos[0], pos[1], marker=m, color=cmap(thrust))
-fig.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap="plasma"),
-             ax=ax, label="Normalized Thrust [a.u.]")
+ax.colorbar(plt.cm.ScalarMappable(norm=Normalize(0, 1), cmap="plasma"),
+            label="Normalized Thrust [a.u.]")
 ax.set_xlabel("X position [m]")
 ax.set_ylabel("Y position [m]")
 

--- a/galleries/examples/misc/contour_manual.py
+++ b/galleries/examples/misc/contour_manual.py
@@ -30,7 +30,7 @@ fig, ax = plt.subplots()
 
 # Filled contours using filled=True.
 cs = ContourSet(ax, [0, 1, 2], [filled01, filled12], filled=True, cmap="bone")
-cbar = fig.colorbar(cs)
+cbar = ax.colorbar(cs)
 
 # Contour lines (non-filled).
 lines = ContourSet(
@@ -51,7 +51,7 @@ M = Path.MOVETO
 L = Path.LINETO
 kinds01 = [[M, L, L, L, M, L, L, L]]
 cs = ContourSet(ax, [0, 1], [filled01], [kinds01], filled=True)
-cbar = fig.colorbar(cs)
+ax.colorbar(cs)
 
 ax.set(xlim=(-0.5, 3.5), ylim=(-0.5, 3.5),
        title='User specified filled contours with holes')

--- a/galleries/examples/mplot3d/box3d.py
+++ b/galleries/examples/mplot3d/box3d.py
@@ -72,7 +72,7 @@ ax.view_init(40, -30, 0)
 ax.set_box_aspect(None, zoom=0.9)
 
 # Colorbar
-fig.colorbar(C, ax=ax, fraction=0.02, pad=0.1, label='Name [units]')
+ax.colorbar(C, fraction=0.02, pad=0.1, label='Name [units]')
 
 # Show Figure
 plt.show()

--- a/galleries/examples/mplot3d/subplot3d.py
+++ b/galleries/examples/mplot3d/subplot3d.py
@@ -26,10 +26,10 @@ Y = np.arange(-5, 5, 0.25)
 X, Y = np.meshgrid(X, Y)
 R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
-surf = ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap="coolwarm",
-                       linewidth=0, antialiased=False)
+ax.plot_surface(X, Y, Z, rstride=1, cstride=1, cmap="coolwarm",
+                linewidth=0, antialiased=False)
 ax.set_zlim(-1.01, 1.01)
-fig.colorbar(surf, shrink=0.5, aspect=10)
+ax.colorbar(shrink=0.5, aspect=10)
 
 # ==============
 # Second subplot

--- a/galleries/examples/mplot3d/surface3d.py
+++ b/galleries/examples/mplot3d/surface3d.py
@@ -25,8 +25,7 @@ R = np.sqrt(X**2 + Y**2)
 Z = np.sin(R)
 
 # Plot the surface.
-surf = ax.plot_surface(X, Y, Z, cmap="coolwarm",
-                       linewidth=0, antialiased=False)
+ax.plot_surface(X, Y, Z, cmap="coolwarm", linewidth=0, antialiased=False)
 
 # Customize the z axis.
 ax.set_zlim(-1.01, 1.01)
@@ -35,7 +34,7 @@ ax.zaxis.set_major_locator(LinearLocator(10))
 ax.zaxis.set_major_formatter('{x:.02f}')
 
 # Add a color bar which maps values to colors.
-fig.colorbar(surf, shrink=0.5, aspect=5)
+ax.colorbar(shrink=0.5, aspect=5)
 
 plt.show()
 

--- a/galleries/examples/shapes_and_collections/line_collection.py
+++ b/galleries/examples/shapes_and_collections/line_collection.py
@@ -53,7 +53,7 @@ ax.set_aspect("equal")  # to make the arcs look circular
 line_collection = LineCollection(arcs, array=radii, cmap="rainbow")
 ax.add_collection(line_collection)
 
-fig.colorbar(line_collection, label="Radius")
+ax.colorbar(label="Radius")
 ax.set_title("Line Collection with mapped colors")
 
 plt.show()

--- a/galleries/examples/shapes_and_collections/patch_collection.py
+++ b/galleries/examples/shapes_and_collections/patch_collection.py
@@ -56,7 +56,7 @@ colors = 100 * np.random.rand(len(patches))
 p = PatchCollection(patches, alpha=0.4)
 p.set_array(colors)
 ax.add_collection(p)
-fig.colorbar(p, ax=ax)
+ax.colorbar()
 
 plt.show()
 

--- a/galleries/examples/statistics/hexbin_demo.py
+++ b/galleries/examples/statistics/hexbin_demo.py
@@ -21,15 +21,15 @@ ylim = y.min(), y.max()
 
 fig, (ax0, ax1) = plt.subplots(ncols=2, sharey=True, figsize=(9, 4))
 
-hb = ax0.hexbin(x, y, gridsize=50, cmap='inferno')
+ax0.hexbin(x, y, gridsize=50, cmap='inferno')
+ax0.colorbar(label='counts')
 ax0.set(xlim=xlim, ylim=ylim)
 ax0.set_title("Hexagon binning")
-cb = fig.colorbar(hb, ax=ax0, label='counts')
 
-hb = ax1.hexbin(x, y, gridsize=50, bins='log', cmap='inferno')
+ax1.hexbin(x, y, gridsize=50, bins='log', cmap='inferno')
+ax1.colorbar(label='counts')
 ax1.set(xlim=xlim, ylim=ylim)
 ax1.set_title("With a log color scale")
-cb = fig.colorbar(hb, ax=ax1, label='counts')
 
 plt.show()
 

--- a/galleries/examples/statistics/time_series_histogram.py
+++ b/galleries/examples/statistics/time_series_histogram.py
@@ -77,15 +77,14 @@ x_fine = np.broadcast_to(x_fine, (num_series, num_fine)).ravel()
 cmap = plt.colormaps["plasma"]
 cmap = cmap.with_extremes(bad=cmap(0))
 h, xedges, yedges = np.histogram2d(x_fine, y_fine, bins=[400, 100])
-pcm = axes[1].pcolormesh(xedges, yedges, h.T, cmap=cmap,
-                         norm="log", vmax=1.5e2, rasterized=True)
-fig.colorbar(pcm, ax=axes[1], label="# points", pad=0)
+axes[1].pcolormesh(xedges, yedges, h.T, cmap=cmap,
+                   norm="log", vmax=1.5e2, rasterized=True)
+axes[1].colorbar(label="# points", pad=0)
 axes[1].set_title("2d histogram and log color scale")
 
 # Same data but on linear color scale
-pcm = axes[2].pcolormesh(xedges, yedges, h.T, cmap=cmap,
-                         vmax=1.5e2, rasterized=True)
-fig.colorbar(pcm, ax=axes[2], label="# points", pad=0)
+axes[2].pcolormesh(xedges, yedges, h.T, cmap=cmap, vmax=1.5e2, rasterized=True)
+axes[2].colorbar(label="# points", pad=0)
 axes[2].set_title("2d histogram and linear color scale")
 
 toc = time.time()

--- a/galleries/examples/subplots_axes_and_figures/axis_labels_demo.py
+++ b/galleries/examples/subplots_axes_and_figures/axis_labels_demo.py
@@ -11,10 +11,10 @@ import matplotlib.pyplot as plt
 
 fig, ax = plt.subplots()
 
-sc = ax.scatter([1, 2], [1, 2], c=[1, 2])
+ax.scatter([1, 2], [1, 2], c=[1, 2])
 ax.set_ylabel('YLabel', loc='top')
 ax.set_xlabel('XLabel', loc='left')
-cbar = fig.colorbar(sc)
+cbar = ax.colorbar()
 cbar.set_label("ZLabel", loc='top')
 
 plt.show()

--- a/galleries/examples/ticks/colorbar_tick_labelling_demo.py
+++ b/galleries/examples/ticks/colorbar_tick_labelling_demo.py
@@ -24,15 +24,14 @@ fig, ax = plt.subplots()
 
 data = rng.standard_normal((250, 250))
 
-cax = ax.imshow(data, vmin=-1, vmax=1, cmap='coolwarm')
+ax.imshow(data, vmin=-1, vmax=1, cmap='coolwarm')
 ax.set_title('Gaussian noise with vertical colorbar')
 
 # Add colorbar, make sure to specify tick locations to match desired ticklabels
-cbar = fig.colorbar(cax,
-                    ticks=[-1, 0, 1],
-                    format=mticker.FixedFormatter(['< -1', '0', '> 1']),
-                    extend='both'
-                    )
+cbar = ax.colorbar(ticks=[-1, 0, 1],
+                   format=mticker.FixedFormatter(['< -1', '0', '> 1']),
+                   extend='both'
+                   )
 labels = cbar.ax.get_yticklabels()
 labels[0].set_verticalalignment('top')
 labels[-1].set_verticalalignment('bottom')
@@ -44,11 +43,11 @@ fig, ax = plt.subplots()
 
 data = np.clip(data, -1, 1)
 
-cax = ax.imshow(data, cmap='afmhot')
+ax.imshow(data, cmap='afmhot')
 ax.set_title('Gaussian noise with horizontal colorbar')
 
 # Add colorbar and adjust ticks afterwards
-cbar = fig.colorbar(cax, orientation='horizontal')
+cbar = ax.colorbar(orientation='horizontal')
 cbar.set_ticks(ticks=[-1, 0, 1], labels=['Low', 'Medium', 'High'])
 
 plt.show()

--- a/galleries/examples/user_interfaces/mplcvd.py
+++ b/galleries/examples/user_interfaces/mplcvd.py
@@ -275,18 +275,18 @@ if __name__ == '__main__':
     Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
     Z = (Z1 - Z2) * 2
 
-    imv = axd['viridis'].imshow(
+    axd['viridis'].imshow(
         Z, interpolation='bilinear',
         origin='lower', extent=[-3, 3, -3, 3],
         vmax=abs(Z).max(), vmin=-abs(Z).max()
     )
-    fig.colorbar(imv)
-    imt = axd['turbo'].imshow(
+    axd['viridis'].colorbar()
+    axd['turbo'].imshow(
         Z, interpolation='bilinear', cmap='turbo',
         origin='lower', extent=[-3, 3, -3, 3],
         vmax=abs(Z).max(), vmin=-abs(Z).max()
     )
-    fig.colorbar(imt)
+    axd['turbo'].colorbar()
 
     # A sample image
     with cbook.get_sample_data('grace_hopper.jpg') as image_file:

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -11,6 +11,7 @@ import matplotlib as mpl
 import matplotlib.category  # Register category unit converter as side effect.
 import matplotlib.cbook as cbook
 import matplotlib.collections as mcoll
+import matplotlib.colorbar as mcolorbar  # noqa: F401, needed for docstring substitution
 import matplotlib.colorizer as mcolorizer
 import matplotlib.colors as mcolors
 import matplotlib.contour as mcontour
@@ -354,6 +355,74 @@ class Axes(_AxesBase):
 
     def _remove_legend(self, legend):
         self.legend_ = None
+
+    @_docstring.interpd
+    def colorbar(self, mappable=None, *, use_gridspec=True, **kwargs):
+        """
+        Add a colorbar next to the Axes.
+
+        Parameters
+        ----------
+        mappable : `matplotlib.colorizer.ColorizingArtist`, optional
+            The `.ColorizingArtist` (i.e., `.AxesImage`, `.ContourSet`, etc.) described
+            by this colorbar.
+
+            If not given, the mappable is inferred from the Axes. If there is exactly
+            one image or collection, this is used as mappable. Otherwise, an error is
+            raised and you must specify the mappable explicitly.
+
+            Note that one can create a `.colorizer.ColorizingArtist` "on-the-fly"
+            to generate colorbars not attached to a previously drawn artist, e.g.
+
+            ::
+
+                cr = colorizer.Colorizer(norm=norm, cmap=cmap)
+                ax.colorbar(colorizer.ColorizingArtist(cr))
+
+        Returns
+        -------
+        colorbar : `~matplotlib.colorbar.Colorbar`
+
+        Other Parameters
+        ----------------
+        use_gridspec : bool, optional
+            If *ax* is positioned with a subplotspec and *use_gridspec*
+            is ``True``, then *cax* is also positioned with a subplotspec.
+
+        %(_make_axes_kw_doc)s
+        %(_colormap_kw_doc)s
+
+        Notes
+        -----
+        This method is a convenience shortcut if you want to place a colorbar
+        right next to an Axes. ``ax.colorbar(mappable)`` is equivalent to
+        ``fig.colorbar(mappable, ax=ax)``. In particular, if you have exactly one
+        mappable in the Axes, the general ::
+
+            im = ax.imshow(data)
+            fig.colorbar(im, ax=ax)
+
+        can be written more concisely as ::
+
+            ax.imshow(data)
+            ax.colorbar()
+
+        Use `.Figure.colorbar` if you need more control on placing the colorbar.
+        """
+        if mappable is None:
+            # autodetect the mappable
+            colormapped_artists = [*self.images, *self.collections]
+            if len(colormapped_artists) != 1:
+                raise RuntimeError(
+                    "Axes.colormap() requires exactly one colormapped Artist in the "
+                    f"Axes, but found {len(colormapped_artists)}. In ambiguous cases, "
+                    "please specify the mappable for the colorbar explicitly."
+                )
+            mappable = colormapped_artists[0]
+
+        return self.figure.colorbar(
+            mappable, ax=self, use_gridspec=use_gridspec, **kwargs
+        )
 
     def inset_axes(self, bounds, *, transform=None, zorder=5, **kwargs):
         """

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -11,7 +11,9 @@ from matplotlib.collections import (
     EventCollection,
     QuadMesh,
 )
-from matplotlib.colorizer import Colorizer
+from matplotlib.cm import ScalarMappable
+from matplotlib.colorbar import Colorbar
+from matplotlib.colorizer import Colorizer, ColorizingArtist
 from matplotlib.colors import Colormap, Normalize
 from matplotlib.container import (
     BarContainer, PieContainer, ErrorbarContainer, StemContainer)
@@ -77,6 +79,13 @@ class Axes(_AxesBase):
     @overload
     def legend(self, *, loc: LegendLocType | None = ..., **kwargs) -> Legend: ...
 
+    def colorbar(
+        self,
+        mappable: ScalarMappable | ColorizingArtist | None = ...,
+        *,
+        use_gridspec: bool = ...,
+        **kwargs
+    ) -> Colorbar: ...
     def inset_axes(
         self,
         bounds: tuple[float, float, float, float],

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9329,6 +9329,27 @@ def test_automatic_legend():
     assert ax.get_yticklabels()[0].get_text() == 'b'
 
 
+def test_colorbar():
+    """Test that Axes.colorbar() without arguments uses the only mappable."""
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1)
+
+    im = ax1.imshow([[0, 1], [2, 3]])
+    cb = ax1.colorbar()
+    assert cb.mappable is im
+
+    path_collection = ax2.scatter([0, 1], [0, 1], c=[0, 1])
+    cb2 = ax2.colorbar()
+    assert cb2.mappable is path_collection
+
+    # in case of multiple mappables: bare colorbar() fails, but passing a mappable works
+    im = ax3.imshow([[0, 1], [2, 3]])
+    ax3.scatter([0, 1], [0, 1], c=[0, 1])
+    with pytest.raises(RuntimeError, match="requires exactly one colormapped Artist"):
+        ax3.colorbar()
+    cb3 = ax3.colorbar(im)
+    assert cb3.mappable is im
+
+
 def test_plot_errors():
     with pytest.raises(TypeError, match=r"plot\(\) got an unexpected keyword"):
         plt.plot([1, 2, 3], x=1)


### PR DESCRIPTION
Up to now, we have `pyplot.colorbar()` and `Figure.colorbar()`. 

https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.colorbar.html is convenient in that one can do
```python
plt.imshow(data)
plt.colorbar()
```
and it automatically uses the current image.

With https://matplotlib.org/stable/api/_as_gen/matplotlib.figure.Figure.colorbar.html one has to explicitly pass the image, leading to somewhat bulky
```python
im = ax.imshow(data)
fig.colorbar(im)
```

This PR replicates the ease of use of `plt.colorbar()` in the OOP interface on an Axes: While we don't have the "current image" notion. Intent is still unambiguos if there is exactly one mappable in the Axes, which is the most common case. So one can do
```python
ax.imshow(data)
ax.colorbar()
```

Note also that `ax.colorbar()` is somewhat analogous to `ax.legend()`: Add an explaining context Artist, based on the information that is already in the Axes; i.e. all parameters are optional.

---

**Reviewing**: This PR consists of to commits:
- Introducing the actual method
- Applying it to examples

Use the examples to get a feeling how this will work in practice.