### PR TITLE
Docs: Add xlim_changed and ylim_changed to event handling documentation

### DIFF
--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -76,6 +76,8 @@ Event name             Class            Description
 'figure_leave_event'   `.LocationEvent` mouse leaves a figure
 'axes_enter_event'     `.LocationEvent` mouse enters a new axes
 'axes_leave_event'     `.LocationEvent` mouse leaves an axes
+'xlim_changed'         `.AxesEvent`     x-limits of an Axes have changed
+'ylim_changed'         `.AxesEvent`     y-limits of an Axes have changed
 ====================== ================ ======================================
 
 .. note::


### PR DESCRIPTION
Closes #30647

Adds documentation for the xlim_changed and ylim_changed events in the event handling documentation.