### PR TITLE
DOC: Fix missing references for updated FT2Font.set_text

### DIFF
--- a/doc/missing-references.json
+++ b/doc/missing-references.json
@@ -3,6 +3,9 @@
     "HashableList[_HT]": [
       "<unknown>:1"
     ],
+    "collections.abc.Sequence[tuple[str": [
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1"
+    ],
     "matplotlib.axes._base._AxesBase": [
       "doc/api/artist_api.rst:203"
     ],
@@ -122,8 +125,7 @@
       "doc/api/_as_gen/mpl_toolkits.axisartist.floating_axes.rst:32:<autosummary>:1"
     ],
     "numpy.float64": [
-      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1",
-      "doc/docstring of matplotlib.ft2font.PyCapsule.set_text:1"
+      "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.set_text:1"
     ],
     "numpy.typing.NDArray": [
       "doc/docstring of matplotlib.ft2font.pybind11_detail_function_record_v1_system_libstdcpp_gxx_abi_1xxx_use_cxx11_abi_1.get_image:1",


### PR DESCRIPTION
## PR summary

This probably snuck in during a period when docs were broken, possibly with Sphinx 9 or similar.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines