### PR TITLE
Keep mathtext boxes in xywh representation throughout.

### DIFF
--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -205,7 +205,7 @@ class RendererAgg(RendererBase):
         gc1 = self.new_gc()
         gc1.set_linewidth(0)
         gc1.set_snap(gc.get_snap())
-        for dx, dy, w, h in parse.rects:  # dy is upwards & the rect top side.
+        for dx, dy, w, h in parse.rects:  # dy is upwards.
             if gc1.get_snap() in [None, True]:
                 # Prevent thin bars from disappearing by growing symmetrically.
                 if w < 1:


### PR DESCRIPTION
Previously, mathtext boxes would swap between xywh and x1y1x2y2 representation in the code: ship() uses xywh, calls Rule.render() which converts to x1y1x2y2 and stores in Output.rects in that format; then Output.to_vector() would convert back to xywh (while also swapping downwards y's to upwards y's).  Instead, stick to xywh representation throughout (the rectangle always goes from x to x+w and y to y+h, regardless of whether y is upwards or downwards).  No actual calculation is changed.

Also remove an incorrect comment in RendererAgg.draw_mathtext: "dy" (i.e., y) isn't at the rect top side, but actually usually the bottom one; in any case, again it always goes from dy to dy+h.

-----

Noted while investigating https://github.com/matplotlib/matplotlib/pull/31046#issuecomment-3832185598, which this doesn't touch (the patch mentioned in that issue would now be to swap `self.fontset.render_rect_filled(output, x, y, w, h)` to `self.fontset.render_rect_filled(output, x, y - h, w, h)`).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
