### PR TITLE
Deprecate public access to XMLWriter; simplify some attribute settings

### DIFF
--- a/doc/api/next_api_changes/deprecations/31143-AL.rst
+++ b/doc/api/next_api_changes/deprecations/31143-AL.rst
@@ -1,0 +1,3 @@
+``backend_svg.XMLWriter`` is deprecated
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+It is an internal helper not intended for external use.

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -104,7 +104,7 @@ def _short_float_fmt(x):
     return f'{x:f}'.rstrip('0').rstrip('.')
 
 
-class XMLWriter:
+class _XMLWriter:
     """
     Parameters
     ----------
@@ -252,6 +252,15 @@ class XMLWriter:
         pass  # replaced by the constructor
 
 
+@mpl._api.deprecated("3.11")
+class XMLWriter(_XMLWriter):
+    """
+    An XML writer class.
+
+    :meta private:
+    """
+
+
 def _generate_transform(transform_list):
     parts = []
     for type, value in transform_list:
@@ -295,7 +304,7 @@ class RendererSVG(RendererBase):
                  *, metadata=None):
         self.width = width
         self.height = height
-        self.writer = XMLWriter(svgwriter)
+        self.writer = _XMLWriter(svgwriter)
         self.image_dpi = image_dpi  # actual dpi at which we rasterize stuff
 
         if basename is None:
@@ -926,7 +935,7 @@ class RendererSVG(RendererBase):
                 id='colorMat')
             writer.element(
                 'feColorMatrix',
-                attrib={'type': 'matrix'},
+                type='matrix',
                 values='1 0 0 0 0 \n0 1 0 0 0 \n0 0 1 0 0 \n1 1 1 1 0 \n0 0 0 0 1 ')
             writer.end('filter')
 
@@ -982,7 +991,6 @@ class RendererSVG(RendererBase):
         if transform is None:
             w = 72.0 * w / self.image_dpi
             h = 72.0 * h / self.image_dpi
-
             self.writer.element(
                 'image',
                 transform=_generate_transform([
@@ -990,29 +998,23 @@ class RendererSVG(RendererBase):
                 x=_short_float_fmt(x),
                 y=_short_float_fmt(-(self.height - y - h)),
                 width=_short_float_fmt(w), height=_short_float_fmt(h),
-                attrib=attrib)
+                attrib=attrib,
+            )
         else:
             alpha = gc.get_alpha()
             if alpha != 1.0:
                 attrib['opacity'] = _short_float_fmt(alpha)
-
             flipped = (
-                Affine2D().scale(1.0 / w, 1.0 / h) +
-                transform +
-                Affine2D()
-                .translate(x, y)
-                .scale(1.0, -1.0)
-                .translate(0.0, self.height))
-
-            attrib['transform'] = _generate_transform(
-                [('matrix', flipped.frozen())])
-            attrib['style'] = (
-                'image-rendering:crisp-edges;'
-                'image-rendering:pixelated')
+                Affine2D().scale(1 / w, 1 / h)
+                + transform
+                + Affine2D().translate(x, y).scale(1, -1).translate(0, self.height))
             self.writer.element(
                 'image',
                 width=_short_float_fmt(w), height=_short_float_fmt(h),
-                attrib=attrib)
+                attrib=attrib,
+                transform=_generate_transform([('matrix', flipped.frozen())]),
+                style='image-rendering:crisp-edges;image-rendering:pixelated',
+            )
 
         if url is not None:
             self.writer.end('a')
@@ -1060,14 +1062,15 @@ class RendererSVG(RendererBase):
         if alpha != 1:
             style['opacity'] = _short_float_fmt(alpha)
         font_scale = fontsize / text2path.FONT_SCALE
-        attrib = {
-            'style': _generate_css(style),
-            'transform': _generate_transform([
+        writer.start(
+            'g',
+            style=_generate_css(style),
+            transform=_generate_transform([
                 ('translate', (x, y)),
                 ('rotate', (-angle,)),
-                ('scale', (font_scale, -font_scale))]),
-        }
-        writer.start('g', attrib=attrib)
+                ('scale', (font_scale, -font_scale)),
+            ]),
+        )
 
         if not ismath:
             font = text2path._get_font(prop)


### PR DESCRIPTION
It is not necessary to put the attributes into a dict just to pass the dict to start() later; rather the attributes can be passed directly as kwargs to element().  Even in the case where the attributes are not valid identifiers one can use dict-unpacking to pass them.

This also allows removing the awkward `attrib={}` mutable default on XMLWriter (#31141), and the (theoretical) impossibility of passing an attribute named "attrib" to start().  As this changes the API of XMLWriter, take that opportunity to make that helper class private (with deprecation).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
