### PR TITLE
fix for sphinx_gallery < 0.16.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -194,6 +194,7 @@ if parse_version(sphinx_gallery.__version__) >= parse_version('0.16.0'):
     gallery_order_sectionorder = 'sphinxext.gallery_order.sectionorder'
     gallery_order_subsectionorder = 'sphinxext.gallery_order.subsectionorder'
     clear_basic_units = 'sphinxext.util.clear_basic_units'
+    patch_header = 'sphinxext.util.patch_header'
     matplotlib_reduced_latex_scraper = 'sphinxext.util.matplotlib_reduced_latex_scraper'
 else:
     # gallery_order.py from the sphinxext folder provides the classes that
@@ -201,7 +202,8 @@ else:
     from sphinxext.gallery_order import (
         sectionorder as gallery_order_sectionorder,
         subsectionorder as gallery_order_subsectionorder)
-    from sphinxext.util import clear_basic_units, matplotlib_reduced_latex_scraper
+    from sphinxext.util import (clear_basic_units, matplotlib_reduced_latex_scraper,
+                                patch_header)
 
 if parse_version(sphinx_gallery.__version__) >= parse_version('0.17.0'):
     sg_matplotlib_animations = (True, 'mp4')
@@ -305,7 +307,7 @@ sphinx_gallery_conf = {
     'reference_url': {'matplotlib': None, 'mpl_toolkits': None},
     'prefer_full_module': {r'mpl_toolkits\.'},
     'remove_config_comments': True,
-    'reset_modules': ('matplotlib', clear_basic_units, 'sphinxext.util.patch_header'),
+    'reset_modules': ('matplotlib', clear_basic_units, patch_header),
     'subsection_order': gallery_order_sectionorder,
     'thumbnail_size': (320, 224),
     'within_subsection_order': gallery_order_subsectionorder,


### PR DESCRIPTION
This is a simple PR that fixes a bug I discovered when trying to build the docs. 
Because I have not updated my system, I have sphinx_gallery 0.14.0, and the docs do not compile due to the following line.
`    'reset_modules': ('matplotlib', clear_basic_units, 'sphinxext.util.patch_header'),`
This is the relevant commit https://github.com/matplotlib/matplotlib/commit/c9f728992464965c58fc41c2202cecf6d2fb744a
<img width="632" height="185" alt="image" src="https://github.com/user-attachments/assets/65d1154c-3bfa-44e8-989b-7af444dd0546" />


This PR changes how `sphinxext.util.patch_header` is imported so that it behaves the same as `sphinxext.util.clear_basic_units`, which differs depending on the version of sphinx_gallery.

An alternative solution is probably to require sphinx_gallery >= 0.16.0, but I have not evaluated this.