### PR TITLE
ENH: Add figure.titleloc rcParam for suptitle horizontal alignment

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -387,13 +387,14 @@ default: %(va)s
         self.texts.remove(label)
         setattr(self, name, None)
 
-    @_docstring.Substitution(x0=0.5, y0=0.98, name='super title', ha='center',
+    @_docstring.Substitution(x0=0.5, y0=0.98, name='super title',
+                             ha='center (default) or rcParams["figure.titleloc"]',
                              va='top', rc='title')
     @_docstring.copy(_suplabels)
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
         info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
+                'ha': mpl.rcParams['figure.titleloc'], 'va': 'top', 'rotation': 0,
                 'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
         return self._suplabels(t, info, **kwargs)
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -589,6 +589,7 @@
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
 #figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
 #figure.titleweight: normal    # weight of the figure title
+#figure.titleloc:    center    # horizontal location of the figure title ('center', 'left', 'right')
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)
 #figure.labelweight: normal    # weight of the figure label
 #figure.figsize:     6.4, 4.8  # figure size in inches

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1306,6 +1306,7 @@ _validators = {
     # figure title
     "figure.titlesize":   validate_fontsize,
     "figure.titleweight": validate_fontweight,
+    "figure.titleloc":    ["center", "left", "right"],
 
     # figure labels
     "figure.labelsize":   validate_fontsize,


### PR DESCRIPTION
This PR fixes #24090 by adding a new rcParam `figure.titleloc` to control the default horizontal alignment of figure.suptitle().

Changes:
- Added 'figure.titleloc' rcParam with options ['center', 'left', 'right']
- Updated suptitle() to use rcParams['figure.titleloc'] for horizontal alignment
- Added documentation in matplotlibrc file

This allows users to set the default alignment via rcParams, similar to how axes.titlelocation works for axis titles.