### PR TITLE
introduction of _ColorbarMappable

### DIFF
--- a/doc/api/colorizer_api.rst
+++ b/doc/api/colorizer_api.rst
@@ -6,4 +6,4 @@
    :members:
    :undoc-members:
    :show-inheritance:
-   :private-members: _ColorizerInterface, _ScalarMappable
+   :private-members: _ColorbarMappable, _ScalarMappable

--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1043,6 +1043,8 @@ class Colorbar:
 
         try:
             ax = self.mappable.axes
+            if ax is None:
+                return
         except AttributeError:
             return
         try:

--- a/lib/matplotlib/colorizer.pyi
+++ b/lib/matplotlib/colorizer.pyi
@@ -1,4 +1,4 @@
-from matplotlib import cbook, colorbar, colors, artist
+from matplotlib import cbook, colorbar, colors, artist, axes as maxes
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -46,10 +46,27 @@ class Colorizer:
     def clip(self, value: bool) -> None: ...
 
 
-class _ColorizerInterface:
-    cmap: colors.Colormap
+
+class _ColorbarMappable:
     colorbar: colorbar.Colorbar | None
     callbacks: cbook.CallbackRegistry
+    cmap: colors.Colormap
+    def __init__(
+        self,
+        colorizer: Colorizer | None,
+        **kwargs
+    ) -> None: ...
+    @property
+    def colorizer(self) -> Colorizer: ...
+    @colorizer.setter
+    def colorizer(self, cl: Colorizer) -> None: ...
+    def changed(self) -> None: ...
+    def set_array(self, A: ArrayLike | None) -> None: ...
+    def get_array(self) -> np.ndarray | None: ...
+    @property
+    def axes(self) -> maxes._base._AxesBase | None: ...
+    @axes.setter
+    def axes(self, new_axes: maxes._base._AxesBase | None) -> None: ...
     def to_rgba(
         self,
         x: np.ndarray,
@@ -71,7 +88,7 @@ class _ColorizerInterface:
     def autoscale_None(self) -> None: ...
 
 
-class _ScalarMappable(_ColorizerInterface):
+class _ScalarMappable(_ColorbarMappable):
     def __init__(
         self,
         norm: colors.Norm | None = ...,
@@ -80,9 +97,6 @@ class _ScalarMappable(_ColorizerInterface):
         colorizer: Colorizer | None = ...,
         **kwargs
     ) -> None: ...
-    def set_array(self, A: ArrayLike | None) -> None: ...
-    def get_array(self) -> np.ndarray | None: ...
-    def changed(self) -> None: ...
 
 
 class ColorizingArtist(_ScalarMappable, artist.Artist):

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -78,7 +78,7 @@ from matplotlib.axes import Axes
 from matplotlib.axes import Subplot  # noqa: F401
 from matplotlib.backends import BackendFilter, backend_registry
 from matplotlib.projections import PolarAxes
-from matplotlib.colorizer import _ColorizerInterface, ColorizingArtist, Colorizer
+from matplotlib.colorizer import _ColorbarMappable, ColorizingArtist, Colorizer
 from matplotlib import mlab  # for detrend_none, window_hanning
 from matplotlib.scale import get_scale_names  # noqa: F401
 
@@ -4201,7 +4201,7 @@ def spy(
         origin=origin,
         **kwargs,
     )
-    if isinstance(__ret, _ColorizerInterface):
+    if isinstance(__ret, _ColorbarMappable):
         sci(__ret)
     return __ret
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -15,6 +15,7 @@ from matplotlib.colors import (
     BoundaryNorm, LogNorm, PowerNorm, Normalize, NoNorm
 )
 from matplotlib.colorbar import Colorbar
+from matplotlib.colorizer import Colorizer, _ColorbarMappable
 from matplotlib.ticker import FixedLocator, LogFormatter, StrMethodFormatter
 from matplotlib.testing.decorators import check_figures_equal
 
@@ -1242,3 +1243,24 @@ def test_colorbar_format_string_and_old():
     plt.imshow([[0, 1]])
     cb = plt.colorbar(format="{x}%")
     assert isinstance(cb._formatter, StrMethodFormatter)
+
+
+def test_ColorbarMappable_as_input():
+    # check that _ColorbarMappable can function as a
+    # valid input for colorbar
+    fig, ax = plt.subplots()
+    norm = Normalize(vmin=-5, vmax=10)
+    cl = Colorizer(norm=norm)
+    cbm = _ColorbarMappable(cl)
+    # test without an axes on the mappable, no kwarg
+    with pytest.raises(ValueError, match='Unable to determine Axes to steal'):
+        cb = fig.colorbar(cbm)
+    # test without an axes on the mappable, with kwarg
+    cb = fig.colorbar(cbm, ax=ax)
+    cb = fig.colorbar(cbm, cax=ax)
+    # test without an axes on the mappable
+    cbm.axes = ax
+    cb = fig.colorbar(cbm)
+    assert cb.mappable is cbm
+    assert cb.vmin == -5
+    assert cb.vmax == 10

--- a/tools/boilerplate.py
+++ b/tools/boilerplate.py
@@ -313,7 +313,7 @@ def boilerplate_gen():
         'hist2d': 'sci(__ret[-1])',
         'imshow': 'sci(__ret)',
         'spy': (
-            'if isinstance(__ret, _ColorizerInterface):\n'
+            'if isinstance(__ret, _ColorbarMappable):\n'
             '        sci(__ret)'
         ),
         'quiver': 'sci(__ret)',


### PR DESCRIPTION
This PR renames `_ColorizerInterface` to `_ColorbarMappable` and shifts some functionality such that `_ColorbarMappable` can function as the mappable for `fig.colorbar(mappable)`. 

`_ColorbarMappable` differs from a `ColorizingArtist` [the regular input to `fig.colobar()`] in that it is not an `Artist`.
This change is needed for improvements to `Axes3d.voxel()`, see https://github.com/matplotlib/matplotlib/pull/31032, but may also find other uses.

I don't think there is currently any use case for `_ColorizerInterface` outside of ColorizingArtist

This PR only changes the private API, with no changes to the public API.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
