### PR TITLE
Snap 3d ctrl

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -174,17 +174,12 @@ class Axes3D(Axes):
 
         self.mouse_init()
         fig = self.get_figure(root=True)
-        self._snap_rotation = False
         fig.canvas.callbacks._connect_picklable(
             'motion_notify_event', self._on_move)
         fig.canvas.callbacks._connect_picklable(
             'button_press_event', self._button_press)
         fig.canvas.callbacks._connect_picklable(
             'button_release_event', self._button_release)
-        fig.canvas.callbacks._connect_picklable(
-           'key_press_event', self._key_press)
-        fig.canvas.callbacks._connect_picklable(
-            'key_release_event', self._key_release)
         self.set_top_view()
 
         self.patch.set_linewidth(0)
@@ -1360,16 +1355,6 @@ class Axes3D(Axes):
 
         self.grid(mpl.rcParams['axes3d.grid'])
 
-    def _key_press(self, event):
-        if event.key in ("control", "ctrl"):
-            self._snap_rotation = True
-
-
-    def _key_release(self, event):
-        if event.key in ("control", "ctrl"):
-            self._snap_rotation = False
-
-
     def _button_press(self, event):
         if event.inaxes == self:
             self.button_pressed = event.button
@@ -1612,7 +1597,7 @@ class Axes3D(Axes):
 
                 q = dq * q
                 elev, azim, roll = np.rad2deg(q.as_cardan_angles())
-            if getattr(self, "_snap_rotation", False):
+            if event.key in ("control", "ctrl"):
                 step = 5
                 elev = float(step * round(elev / step))
                 azim = float(step * round(azim / step))

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2788,13 +2788,14 @@ def test_axis_get_tightbbox_includes_offset_text():
 
 
 class DummyEvent:
-    def __init__(self, xdata=None, ydata=None, inaxes=None):
+    def __init__(self, xdata=None, ydata=None, inaxes=None, key=None):
         self.xdata = xdata
         self.ydata = ydata
         self.inaxes = inaxes
         self.x = 0
         self.y = 0
         self.button = 1
+        self.key = key
 
 
 def _is_multiple_of_step(val, step):
@@ -2817,8 +2818,6 @@ def test_ctrl_rotation_snaps_to_5deg(monkeypatch):
     ax.azim = 33.7
     ax.roll = 2.2
 
-    ax._snap_rotation = True
-
     monkeypatch.setitem(plt.rcParams, "axes3d.mouserotationstyle", "azel")
 
     captured = {}
@@ -2830,7 +2829,7 @@ def test_ctrl_rotation_snaps_to_5deg(monkeypatch):
 
     monkeypatch.setattr(ax, "view_init", fake_view_init)
 
-    event = DummyEvent(xdata=0.1, ydata=0.1, inaxes=ax)
+    event = DummyEvent(xdata=0.1, ydata=0.1, inaxes=ax, key="control")
     ax._on_move(event)
 
     assert _is_multiple_of_step(captured["elev"], 5)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x ] "closes #31093" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

Description 

This PR adds an optional "snap-to-angle" mode for interactive 3D rotations.

When rotating an `Axes3D` plot, holding the Ctrl key will snap the view angles
(azimuth/elevation/roll) to 5 degree increments instead of rotating continuously.
This makes it easier to reproduce common viewing angles.

A small unit test is added to ensure the snapping behavior works.