### PR TITLE
Voxels 3d colorizer v2

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1043,6 +1043,8 @@ class Colorbar:
 
         try:
             ax = self.mappable.axes
+            if ax is None:
+                return
         except AttributeError:
             return
         try:

--- a/lib/matplotlib/colorizer.pyi
+++ b/lib/matplotlib/colorizer.pyi
@@ -1,4 +1,4 @@
-from matplotlib import cbook, colorbar, colors, artist
+from matplotlib import cbook, colorbar, colors, artist, axes as maxes
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -71,7 +71,24 @@ class _ColorizerInterface:
     def autoscale_None(self) -> None: ...
 
 
-class _ScalarMappable(_ColorizerInterface):
+class _ColorbarMappable(_ColorizerInterface):
+    def __init__(
+        self,
+        colorizer: Colorizer | None,
+        **kwargs
+    ) -> None: ...
+    @property
+    def colorizer(self) -> Colorizer: ...
+    @colorizer.setter
+    def colorizer(self, cl: Colorizer) -> None: ...
+    def changed(self) -> None: ...
+    @property
+    def axes(self) -> maxes._base._AxesBase | None: ...
+    @axes.setter
+    def axes(self, new_axes: maxes._base._AxesBase | None) -> None: ...
+
+
+class _ScalarMappable(_ColorbarMappable):
     def __init__(
         self,
         norm: colors.Norm | None = ...,
@@ -82,7 +99,6 @@ class _ScalarMappable(_ColorizerInterface):
     ) -> None: ...
     def set_array(self, A: ArrayLike | None) -> None: ...
     def get_array(self) -> np.ndarray | None: ...
-    def changed(self) -> None: ...
 
 
 class ColorizingArtist(_ScalarMappable, artist.Artist):

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -3592,7 +3592,7 @@ class Axes3D(Axes):
 
         # iterate over the faces, and generate a Poly3DCollection for each
         # voxel
-        polygons = art3d.VoxelDict(self, colorizer)
+        polygons = art3d.VoxelDict(colorizer, self)
         for coord, faces_inds in voxel_faces.items():
             # convert indices into 3D positions
             if xyz is None:

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import platform
 import sys
+import collections.abc
 
 from packaging.version import parse as parse_version
 import pytest
@@ -1496,7 +1497,7 @@ class TestVoxels:
         colors[v1] = [0, 1, 0, 0.5]
         v = ax.voxels(voxels, facecolors=colors)
 
-        assert type(v) is dict
+        assert issubclass(type(v), collections.abc.MutableMapping)
         for coord, poly in v.items():
             assert voxels[coord], "faces returned for absent voxel"
             assert isinstance(poly, art3d.Poly3DCollection)


### PR DESCRIPTION
## PR summary
This PR is in response to and closes #22969 [ENH]: Voxels as mappable for colorbar
The technical implementation builds upon the discussion in PR #30982 (closed) 

This change allows axes3d.voxels() to take scalar data as input, and map it to color using a colorbar. The colors are applied to the voxels before shading.

The following code demonstrates the new functionality:
```py
import numpy as np
import matplotlib.pyplot as plt

#Mock data
X,Y,Z = np.meshgrid(np.linspace(0,5,10), np.linspace(0,5,10), np.linspace(0,5,10), indexing="ij")
Hist = np.zeros((9,9,9))
Hist[2,5,5], Hist[5,5,3], Hist[5,7,5], Hist[5,0,5] = 1, 55, 4, 39
Hist[5,1,5] = 39
Hist[Hist == 0] = np.nan

# plot
fig=plt.figure()
ax = fig.add_subplot(projection='3d')
res = ax.voxels(X, Y, Z, Hist, cmap='rainbow', norm='log', alpha=0.5)
fig.colorbar(res)
res.colorizer.norm.vmin = 3
```
<img width="491" height="400" alt="image" src="https://github.com/user-attachments/assets/5d01e39b-f084-4384-bd74-ef44945b2974" />

The technical implementation is such that:
* scalar data can be input instead of boolean for the `filled` argument
>       filled : 3D np.array of bool or float
>            If bool, with truthy values indicate which voxels to fill.
>            If float, voxels with finite values are shown with color
>            mapped via *cmap* and *norm*, while voxels with nan are ignored.

### Technical implementation

This technical implementation changes the return type of `ax.voxel()` from `dict` to the new class `VoxelDict`. 
Where `VoxelDict` is valid input for `fig.colorbar()`, but `VoxelDict` is not itself an artist.

```py
class VoxelDict(mcolorizer._ColorbarMappable,
                collections.abc.MutableMapping):
```

`VoxelDict` inherits from `_ColorbarMappable`, a new class introduced in the class hierarchy of `ColorizingArtist` (colorizer.py).
with these changes, this hierarchy is now:

```py
class _ColorizerInterface:
    ...
class _ColorbarMappable(_ColorizerInterface):
    """
    Base class for objects that can connect to a colorbar.

    All classes that can act as a mappable for `fig.colorbar(mappable)`
    will subclass this class.
    """
    ...
class _ScalarMappable(_ColorbarMappable):
    ...
class ColorizingArtist(_ScalarMappable, artist.Artist):
    ...
```

I believe this change in the class hierarchy is suitable, because it makes explicit the requirements for colorbar.

### Next step

First we need a discussion about the merits of the technical implementation.
Note that this implementation allows the user to set new data on existing voxels (which will update the colors), but it does not allow for adding/removing the voxels themselves [this will require more complicated methods, and can be implemented later].

If there is agreement that this implementation is suitable, I will need to add more tests.


- [x] "closes #22969" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
