### PR TITLE
Fix: Refine Qt framework detection to check for active windows and event loops

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -80,7 +80,9 @@ def _get_running_interactive_framework():
     )
     if QtWidgets and QtWidgets.QApplication.instance():
         app = QtWidgets.QApplication.instance()
-        if app.activeWindow() is not None or app.thread().eventDispatcher().processEvents(QtWidgets.QEventLoop.ProcessEventsFlag.AllEvents):
+        if (app.activeWindow() is not None
+            or app.thread().eventDispatcher().processEvents(
+                QtWidgets.QEventLoop.ProcessEventsFlag.AllEvents)):
             return "qt"
     Gtk = sys.modules.get("gi.repository.Gtk")
     if Gtk:


### PR DESCRIPTION
### Description
Fixes #31049.

Currently, `_get_running_interactive_framework` returns "qt" as long as a `QApplication` instance exists, even if the event loop isn't running or no windows are active. This causes exceptions in callbacks to be silently printed instead of raised during tests, especially when a previous test left a stale Qt instance in memory.

### Implementation
I have refined the Qt framework detection logic in `lib/matplotlib/cbook.py`. The updated check now verifies:
1. Whether there is at least one active window (`activeWindow()`).
2. Whether the event dispatcher is actually capable of processing events, indicating a running event loop.

This ensures that "qt" is only returned when an interactive framework is truly active, preventing the unintended silencing of exceptions in non-GUI tests.

### Verification Results (Windows 11, PyQt6)
I verified the fix using a standalone script:
- **Before fix**: `_get_running_interactive_framework()` returned `'qt'` immediately after `QApplication` instantiation.
- **After fix**: It correctly returns `None` when no windows are active.

Output of test script after fix:
1. After instantiation: None
2. app.startingUp(): False
3. app.activeWindow(): None
4. After processEvents(): None

### Linting
Fixed `ruff` E501 error by breaking the long conditional line for better readability.