### PR TITLE
Fix positioning of wide mathtext accents.

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2324,12 +2324,13 @@ class Parser:
         if accent in self._wide_accents:
             accent_box = AutoWidthChar(
                 '\\' + accent, sym.width, state, char_class=Accent)
+            centered = HCentered([accent_box])
         else:
             accent_box = Accent(self._accent_map[accent], state)
-        if accent == 'mathring':
-            accent_box.shrink()
-            accent_box.shrink()
-        centered = HCentered([Hbox(sym.width / 4.0), accent_box])
+            if accent == 'mathring':
+                accent_box.shrink()
+                accent_box.shrink()
+            centered = HCentered([Hbox(sym.width / 4.0), accent_box])
         centered.hpack(sym.width, 'exactly')
         return Vlist([
                 centered,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

A wide accent over more than one character should just be centered over
the underlying box.  In any case this works better than the current
strategy of shifting by an amount depending on the box's width (which
results in absurdly large shifts for wide boxes).

When positioning over a single character the behavior is different --
TeX uses specific font metrics info for that case, and we can try
rendering as combining characters instead (not done in this PR; see https://github.com/matplotlib/matplotlib/issues/4561#issuecomment-682401752, #23257, etc.).

See https://tex.stackexchange.com/a/47064 for a description of TeX's behavior.
Closes #19299.
The reference images are included as a separate commit for reference, but I guess they should be stripped before merging, as usual.

`figtext(.5, .5, r"$\widebar{foobarbazquux}$")` used to give
<img width="640" height="488" alt="image" src="https://github.com/user-attachments/assets/9360cae3-b3a1-452c-bc25-1844a041183d" />
but is now
<img width="640" height="488" alt="image" src="https://github.com/user-attachments/assets/c0521f40-3341-4793-995a-61bf208d7272" />

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
