### PR TITLE
Add tests for invalid properties and duplicate aliases in Artist.set

### DIFF
--- a/lib/matplotlib/tests/test_artist.py
+++ b/lib/matplotlib/tests/test_artist.py
@@ -264,7 +264,7 @@ def test_artist_set_invalid_property_raises():
     Test that set() raises AttributeError for invalid property names.
     """
     line = mlines.Line2D([0, 1], [0, 1])
-    
+
     with pytest.raises(AttributeError, match="unexpected keyword argument"):
         line.set(not_a_property=1)
 
@@ -274,7 +274,7 @@ def test_artist_set_duplicate_aliases_raises():
     Test that set() raises TypeError when both a property and its alias are provided.
     """
     line = mlines.Line2D([0, 1], [0, 1])
-    
+
     with pytest.raises(TypeError, match="aliases of one another"):
         line.set(lw=2, linewidth=3)
 


### PR DESCRIPTION
## PR Summary

As mentioned in #30979, set is not tested directly even though it is used in many places.

These tests lock in the current behaviour:

-passing an invalid property name raises an AttributeError, and
-providing both a property and its alias (for example lw and linewidth) raises a TypeError.

The behaviour already exists at runtime; these tests just make sure it doesn’t change by accident.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines

