### PR TITLE
Implement TeX's fraction and script alignment

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -958,53 +958,83 @@ class ComputerModernFontConstants(FontConstantsBase):
     # type 32). Now that we're using the rendered x-height, some font constants
     # have been increased by the same factor to compensate.
     script_space = 0.132861328125
-    supdrop = 0.354296875
-    subdrop = 0.354296875
-    sup1 = 0.79716796875
-    sub1 = 0.354296875
-    sub2 = 0.5314453125
     delta = 0.132861328125
     delta_slanted = 0.3
     delta_integral = 0.3
-    num1 = 1.5
-    num2 = 1.5
-    num3 = 1.5
-    denom1 = 1.6
-    denom2 = 1.2
+    _x_height = 451470
+    # These all come from the cmsy10.tfm metrics, divided by the design xheight from
+    # there, since we multiply these values by the scaled xheight later.
+    supdrop = 404864 / _x_height
+    subdrop = 52429 / _x_height
+    sup1 = 432949 / _x_height
+    sub1 = 157286 / _x_height
+    sub2 = 259226 / _x_height
+    num1 = 709370 / _x_height
+    num2 = 412858 / _x_height
+    num3 = 465286 / _x_height
+    denom1 = 719272 / _x_height
+    denom2 = 361592 / _x_height
 
 
 class STIXFontConstants(FontConstantsBase):
     script_space = 0.1
-    sup1 = 0.8
-    sub2 = 0.6
     delta = 0.05
     delta_slanted = 0.3
     delta_integral = 0.3
-    num1 = 1.6
-    num2 = 1.6
-    num3 = 1.6
-    denom1 = 1.6
+    # These values are extracted from the TeX table of STIXGeneral.ttf using FreeType,
+    # and then divided by design xheight, since we multiply these values by the scaled
+    # xheight later.
+    _x_height = 450
+    supdrop = 386 / _x_height
+    subdrop = 50.0002 / _x_height
+    sup1 = 413 / _x_height
+    sub1 = 150 / _x_height
+    sub2 = 309 / _x_height
+    num1 = 747 / _x_height
+    num2 = 424 / _x_height
+    num3 = 474 / _x_height
+    denom1 = 756 / _x_height
+    denom2 = 375 / _x_height
 
 
-class STIXSansFontConstants(FontConstantsBase):
+class STIXSansFontConstants(STIXFontConstants):
     script_space = 0.05
-    sup1 = 0.8
     delta_slanted = 0.6
     delta_integral = 0.3
-    num1 = 1.5
-    num3 = 1.5
-    denom1 = 1.5
 
 
 class DejaVuSerifFontConstants(FontConstantsBase):
-    num1 = 1.5
-    num2 = 1.6
-    num3 = 1.4
-    denom1 = 1.4
+    # These values are extracted from the TeX table of DejaVuSerif.ttf using FreeType,
+    # and then divided by design xheight, since we multiply these values by the scaled
+    # xheight later.
+    _x_height = 1063
+    supdrop = 790.527 / _x_height
+    subdrop = 102.4 / _x_height
+    sup1 = 845.824 / _x_height
+    sub1 = 307.199 / _x_height
+    sub2 = 632.832 / _x_height
+    num1 = 1529.86 / _x_height
+    num2 = 868.352 / _x_height
+    num3 = 970.752 / _x_height
+    denom1 = 1548.29 / _x_height
+    denom2 = 768 / _x_height
 
 
 class DejaVuSansFontConstants(FontConstantsBase):
-    pass
+    # These values are extracted from the TeX table of DejaVuSans.ttf using FreeType,
+    # and then divided by design xheight, since we multiply these values by the scaled
+    # xheight later.
+    _x_height = 1120
+    supdrop = 790.527 / _x_height
+    subdrop = 102.4 / _x_height
+    sup1 = 845.824 / _x_height
+    sub1 = 307.199 / _x_height
+    sub2 = 632.832 / _x_height
+    num1 = 1529.86 / _x_height
+    num2 = 868.352 / _x_height
+    num3 = 970.752 / _x_height
+    denom1 = 1548.29 / _x_height
+    denom2 = 768 / _x_height
 
 
 # Maps font family names to the FontConstantBase subclass to use

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -577,12 +577,12 @@ def test_box_repr():
         _mathtext.DejaVuSansFonts(fm.FontProperties(), LoadFlags.NO_HINTING),
         fontsize=12, dpi=100))
     assert s == textwrap.dedent("""\
-        Hlist<w=9.51 h=18.09 d=7.03 s=0.00>[
+        Hlist<w=9.51 h=15.30 d=5.00 s=0.00>[
           Hlist<w=0.00 h=0.00 d=0.00 s=0.00>[],
-          Hlist<w=9.51 h=18.09 d=7.03 s=0.00>[
-            Hlist<w=9.51 h=18.09 d=7.03 s=0.00>[
+          Hlist<w=9.51 h=15.30 d=5.00 s=0.00>[
+            Hlist<w=9.51 h=15.30 d=5.00 s=0.00>[
               Hbox,
-              Vlist<w=7.43 h=25.12 d=0.00 s=7.03>[
+              Vlist<w=7.43 h=20.30 d=0.00 s=5.00>[
                 HCentered<w=7.43 h=8.51 d=0.00 s=0.00>[
                   Glue,
                   Hlist<w=7.43 h=8.51 d=0.00 s=0.00>[


### PR DESCRIPTION
## PR summary

This is a rebase of #22852 by @tfpf. However, since we are planning to refresh the test images already, this reverts the change to move many mathtext images to SVG only (and I believe fixes some duplicated tests due to incorrect conflict resolution). Now, the only test change is to a nested-`\frac` test that is a duplicate and now is a nested-`\dfrac` test.

This is based on #30059 plus all the current test image changes, so that you can look at the second-last commit for this change and the _last_ commit to review image changes from only this PR. I believe it does a fairly good job of fixing the fraction bar alignment issue that came up in #30059.

I have reviewed the fraction and sub/super script implementation with reference to the TeX book, but have not yet finished reviewing the font constants.

Fixes #18086
Fixes #18389
Fixes #22172

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines