### PR TITLE
fix AxisLabel not picking up fontsize from set_ylabel in axisartist

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -285,7 +285,9 @@ class AxisLabel(AttributeCopier, LabelBase):
         self._axis = axis
         self._pad = 5
         self._external_pad = 0  # in pixels
+        self._fontsize_from_default = True
         LabelBase.__init__(self, *args, **kwargs)
+        self._fontsize_from_default = True
         self.set_axis_direction(axis_direction)
 
     def set_pad(self, pad):
@@ -376,6 +378,24 @@ class AxisLabel(AttributeCopier, LabelBase):
         """
         self.set_default_alignment(d)
         self.set_default_angle(d)
+
+    def set_fontsize(self, fontsize):
+        # docstring inherited
+        self._fontsize_from_default = False
+        super().set_fontsize(fontsize)
+
+    set_size = set_fontsize
+
+    def get_fontsize(self):
+        # docstring inherited
+        if self._fontsize_from_default and self._axis is not None:
+            try:
+                return self.get_ref_artist().get_fontsize()
+            except (IndexError, AttributeError):
+                pass
+        return super().get_fontsize()
+
+    get_size = get_fontsize
 
     def get_color(self):
         return self.get_attribute_from_ref_artist("color")

--- a/lib/mpl_toolkits/axisartist/tests/test_axislines.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axislines.py
@@ -146,3 +146,21 @@ def test_subplotzero_ylabel():
     ax.axis["left", "right", "bottom", "top"].set_visible(False)
 
     zero_axis.set_axisline_style("->")
+
+
+def test_label_fontsize_from_axes():
+    """Test that AxisLabel inherits fontsize from the underlying axis label."""
+    fig = plt.figure()
+    ax = Subplot(fig, 1, 1, 1)
+    fig.add_subplot(ax)
+
+    # set_ylabel with fontsize should propagate to AxisLabel
+    ax.set_ylabel("Test", fontsize=20)
+    assert ax.axis["left"].label.get_fontsize() == 20
+
+    ax.set_ylabel("Test", fontsize=14)
+    assert ax.axis["left"].label.get_fontsize() == 14
+
+    # explicit set_fontsize on AxisLabel should override
+    ax.axis["left"].label.set_fontsize(30)
+    assert ax.axis["left"].label.get_fontsize() == 30


### PR DESCRIPTION
Fixes #28124.

When using `host_subplot` (or any `axisartist.Axes`), calling `ax.set_ylabel('text', fontsize=20)` sets the fontsize on the underlying `yaxis.label`, but the `AxisLabel` in axis_artist never picks it up — it only copies the text string and color from the ref artist. So the label renders at the default size regardless of what you pass to `set_ylabel`.

The fix adds `get_fontsize`/`set_fontsize` overrides to `AxisLabel` that inherit fontsize from the ref artist by default (similar to how `get_color` already works via `AttributeCopier`). If you set fontsize directly on the `AxisLabel` itself, the override is respected.

```python
from mpl_toolkits.axisartist import Axes

fig = plt.figure()
ax = fig.add_subplot(111, axes_class=Axes)
ax.set_ylabel('ylabel', fontsize=20)
# before: label renders at default size (~10pt)
# after: label renders at 20pt as expected
```