### PR TITLE
Fix remove method for figure title and xy-labels

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -376,9 +376,16 @@ default: %(va)s
         else:
             suplab = self.text(x, y, t, **kwargs)
             setattr(self, info['name'], suplab)
+            suplab._remove_method = functools.partial(self._remove_suplabel,
+                                                      name=info['name'])
+
         suplab._autopos = autopos
         self.stale = True
         return suplab
+
+    def _remove_suplabel(self, label, name):
+        self.texts.remove(label)
+        setattr(self, name, None)
 
     @_docstring.Substitution(x0=0.5, y0=0.98, name='super title', ha='center',
                              va='top', rc='title')

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -365,6 +365,28 @@ def test_get_suptitle_supxlabel_supylabel():
     assert fig.get_supylabel() == 'supylabel'
 
 
+def test_remove_suptitle_supxlabel_supylabel():
+    fig = plt.figure()
+
+    title = fig.suptitle('suptitle')
+    xlabel = fig.supxlabel('supxlabel')
+    ylabel = fig.supylabel('supylabel')
+
+    assert len(fig.texts) == 3
+    assert fig._suptitle is not None
+    assert fig._supxlabel is not None
+    assert fig._supylabel is not None
+
+    title.remove()
+    assert fig._suptitle is None
+    xlabel.remove()
+    assert fig._supxlabel is None
+    ylabel.remove()
+    assert fig._supylabel is None
+
+    assert not fig.texts
+
+
 @image_comparison(['alpha_background'],
                   # only test png and svg. The PDF output appears correct,
                   # but Ghostscript does not preserve the background color.


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
Fixes #31073

Currently the remove method for suptitle and supx/ylabel is set within [fig.text](https://github.com/matplotlib/matplotlib/blob/eb7c4cebdc589f894c165de1852f63791e0edb3f/lib/matplotlib/figure.py#L1190) and only removes them from the list of texts.  We need to additionally reset the attributes to None, consistent with [their instantiation](https://github.com/matplotlib/matplotlib/blob/eb7c4cebdc589f894c165de1852f63791e0edb3f/lib/matplotlib/figure.py#L131-L133).

I have run the code from the issue and the output is consistent with having never set the suptitle.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
