### PR TITLE
MNT/BUG: Add shared axes methods and fix alpha array in imshow (#26092, #31097)

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -525,12 +525,18 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                 if float_rgba_in and np.ndim(alpha) == 0 and np.any(A[..., 3] < 1):
                     # Do not modify original RGBA input
                     A = A.copy()
+                # Store the original alpha before premultiplication
+                original_alpha = A[..., 3].copy() if np.ndim(alpha) > 0 else None
                 A[..., :3] *= A[..., 3:]
                 res = _resample(self, A, out_shape, t)
                 np.divide(res[..., :3], res[..., 3:], out=res[..., :3],
                             where=res[..., 3:] != 0)
                 if post_apply_alpha:
                     res[..., 3] *= alpha
+                elif original_alpha is not None:
+                    # Restore the original alpha array (before premultiplication)
+                    # to avoid artifacts from premultiplication/unpremultiplication
+                    res[..., 3] = _resample(self, original_alpha, out_shape, t)
 
             # res is now either a 2D array of normed (int or float) data
             # or an RGBA array of re-sampled input

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -1337,6 +1337,14 @@ class Axes3D(Axes):
         self.view_init(elev=other.elev, azim=other.azim, roll=other.roll,
                        vertical_axis=vertical_axis, share=True)
 
+    def get_shared_z_axes(self):
+        """Return an immutable view on the shared z-axes Grouper."""
+        return cbook.GrouperView(self._shared_axes["z"])
+
+    def get_shared_view_axes(self):
+        """Return an immutable view on the shared view-axes Grouper."""
+        return cbook.GrouperView(self._shared_axes["view"])
+
     def clear(self):
         # docstring inherited.
         super().clear()


### PR DESCRIPTION
This PR addresses two issues:

## Fixes

### Issue #31097 - MNT: Add get_shared_z_axes() and get_shared_view_axes() to Axes3D
- Added get_shared_z_axes() method to return an immutable view on the shared z-axes Grouper
- Added get_shared_view_axes() method to return an immutable view on the shared view-axes Grouper
- Provides consistency with 2D Axes which have get_shared_x_axes() and get_shared_y_axes()

### Issue #26092 - BUG: Fix alpha array not working with RGB image in imshow
- Fixed issue where RGB images with array-type alpha values were not being correctly applied
- Problem was caused by artifacts from premultiplication/unpremultiplication during resampling
- Now when an array alpha is provided with an RGB image, the original alpha values are preserved and resampled separately

Closes #26092
Closes #31097