### PR TITLE
Cleanup QuiverKey init and deprecate some attributes.

### DIFF
--- a/doc/api/next_api_changes/deprecations/31170-AL.rst
+++ b/doc/api/next_api_changes/deprecations/31170-AL.rst
@@ -1,0 +1,6 @@
+``kw``, ``fontproperties``, ``labelcolor``, and ``verts`` attributes of ``QuiverKey``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+These attributes are deprecated (note that ``fontproperties``, ``labelcolor``,
+or ``verts`` after the first draw had no effect previously).  Directly
+access the relevant attributes on the sub-artists ``QuiverKey.vector`` and
+``QuiverKey.text``, instead.

--- a/lib/matplotlib/quiver.pyi
+++ b/lib/matplotlib/quiver.pyi
@@ -25,9 +25,6 @@ class QuiverKey(martist.Artist):
     color: ColorType | None
     label: str
     labelpos: Literal["N", "S", "E", "W"]
-    labelcolor: ColorType | None
-    fontproperties: dict[str, Any]
-    kw: dict[str, Any]
     text: Text
     zorder: float
     def __init__(
@@ -48,6 +45,14 @@ class QuiverKey(martist.Artist):
         zorder: float | None = ...,
         **kwargs
     ) -> None: ...
+    @property
+    def kw(self) -> dict[str, Any]: ...
+    @property
+    def fontproperties(self) -> dict[str, Any]: ...
+    @property
+    def labelcolor(self) -> ColorType | None: ...
+    @property
+    def verts(self) -> Sequence[ArrayLike]: ...
     @property
     def labelsep(self) -> float: ...
     def set_figure(self, fig: Figure | SubFigure) -> None: ...

--- a/lib/matplotlib/tests/test_quiver.py
+++ b/lib/matplotlib/tests/test_quiver.py
@@ -266,7 +266,7 @@ def test_quiverkey_angles():
     qk = ax.quiverkey(q, 1, 1, 2, 'Label')
     # The arrows are only created when the key is drawn
     fig.canvas.draw()
-    assert len(qk.verts) == 1
+    assert len(qk.vector.get_paths()) == 1
 
 
 def test_quiverkey_angles_xy_aitoff():
@@ -295,7 +295,7 @@ def test_quiverkey_angles_xy_aitoff():
         qk = ax.quiverkey(q, 0, 0, 1, '1 units')
 
         fig.canvas.draw()
-        assert len(qk.verts) == 1
+        assert len(qk.vector.get_paths()) == 1
 
 
 def test_quiverkey_angles_scale_units_cartesian():
@@ -322,7 +322,7 @@ def test_quiverkey_angles_scale_units_cartesian():
         qk = ax.quiverkey(q, 0, 0, 1, '1 units')
 
         fig.canvas.draw()
-        assert len(qk.verts) == 1
+        assert len(qk.vector.get_paths()) == 1
 
 
 def test_quiver_setuvc_numbers():


### PR DESCRIPTION
Ensure that QuiverKey.vector exists as soon as the constructor exits, rather than waiting for the first draw.

Deprecate the `fontproperties`, `labelcolor`, and `verts` attribute (overwriting them would not actually update the underlying artist (except before the first draw) anyways).  Also deprecate `kw` (which *could* be updated with effect, but it seems simpler to directly update the underlying artist here too, if really needed; moreover the old version, which mutated `self.Q.polykw` *in-place*, likely led to weird side-effects e.g. if a key is first added to `kw`, a draw is triggered, mutating `self.Q.polykw`, then the key is removed).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

Noted while reviewing #31169.

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
