### PR TITLE
MNT: Add get_shared_z_axes() and get_shared_view_axes() to Axes3D

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1337,6 +1337,14 @@ class Axes3D(Axes):
         self.view_init(elev=other.elev, azim=other.azim, roll=other.roll,
                        vertical_axis=vertical_axis, share=True)
 
+    def get_shared_z_axes(self):
+        """Return an immutable view on the shared z-axes Grouper."""
+        return cbook.GrouperView(self._shared_axes["z"])
+
+    def get_shared_view_axes(self):
+        """Return an immutable view on the shared view-axes Grouper."""
+        return cbook.GrouperView(self._shared_axes["view"])
+
     def clear(self):
         # docstring inherited.
         super().clear()


### PR DESCRIPTION
Add methods to access the shared z-axes and shared view-axes groupers for consistency with 2D Axes which have get_shared_x_axes() and get_shared_y_axes().

This provides a public API to inspect which axes are sharing the z-axis or view angles with a given Axes3D instance.

Closes #31097