### PR TITLE
Add overlay parameter to twinx() and twiny()

### DIFF
--- a/doc/release/next_whats_new/twin_overlay.rst
+++ b/doc/release/next_whats_new/twin_overlay.rst
@@ -1,0 +1,9 @@
+``overlay`` parameter for ``twinx`` and ``twiny``
+--------------------------------------------------
+
+`.Axes.twinx` and `.Axes.twiny` now accept an *overlay* parameter.  When set
+to ``False``, the twin Axes is drawn behind the original Axes instead of on
+top of it. This is useful when the content of the original axis should take
+visual precedence::
+
+    ax_twin = ax.twinx(overlay=False)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4659,7 +4659,7 @@ class _AxesBase(martist.Artist):
         self._twinned_axes.join(self, twin)
         return twin
 
-    def twinx(self, axes_class=None, **kwargs):
+    def twinx(self, axes_class=None, overlay=True, **kwargs):
         """
         Create a twin Axes sharing the xaxis.
 
@@ -4679,6 +4679,14 @@ class _AxesBase(martist.Artist):
             By default, `~.axes.Axes` is used.
 
             .. versionadded:: 3.11
+
+        overlay : bool, default: True
+            If True (default), the twin Axes is drawn on top of the
+            original Axes.  If False, the twin Axes is drawn behind the
+            original, which is useful when the content of the original
+            (left) y-axis should take visual precedence.
+
+            .. versionadded:: 3.12
 
         kwargs : dict
             The keyword arguments passed to `.Figure.add_subplot` or `.Figure.add_axes`.
@@ -4705,10 +4713,13 @@ class _AxesBase(martist.Artist):
         self.yaxis.tick_left()
         ax2.xaxis.set_visible(False)
         ax2.patch.set_visible(False)
+        if not overlay:
+            self.patch.set_visible(False)
+            self.set_zorder(ax2.get_zorder() + 1)
         ax2.xaxis.units = self.xaxis.units
         return ax2
 
-    def twiny(self, axes_class=None, **kwargs):
+    def twiny(self, axes_class=None, overlay=True, **kwargs):
         """
         Create a twin Axes sharing the yaxis.
 
@@ -4728,6 +4739,14 @@ class _AxesBase(martist.Artist):
             By default, `~.axes.Axes` is used.
 
             .. versionadded:: 3.11
+
+        overlay : bool, default: True
+            If True (default), the twin Axes is drawn on top of the
+            original Axes.  If False, the twin Axes is drawn behind the
+            original, which is useful when the content of the original
+            (bottom) x-axis should take visual precedence.
+
+            .. versionadded:: 3.12
 
         kwargs : dict
             The keyword arguments passed to `.Figure.add_subplot` or `.Figure.add_axes`.
@@ -4753,6 +4772,9 @@ class _AxesBase(martist.Artist):
         self.xaxis.tick_bottom()
         ax2.yaxis.set_visible(False)
         ax2.patch.set_visible(False)
+        if not overlay:
+            self.patch.set_visible(False)
+            self.set_zorder(ax2.get_zorder() + 1)
         ax2.yaxis.units = self.yaxis.units
         return ax2
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8070,6 +8070,29 @@ def test_twinning_default_axes_class():
     assert type(twiny) is Axes
 
 
+@pytest.mark.parametrize("twin", ["x", "y"])
+def test_twin_overlay(twin):
+    """Test the overlay parameter of twinx/twiny."""
+    fig, ax = plt.subplots()
+
+    # Default (overlay=True): twin has same zorder, original patch visible
+    if twin == "x":
+        ax2 = ax.twinx()
+    else:
+        ax2 = ax.twiny()
+    assert ax.patch.get_visible()
+    assert ax.get_zorder() == ax2.get_zorder()
+
+    # overlay=False: original patch hidden, original zorder above twin
+    fig2, ax3 = plt.subplots()
+    if twin == "x":
+        ax4 = ax3.twinx(overlay=False)
+    else:
+        ax4 = ax3.twiny(overlay=False)
+    assert not ax3.patch.get_visible()
+    assert ax3.get_zorder() > ax4.get_zorder()
+
+
 def test_zero_linewidth():
     # Check that setting a zero linewidth doesn't error
     plt.plot([0, 1], [0, 1], ls='--', lw=0)


### PR DESCRIPTION
## Summary

Adds an `overlay` boolean parameter (default `True`) to `Axes.twinx()` and `Axes.twiny()` that controls whether the twin Axes is drawn on top of or behind the original Axes.

When `overlay=False`, the original Axes' patch is hidden and its zorder is raised above the twin, so the original content renders in the foreground. This replaces the common workaround:

```python
ax_t = ax.twinx()
ax.patch.set_visible(False)
ax.set_zorder(ax_t.get_zorder() + 1)
```

with simply:

```python
ax_t = ax.twinx(overlay=False)
```

## Changes

- **`lib/matplotlib/axes/_base.py`**: Added `overlay` parameter to `twinx()` and `twiny()`
- **`lib/matplotlib/tests/test_axes.py`**: Added parametrized test for overlay behavior
- **`doc/release/next_whats_new/twin_overlay.rst`**: What's new entry

Closes #31122