### PR TITLE
TST: Use correct method of clearing mock objects

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -669,7 +669,7 @@ def _impl_test_interactive_timers():
     assert mock.call_count > 1
 
     # Now turn it into a single shot timer and verify only one gets triggered
-    mock.call_count = 0
+    mock.reset_mock()
     timer.single_shot = True
     timer.start()
     plt.pause(pause_time)

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -1646,7 +1646,7 @@ def test_norm_callback():
     assert increment.call_count == 2
 
     # We only want autoscale() calls to send out one update signal
-    increment.call_count = 0
+    increment.reset_mock()
     norm.autoscale([0, 1, 2])
     assert increment.call_count == 1
 


### PR DESCRIPTION
## PR summary

In Python 3.13.12 and 3.14.3, fixes for thread-safety of mock `call_count` meant that manually changing it no longer works [1]. Instead use the more correct `reset_mock` method.

[1] https://github.com/python/cpython/issues/142651#issuecomment-3872242970

Fixes #31112

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines