### PR TITLE
Fix confusion between text height and ascent in metrics calculations.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -799,23 +799,24 @@ class TextArea(OffsetBox):
             ismath="TeX" if self._text.get_usetex() else False,
             dpi=self.get_figure(root=True).dpi)
 
-        bbox, info, yd = self._text._get_layout(renderer)
+        bbox, info = self._text._get_layout(renderer)
+        _last_line, (_last_width, _last_ascent, last_descent), _last_xy = info[-1]
         w, h = bbox.size
 
         self._baseline_transform.clear()
 
         if len(info) > 1 and self._multilinebaseline:
             yd_new = 0.5 * h - 0.5 * (h_ - d_)
-            self._baseline_transform.translate(0, yd - yd_new)
-            yd = yd_new
+            self._baseline_transform.translate(0, last_descent - yd_new)
+            last_descent = yd_new
         else:  # single line
-            h_d = max(h_ - d_, h - yd)
-            h = h_d + yd
+            h_d = max(h_ - d_, h - last_descent)
+            h = h_d + last_descent
 
         ha = self._text.get_horizontalalignment()
         x0 = {"left": 0, "center": -w / 2, "right": -w}[ha]
 
-        return Bbox.from_bounds(x0, -yd, w, h)
+        return Bbox.from_bounds(x0, -last_descent, w, h)
 
     def draw(self, renderer):
         # docstring inherited


### PR DESCRIPTION
The text height includes both the ascender and the descender, but the logic in _get_layout is that multiline texts should be treated as having an ascent at least as large as "l" and a descent at least as large as "p" (not a height at least as large as "lp" and a descent at least as large as "p") to prevent lines from bumping into each other (see changes to test_text/test_multiline, where the topmost superscript was close to bumping into the "p" descender previously).

Partial fix for #21653; see https://github.com/matplotlib/matplotlib/issues/21653#issuecomment-3860273644.

old
<img width="800" height="600" alt="multiline-expected" src="https://github.com/user-attachments/assets/b6c66f0b-0b08-484e-bcc0-302fe6a929d5" />
new
<img width="800" height="600" alt="multiline" src="https://github.com/user-attachments/assets/478b57e1-15e3-4a94-9ab0-2ae4c843c439" />

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
