### PR TITLE
Add type hint for fig_kw in subplots

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -1665,7 +1665,7 @@ def subplots(
     height_ratios: Sequence[float] | None = ...,
     subplot_kw: dict[str, Any] | None = ...,
     gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
+    **fig_kw: Any
 ) -> tuple[Figure, Axes]:
     ...
 
@@ -1682,7 +1682,7 @@ def subplots(
     height_ratios: Sequence[float] | None = ...,
     subplot_kw: dict[str, Any] | None = ...,
     gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
+    **fig_kw: Any
 ) -> tuple[Figure, np.ndarray]:  # TODO numpy/numpy#24738
     ...
 
@@ -1699,7 +1699,7 @@ def subplots(
     height_ratios: Sequence[float] | None = ...,
     subplot_kw: dict[str, Any] | None = ...,
     gridspec_kw: dict[str, Any] | None = ...,
-    **fig_kw
+    **fig_kw: Any
 ) -> tuple[Figure, Any]:
     ...
 
@@ -1713,7 +1713,7 @@ def subplots(
     height_ratios: Sequence[float] | None = None,
     subplot_kw: dict[str, Any] | None = None,
     gridspec_kw: dict[str, Any] | None = None,
-    **fig_kw
+    **fig_kw: Any
 ) -> tuple[Figure, Any]:
     """
     Create a figure and a set of subplots.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

Connects to #31003

## Description
Adds `Any` type hint to `**fig_kw` in `pyplot.subplots`.

## Rationale
Currently, `fig_kw` is untyped. This causes `reportUnknownMemberType` errors in downstream projects (like `pandas-stubs`) that attempt to use strict Pyright type checking. Since `fig_kw` passes arbitrary keyword arguments to the `Figure` constructor, `Any` is the appropriate type annotation here.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #31003 is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
