### PR TITLE
MAINT: Move to first-contribution action

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -1,18 +1,23 @@
 ---
 name: PR Greetings
 
-on: [pull_request_target]
+on:
+  pull_request_target:
+    types: opened
+  issues:
+    types: opened
 
 jobs:
   greeting:
     runs-on: ubuntu-latest
     permissions:
+      issues: write
       pull-requests: write
     steps:
-      - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d  # v3.1.0
+      - uses: plbstl/first-contribution@4b2b042fffa26792504a18e49aa9543a87bec077  # v4.1.0
         with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          pr_message: >+
+          labels: first-contribution
+          pr-opened-msg: >+
             Thank you for opening your first PR into Matplotlib!
 
 
@@ -35,3 +40,4 @@ jobs:
             We strive to be a welcoming and open project. Please follow our
             [Code of
             Conduct](https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md).
+          issue-opened-msg: ""


### PR DESCRIPTION
## PR summary
Supersedes https://github.com/matplotlib/matplotlib/pull/30635
Related to https://github.com/matplotlib/matplotlib/pull/31043 (one will need a rebase after the other is merged)

Fixes the "PR Greeting" workflow by moving to the https://github.com/plbstl/first-contribution action as suggested by @bjlittle .

This action will:
- Post a comment to a first-contributor's PR, just like it did before.
- Add a "first-contributor" label to issues opened by users who had never opened issues in matplotlib/matplotlib before.

There is an option to add a message to first-time issues, but I'm not sure we need that. Also open to reformulate the first -time PR message if that's needed. One thing I had in mind is that maybe we want to point folks to the Discourse forum instead of Gitter?

### Tests

I tested this on my fork. You can see the results here:
- PR https://github.com/melissawm/matplotlib/pull/30
- Issue https://github.com/melissawm/matplotlib/issues/32

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines