### PR TITLE
MNT: Remove unused eventson context from artist property update

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -1228,19 +1228,18 @@ Supported properties are
         property name for "{prop_name}".
         """
         ret = []
-        with cbook._setattr_cm(self, eventson=False):
-            for k, v in props.items():
-                # Allow attributes we want to be able to update through
-                # art.update, art.set, setp.
-                if k == "axes":
-                    ret.append(setattr(self, k, v))
-                else:
-                    func = getattr(self, f"set_{k}", None)
-                    if not callable(func):
-                        raise AttributeError(
-                            errfmt.format(cls=type(self), prop_name=k),
-                            name=k)
-                    ret.append(func(v))
+        for k, v in props.items():
+            # Allow attributes we want to be able to update through
+            # art.update, art.set, setp.
+            if k == "axes":
+                ret.append(setattr(self, k, v))
+            else:
+                func = getattr(self, f"set_{k}", None)
+                if not callable(func):
+                    raise AttributeError(
+                        errfmt.format(cls=type(self), prop_name=k),
+                        name=k)
+                ret.append(func(v))
         if ret:
             self.pchanged()
             self.stale = True


### PR DESCRIPTION
The attribute `eventson` was introduced in 79aa291c. While it was set on and off in various places, there has never been any code that made logic depend on its state. The attribute itself was removed in #18910, but its toggling through the context manager was overlooked there.

Fun fact: This temporary setting of `eventson` never had any effect, but it was maintained through several refactorings of the property update mechanism. 🤯 

Note: There is another `eventson` in widgets.py, which is completely independent on this here, because widgets are not Artists.
