### PR TITLE
DOC: Remove 'mid' from quiver pivot documentation

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -113,11 +113,9 @@ angles : {'uv', 'xy'} or array-like, default: 'uv'
     Note: inverting a data axis will correspondingly invert the
     arrows only with ``angles='xy'``.
 
-pivot : {'tail', 'mid', 'middle', 'tip'}, default: 'tail'
+pivot : {'tail', 'middle', 'tip'}, default: 'tail'
     The part of the arrow that is anchored to the *X*, *Y* grid. The arrow
     rotates about this point.
-
-    'mid' is a synonym for 'middle'.
 
 scale : float, optional
     Scales the length of the arrow inversely.


### PR DESCRIPTION
Fixes #31127

The documentation incorrectly listed 'mid' as a synonym for 'middle',
but this is not implemented in the code. This commit removes the
misleading reference to match the actual allowed values.

The allowed pivot values are: 'tail', 'middle', 'tip'
The documentation had incorrectly listed: 'tail', 'mid', 'middle', 'tip'
And stated: 'mid' is a synonym for 'middle'

This was confusing users who tried to use 'mid' and got an error.
