### PR TITLE
Add rcParams for figure.suptitle defaults

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -392,9 +392,14 @@ default: %(va)s
     @_docstring.copy(_suplabels)
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
-        info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
-                'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
+        info = {'name': '_suptitle',
+                'x0': mpl.rcParams['figure.titlex'],
+                'y0': mpl.rcParams['figure.titley'],
+                'ha': mpl.rcParams['figure.titleha'],
+                'va': mpl.rcParams['figure.titleva'],
+                'rotation': 0,
+                'size': 'figure.titlesize',
+                'weight': 'figure.titleweight'}
         return self._suplabels(t, info, **kwargs)
 
     def get_suptitle(self):

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -589,6 +589,10 @@
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
 #figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
 #figure.titleweight: normal    # weight of the figure title
+#figure.titlex:      0.5       # x location of the figure title in figure coordinates
+#figure.titley:      0.98      # y location of the figure title in figure coordinates
+#figure.titleha:     center    # horizontal alignment of the figure title
+#figure.titleva:     top       # vertical alignment of the figure title
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)
 #figure.labelweight: normal    # weight of the figure label
 #figure.figsize:     6.4, 4.8  # figure size in inches

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1306,6 +1306,10 @@ _validators = {
     # figure title
     "figure.titlesize":   validate_fontsize,
     "figure.titleweight": validate_fontweight,
+    "figure.titlex":      validate_float,
+    "figure.titley":      validate_float,
+    "figure.titleha":     validate_alignment,
+    "figure.titleva":     validate_alignment,
 
     # figure labels
     "figure.labelsize":   validate_fontsize,


### PR DESCRIPTION
The `figure.suptitle()` method used hardcoded defaults for x, y, ha, and va positions, while size and weight already used rcParams. Users couldn't configure these defaults globally.

This PR adds four new rcParams:
- `figure.titlex`: Default 0.5
- `figure.titley`: Default 0.98
- `figure.titleha`: Default 'center'
- `figure.titleva`: Default 'top'

Updated `Figure.suptitle()` to use these rcParams instead of hardcoded values.

Closes #24090