### PR TITLE
ft2font: Extend OS/2 table with new fields

### DIFF
--- a/lib/matplotlib/ft2font.pyi
+++ b/lib/matplotlib/ft2font.pyi
@@ -1,7 +1,7 @@
 from enum import Enum, Flag
 from os import PathLike
 import sys
-from typing import BinaryIO, Literal, NewType, TypeAlias, TypedDict, cast, final, overload
+from typing import BinaryIO, Literal, NewType, NotRequired, TypeAlias, TypedDict, cast, final, overload
 from typing_extensions import Buffer  # < Py 3.12
 
 import numpy as np
@@ -142,6 +142,17 @@ class _SfntOs2Dict(TypedDict):
     fsSelection: int
     fsFirstCharIndex: int
     fsLastCharIndex: int
+    # version >= 1
+    ulCodePageRange: NotRequired[tuple[int, int]]
+    # version >= 2
+    sxHeight: NotRequired[int]
+    sCapHeight: NotRequired[int]
+    usDefaultChar: NotRequired[int]
+    usBreakChar: NotRequired[int]
+    usMaxContext: NotRequired[int]
+    # version >= 5
+    usLowerOpticalPointSize: NotRequired[int]
+    usUpperOpticalPointSize: NotRequired[int]
 
 class _SfntHheaDict(TypedDict):
     version: tuple[int, int]

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -590,6 +590,7 @@ _expected_sfnt_tables = {
             'ulCharRange': (3875565311, 3523280383, 170156073, 67117068),
             'achVendID': b'PfEd',
             'fsSelection': 64, 'fsFirstCharIndex': 32, 'fsLastCharIndex': 65535,
+            'ulCodePageRange': (1610613247, 3758030848),
         },
         'hhea': {
             'version': (1, 0),
@@ -736,6 +737,12 @@ _expected_sfnt_tables = {
             'ulCharRange': (3, 192, 0, 0),
             'achVendID': b'STIX',
             'fsSelection': 32, 'fsFirstCharIndex': 32, 'fsLastCharIndex': 10217,
+            'ulCodePageRange': (2688417793, 2432565248),
+            'sxHeight': 0,
+            'sCapHeight': 0,
+            'usDefaultChar': 0,
+            'usBreakChar': 32,
+            'usMaxContext': 1,
         },
         'hhea': {
             'version': (1, 0),

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1263,8 +1263,9 @@ PyFT2Font_get_sfnt_table(PyFT2Font *self, std::string tagname)
     }
     case FT_SFNT_OS2: {
         auto t = static_cast<TT_OS2 *>(table);
-        return py::dict(
-            "version"_a=t->version,
+        auto version = t->version;
+        auto result = py::dict(
+            "version"_a=version,
             "xAvgCharWidth"_a=t->xAvgCharWidth,
             "usWeightClass"_a=t->usWeightClass,
             "usWidthClass"_a=t->usWidthClass,
@@ -1287,6 +1288,22 @@ PyFT2Font_get_sfnt_table(PyFT2Font *self, std::string tagname)
             "fsSelection"_a=t->fsSelection,
             "fsFirstCharIndex"_a=t->usFirstCharIndex,
             "fsLastCharIndex"_a=t->usLastCharIndex);
+        if (version >= 1) {
+            result["ulCodePageRange"] = py::make_tuple(t->ulCodePageRange1,
+                                                       t->ulCodePageRange2);
+        }
+        if (version >= 2) {
+            result["sxHeight"] = t->sxHeight;
+            result["sCapHeight"] = t->sCapHeight;
+            result["usDefaultChar"] = t->usDefaultChar;
+            result["usBreakChar"] = t->usBreakChar;
+            result["usMaxContext"] = t->usMaxContext;
+        }
+        if (version >= 5) {
+            result["usLowerOpticalPointSize"] = t->usLowerOpticalPointSize;
+            result["usUpperOpticalPointSize"] = t->usUpperOpticalPointSize;
+        }
+        return result;
     }
     case FT_SFNT_HHEA: {
         auto t = static_cast<TT_HoriHeader *>(table);


### PR DESCRIPTION
## PR summary

Versions 1, 2, and 5 add additional fields to this struct, which may or may not be useful in the future.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines