### PR TITLE
Switch from pre-commit to prek

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd  # v3.0.1
+      - uses: j178/prek-action@564dda4cfa5e96aafdc4a5696c4bf7b46baae5ac  # v1.1.0
         with:
           extra_args: --hook-stage manual --all-files
 

--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -322,7 +322,7 @@ you are aware of the existing issues beforehand.
 
 Install pre-commit hooks
 ========================
-`pre-commit <https://pre-commit.com/>`_ hooks save time in the review process by
+`prek <https://prek.j178.dev/>`_ hooks save time in the review process by
 identifying issues with the code before a pull request is formally opened. Most
 hooks can also aide in fixing the errors, and the checks should have
 corresponding :ref:`development workflow <development-workflow>` and
@@ -333,8 +333,8 @@ committed files, import order, and incorrect branching.
 
 Install pre-commit hooks ::
 
-    python -m pip install pre-commit
-    pre-commit install
+    python -m pip install prek
+    prek install
 
 Hooks are run automatically after the ``git commit`` stage of the
 :ref:`editing workflow<edit-flow>`. When a hook has found and fixed an error in a
@@ -343,11 +343,11 @@ file, that file must be *staged and committed* again.
 Hooks can also be run manually. All the hooks can be run, in order as
 listed in ``.pre-commit-config.yaml``, against the full codebase with ::
 
-    pre-commit run --all-files
+    prek run --all-files
 
-To run a particular hook manually, run ``pre-commit run`` with the hook id ::
+To run a particular hook manually, run ``prek run`` with the hook id ::
 
-    pre-commit run <hook id> --all-files
+    prek run <hook id> --all-files
 
 
 Please note that the ``mypy`` pre-commit hook cannot check the :ref:`type-hints`

--- a/doc/devel/pr_guide.rst
+++ b/doc/devel/pr_guide.rst
@@ -56,7 +56,7 @@ When opening a pull request on Github, please ensure that:
 
 * Changes were made on a :ref:`feature branch <make-feature-branch>`.
 
-* :ref:`pre-commit <pre-commit-hooks>` checks for spelling, formatting, etc pass
+* :ref:`prek <pre-commit-hooks>` checks for spelling, formatting, etc pass
 
 * The pull request targets the :ref:`main branch <pr-branch-selection>`
 

--- a/environment.yml
+++ b/environment.yml
@@ -61,7 +61,7 @@ dependencies:
   - nbformat!=5.0.0,!=5.0.1
   - pandas!=0.25.0
   - psutil
-  - pre-commit
+  - prek
   - pydocstyle>=5.1.0
   - pytest!=4.6.0,!=5.4.0,!=8.1.0
   - pytest-cov


### PR DESCRIPTION
## PR summary

Following the [benchmarks from Hugo van Kemenade](https://hugovk.dev/blog/2025/ready-prek-go/), we get about 3× faster with prek:
|                 | pre-commit | prek      | Ratio |
| --------------- | ---------- | --------- | ----- |
| run --all-files | 4m52.503s  | 1m26.718s | 3.373 |
| install-hooks   | 3m31.002s  | 1m6.608s  | 3.168 |
| hyperfine       | 176.214    | 58.500    | 3.01  |

with hyperfine results of:
```
Benchmark 1: prek install-hooks
  Time (mean ± σ):     58.500 s ± 15.029 s    [User: 8.485 s, System: 3.138 s]
  Range (min … max):   30.766 s … 76.617 s    10 runs

Benchmark 2: pre-commit install-hooks
  Time (mean ± σ):     176.214 s ± 11.544 s    [User: 31.003 s, System: 5.127 s]
  Range (min … max):   161.969 s … 198.271 s    10 runs

Summary
  prek install-hooks ran
    3.01 ± 0.80 times faster than pre-commit install-hooks
```

These benchmarks were run on my desktop, which is _several_ generations behind, but was more idle than my laptop. I would run on my laptop (which is still about 5 years old), but I don't really want to wait for hyperfine to do another long run like that.

Since we aren't using pre-commit's CI anyway, it's easy to switch GitHub Actions directly.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
