### PR TITLE
Fix mutable default arguments in backend_svg.py

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -133,7 +133,7 @@ class XMLWriter:
             self.__write(_escape_cdata(data))
             self.__data = []
 
-    def start(self, tag, attrib={}, **extra):
+    def start(self, tag, attrib=None, **extra):
         """
         Open a new element.  Attributes can be given as keyword
         arguments, or as a string/string dictionary. The method returns
@@ -152,6 +152,8 @@ class XMLWriter:
         -------
         An element identifier.
         """
+        if attrib is None:
+            attrib = {}
         self.__flush()
         tag = _escape_cdata(tag)
         self.__data = []
@@ -232,12 +234,14 @@ class XMLWriter:
         while len(self.__tags) > id:
             self.end()
 
-    def element(self, tag, text=None, attrib={}, **extra):
+    def element(self, tag, text=None, attrib=None, **extra):
         """
         Add an entire element.  This is the same as calling :meth:`start`,
         :meth:`data`, and :meth:`end` in sequence. The *text* argument can be
         omitted.
         """
+        if attrib is None:
+            attrib = {}
         self.start(tag, attrib, **extra)
         if text:
             self.data(text)


### PR DESCRIPTION
## Description
This PR fixes a mutable default argument issue in `lib/matplotlib/backends/backend_svg.py`. 

In the `XMLWriter` class, the `start` and `element` methods were using a mutable dictionary (`attrib={}`) as a default argument. 

While the current implementation may not be strictly mutating this dictionary in place, using a mutable default is an anti-pattern that creates a shared state across function calls. This change replaces it with `None` to ensure a fresh dictionary is created for every call, preventing potential side effects in future code changes.

## Changes
- Changed `def start(..., attrib={}, ...)` to `def start(..., attrib=None, ...)`
- Changed `def element(..., attrib={}, ...)` to `def element(..., attrib=None, ...)`
- Added `if attrib is None: attrib = {}` to initialize the dictionary safely inside the methods.