### PR TITLE
Remove some code for compatibility with pyparsing<3

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -24,7 +24,7 @@ import numpy as np
 from numpy.typing import NDArray
 from pyparsing import (
     Empty, Forward, Literal, Group, NotAny, OneOrMore, Optional,
-    ParseBaseException, ParseException, ParseExpression, ParseFatalException,
+    ParseBaseException, ParseExpression, ParseFatalException,
     ParserElement, ParseResults, QuotedString, Regex, StringEnd, ZeroOrMore,
     pyparsing_common, nested_expr, one_of)
 
@@ -2162,8 +2162,7 @@ class Parser:
         try:
             result = self._expression.parse_string(s)
         except ParseBaseException as err:
-            # explain becomes a plain method on pyparsing 3 (err.explain(0)).
-            raise ValueError("\n" + ParseException.explain(err, 0)) from None
+            raise ValueError("\n" + err.explain(0)) from None
         self._state_stack = []
         self._in_subscript_or_superscript = False
         # prevent operator spacing from leaking into a new expression


### PR DESCRIPTION
## PR summary

Just a drive-by cleanup on a comment I noticed, since we depend on pyparsing 3 now.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines