### PR TITLE
ENH: Add rcParams for figure.suptitle defaults

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -392,8 +392,15 @@ default: %(va)s
     @_docstring.copy(_suplabels)
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
-        info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
+        # Use rcParams for defaults, with backward-compatible fallbacks
+        ha = mpl.rcParams.get('figure.titleloc', 'center')
+        va = mpl.rcParams.get('figure.titleva', 'top')
+        y0 = mpl.rcParams.get('figure.titleh', 0.98)
+        # Map location to x position for 'center', 'left', 'right'
+        loc_to_x = {'center': 0.5, 'left': 0.0, 'right': 1.0}
+        x0 = loc_to_x.get(ha, 0.5)
+        info = {'name': '_suptitle', 'x0': x0, 'y0': y0,
+                'ha': ha, 'va': va, 'rotation': 0,
                 'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
         return self._suplabels(t, info, **kwargs)
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -589,6 +589,9 @@
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
 #figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
 #figure.titleweight: normal    # weight of the figure title
+#figure.titleloc:    center    # horizontal location of the figure title
+#figure.titleh:      0.98      # vertical position of the figure title
+#figure.titleva:     top       # vertical alignment of the figure title
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)
 #figure.labelweight: normal    # weight of the figure label
 #figure.figsize:     6.4, 4.8  # figure size in inches

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1306,6 +1306,9 @@ _validators = {
     # figure title
     "figure.titlesize":   validate_fontsize,
     "figure.titleweight": validate_fontweight,
+    "figure.titleloc":    ["center", "left", "right"],
+    "figure.titleh":      validate_float,
+    "figure.titleva":     ["top", "center", "bottom", "baseline"],
 
     # figure labels
     "figure.labelsize":   validate_fontsize,
@@ -2637,6 +2640,24 @@ _params = [
         default="normal",
         validator=validate_fontweight,
         description="weight of the figure title"
+    ),
+    _Param(
+        "figure.titleloc",
+        default="center",
+        validator=["center", "left", "right"],
+        description="horizontal location of the figure title (``Figure.suptitle()``)"
+    ),
+    _Param(
+        "figure.titleh",
+        default=0.98,
+        validator=validate_float,
+        description="vertical position of the figure title in figure coordinates"
+    ),
+    _Param(
+        "figure.titleva",
+        default="top",
+        validator=["top", "center", "bottom", "baseline"],
+        description="vertical alignment of the figure title"
     ),
     _Param(
         "figure.labelsize",


### PR DESCRIPTION
Add new rcParams to control the default behavior of Figure.suptitle():

- figure.titleloc: horizontal location ('center', 'left', 'right')
- figure.titleh: vertical position in figure coordinates  
- figure.titleva: vertical alignment ('top', 'center', 'bottom', 'baseline')

This allows users to set default values via rcParams instead of passing them every time suptitle() is called. For example, users who want left-aligned figure titles can now set 'figure.titleloc: left' in their matplotlibrc file.

Fixes #24090