### PR TITLE
Fix alpha array ignored for RGB images in imshow. 

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -512,8 +512,11 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                     if A.shape[2] == 3:  # image has no alpha channel
                         A = np.dstack([A, np.ones(A.shape[:2])])
                 elif np.ndim(alpha) > 0:  # Array alpha
-                    # user-specified array alpha overrides the existing alpha channel
-                    A = np.dstack([A[..., :3], alpha])
+                    if A.shape[2] == 3:  # image has no alpha channel, so add one
+                        A = np.dstack([A, alpha])
+                    else:
+                        # Apply array alpha to existing alpha channel
+                        A = np.dstack([A[..., :3], A[..., 3] * alpha])
                 else:  # Scalar alpha
                     if A.shape[2] == 3:  # broadcast scalar alpha
                         A = np.dstack([A, np.full(A.shape[:2], alpha, np.float32)])

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -36,6 +36,19 @@ def test_alpha_interp():
     axr.imshow(img, interpolation="bilinear")
 
 
+@check_figures_equal(extensions=["png"])
+def test_imshow_alpha_array_with_rgb(fig_test, fig_ref):
+    """Array alpha should work with RGB images (issue #26092)."""
+    np.random.seed(19680801)
+    arr_rgb = np.random.random((10, 10, 3))
+
+    alpha = np.ones((10, 10))
+    alpha[:5] = 0.2
+
+    fig_test.subplots().imshow(arr_rgb, alpha=alpha)
+    fig_ref.subplots().imshow(np.dstack([arr_rgb, alpha]))
+
+
 @image_comparison(['interp_nearest_vs_none'], tol=3.7,  # For Ghostscript 10.06+.
                   extensions=['pdf', 'svg'], remove_text=True)
 def test_interp_nearest_vs_none():
@@ -1867,7 +1880,8 @@ def test_interpolation_stage_rgba_respects_alpha_param(fig_test, fig_ref, intp_s
     new_array_alpha = np.random.rand(ny, nx)
     axs_tst[1][2].imshow(im_rgba, interpolation_stage=intp_stage, alpha=new_array_alpha)
     axs_ref[1][2].imshow(
-        np.concatenate(  # combine rgb channels with new array alpha
-            (im_rgb, new_array_alpha.reshape((ny, nx, 1))), axis=-1
+        np.concatenate(  # combine rgb channels with multiplied alpha
+            (im_rgb, (array_alpha * new_array_alpha).reshape((ny, nx, 1))),
+            axis=-1
         ), interpolation_stage=intp_stage
     )


### PR DESCRIPTION
Array alpha was silently ignored when passing RGB image data to imshow(). For RGBA images, array alpha replaced the existing alpha channel instead of multiplying with it.

Now array alpha is used directly for RGB (3-channel) input, and multiplied with the existing alpha channel for RGBA (4-channel) input, consistent with scalar alpha behavior.

Closes #26092

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
