### PR TITLE
When removing colorbar, restore the correct parent axes.

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -1026,12 +1026,13 @@ class Colorbar:
         If the colorbar was created with ``use_gridspec=True`` the previous
         gridspec is restored.
         """
-        if hasattr(self.ax, '_colorbar_info'):
-            parents = self.ax._colorbar_info['parents']
-            for a in parents:
-                if self.ax in a._colorbars:
-                    a._colorbars.remove(self.ax)
+        parents = (self.ax._colorbar_info["parents"]
+                   if hasattr(self.ax, "_colorbar_info") else [])
+        for ax in parents:
+            if self.ax in ax._colorbars:
+                ax._colorbars.remove(self.ax)
 
+        fig = self.ax.figure
         self.ax.remove()
 
         self.mappable.callbacks.disconnect(self.mappable.colorbar_cid)
@@ -1041,17 +1042,23 @@ class Colorbar:
         self.ax.callbacks.disconnect(self._extend_cid1)
         self.ax.callbacks.disconnect(self._extend_cid2)
 
-        try:
-            ax = self.mappable.axes
-        except AttributeError:
+        if not fig.get_layout_engine().colorbar_gridspec:
+            # Don't do anything, the layout engine fully handles repositioning.
             return
-        try:
-            subplotspec = self.ax.get_subplotspec().get_gridspec()._subplot_spec
-        except AttributeError:  # use_gridspec was False
-            pos = ax.get_position(original=True)
-            ax._set_position(pos)
-        else:  # use_gridspec was True
-            ax.set_subplotspec(subplotspec)
+        if parents:
+            # self.ax was created via make_axes or make_axes_gridspec; try to
+            # restore parents' original positions, i.e. to the state before
+            # they were resized to make room for the colorbar Axes.
+            if (self.ax.get_subplotspec()  # use_gridspec is True
+                    and len(parents) == 1
+                    and parents[0].get_subplotspec()
+                    and (self.ax.get_subplotspec().get_gridspec()
+                         is parents[0].get_subplotspec().get_gridspec())):
+                parents[0].set_subplotspec(
+                    self.ax.get_subplotspec().get_gridspec()._subplot_spec)
+            else:  # use_gridspec is False
+                for ax in parents:
+                    ax._set_position(ax.get_position(original=True))
 
     def _process_values(self):
         """


### PR DESCRIPTION
To figure out which axes need to be restored, `mappable.axes` is less reliable than `_colorbar_info["parents"]`.

Why the tests now need a greater (though still tiny) tolerance to make the "orphan mappable" case pass is a mystery.

Closes #22257.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
