### PR TITLE
Remove mpl.text._get_textbox.

### DIFF
--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -799,7 +799,7 @@ class TextArea(OffsetBox):
             ismath="TeX" if self._text.get_usetex() else False,
             dpi=self.get_figure(root=True).dpi)
 
-        bbox, info = self._text._get_layout(renderer)
+        bbox, info, _ = self._text._get_layout(renderer)
         _last_line, (_last_width, _last_ascent, last_descent), _last_xy = info[-1]
         w, h = bbox.size
 

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -44,44 +44,6 @@ def _rotate_point(angle, x, y):
     return (cos * x - sin * y, sin * x + cos * y)
 
 
-def _get_textbox(text, renderer):
-    """
-    Calculate the bounding box of the text.
-
-    The bbox position takes text rotation into account, but the width and
-    height are those of the unrotated box (unlike `.Text.get_window_extent`).
-    """
-    # TODO : This function may move into the Text class as a method. As a
-    # matter of fact, the information from the _get_textbox function
-    # should be available during the Text._get_layout() call, which is
-    # called within the _get_textbox. So, it would be better to move this
-    # function as a method with some refactoring of _get_layout method.
-
-    projected_xys = []
-
-    theta = math.radians(text.get_rotation())
-    tr = _rotate(-theta)
-
-    _, parts = text._get_layout(renderer)
-
-    for t, (w, a, d), xy in parts:
-        xt, yt = tr.transform(xy)
-        projected_xys.extend([
-            (xt, yt + a),
-            (xt, yt - d),
-            (xt + w, yt + a),
-            (xt + w, yt - d),
-        ])
-    projected_xs, projected_ys = zip(*projected_xys)
-
-    xt_box, yt_box = min(projected_xs), min(projected_ys)
-    w_box, h_box = max(projected_xs) - xt_box, max(projected_ys) - yt_box
-
-    x_box, y_box = _rotate(theta).transform((xt_box, yt_box))
-
-    return x_box, y_box, w_box, h_box
-
-
 def _get_text_metrics_with_cache(renderer, text, fontprop, ismath, dpi):
     """Call ``renderer.get_text_width_height_descent``, caching the results."""
 
@@ -455,8 +417,11 @@ class Text(Artist):
         """
         Return
 
-        - the (rotated) text bbox, and
-        - a list of ``(line, (width, ascent, descent), xy)`` tuples for each line.
+        - the rotated, axis-aligned text bbox;
+        - a list of ``(line, (width, ascent, descent), xy)`` tuples for each line;
+        - a ``(xy, (width, height))` pair of the lower-left corner and size of the
+          rotated, *text-aligned* text box (i.e. describing how to draw the
+          text-surrounding box).
         """
         thisx, thisy = 0.0, 0.0
         lines = self._get_wrapped_text().split("\n")  # Ensures lines is not empty.
@@ -529,7 +494,7 @@ class Text(Artist):
 
         # the corners of the unrotated bounding box
         corners_horiz = [(xmin, ymin), (xmin, ymax), (xmax, ymax), (xmax, ymin)]
-
+        size_horiz = (xmax - xmin, ymax - ymin)
         # now rotate the bbox
         angle = self.get_rotation()
         rotate = functools.partial(_rotate_point, angle)
@@ -539,8 +504,8 @@ class Text(Artist):
         xs, ys = zip(*corners_rotated)
         xmin, xmax = min(xs), max(xs)
         ymin, ymax = min(ys), max(ys)
-        width = xmax - xmin
-        height = ymax - ymin
+        width_rot = xmax - xmin
+        height_rot = ymax - ymin
 
         # Now move the box to the target position offset the display
         # bbox by alignment
@@ -555,57 +520,47 @@ class Text(Artist):
                 valign = self._va_for_angle(angle)
             # compute the text location in display coords and the offsets
             # necessary to align the bbox with that location
-            if halign == 'center':
-                offsetx = (xmin + xmax) / 2
-            elif halign == 'right':
-                offsetx = xmax
-            else:
-                offsetx = xmin
-
-            if valign == 'center':
-                offsety = (ymin + ymax) / 2
-            elif valign == 'top':
-                offsety = ymax
-            elif valign == 'baseline':
-                offsety = ymin + descent
-            elif valign == 'center_baseline':
-                offsety = ymin + height - baseline / 2.0
-            else:
-                offsety = ymin
+            offsetx = (
+                xmin if halign == "left" else
+                xmax if halign == "right" else
+                (xmin + xmax) / 2  # halign == "center"
+            )
+            offsety = (
+                ymin if valign == "bottom" else
+                ymax if valign == "top" else
+                (ymin + ymax) / 2 if valign == "center" else
+                ymin + descent if valign == "baseline" else
+                ymin + height_rot - baseline / 2  # valign == "center_baseline"
+            )
         else:
             xmin1, ymin1 = corners_horiz[0]
             xmax1, ymax1 = corners_horiz[2]
-
-            if halign == 'center':
-                offsetx = (xmin1 + xmax1) / 2.0
-            elif halign == 'right':
-                offsetx = xmax1
-            else:
-                offsetx = xmin1
-
-            if valign == 'center':
-                offsety = (ymin1 + ymax1) / 2.0
-            elif valign == 'top':
-                offsety = ymax1
-            elif valign == 'baseline':
-                offsety = ymax1 - baseline
-            elif valign == 'center_baseline':
-                offsety = ymax1 - baseline / 2.0
-            else:
-                offsety = ymin1
-
+            offsetx = (
+                xmin1 if halign == "left" else
+                xmax1 if halign == "right" else
+                (xmin1 + xmax1) / 2  # halign == "center"
+            )
+            offsety = (
+                ymin1 if valign == "bottom" else
+                ymax1 if valign == "top" else
+                (ymin1 + ymax1) / 2 if valign == "center" else
+                ymax1 - baseline if valign == "baseline" else
+                ymax1 - baseline / 2  # valign == "center_baseline"
+            )
             offsetx, offsety = rotate(offsetx, offsety)
 
         xmin -= offsetx
         ymin -= offsety
 
-        bbox = Bbox.from_bounds(xmin, ymin, width, height)
+        bbox_rot = Bbox.from_bounds(xmin, ymin, width_rot, height_rot)
 
         # now rotate the positions around the first (x, y) position
         xys = [(x - offsetx, y - offsety)
                for x, y in itertools.starmap(rotate, offset_layout)]
+        x, y = corners_rotated[0]
+        xy_corner = (x - offsetx, y - offsety)
 
-        return bbox, list(zip(lines, wads, xys))
+        return bbox_rot, list(zip(lines, wads, xys)), (xy_corner, size_horiz)
 
     def set_bbox(self, rectprops):
         """
@@ -677,7 +632,7 @@ class Text(Artist):
             posy = float(self.convert_yunits(self._y))
             posx, posy = self.get_transform().transform((posx, posy))
 
-            x_box, y_box, w_box, h_box = _get_textbox(self, renderer)
+            _, _, ((x_box, y_box), (w_box, h_box)) = self._get_layout(renderer)
             self._bbox_patch.set_bounds(0., 0., w_box, h_box)
             self._bbox_patch.set_transform(
                 Affine2D()
@@ -857,7 +812,7 @@ class Text(Artist):
 
         renderer.open_group('text', self.get_gid())
 
-        bbox, info = self._get_layout(renderer)
+        bbox, info, _ = self._get_layout(renderer)
         trans = self.get_transform()
 
         # don't use self.get_position here, which refers to text
@@ -1080,7 +1035,7 @@ class Text(Artist):
                 "want to call 'figure.draw_without_rendering()' first.")
 
         with cbook._setattr_cm(fig, dpi=dpi):
-            bbox, _ = self._get_layout(self._renderer)
+            bbox, _, _ = self._get_layout(self._renderer)
             x, y = self.get_unitless_position()
             x, y = self.get_transform().transform((x, y))
             bbox = bbox.translated(x, y)


### PR DESCRIPTION
Consider a multiline Text object with nonzero rotation. Text._get_layout performs the layouting of the individual lines. Previously, it would return (among other things) the axes-aligned bbox of the whole Text (which can be much bigger than the rotated bbox), as well as the metrics of each individual line. mpl.text._get_layout would then take these individual metrics and unrotate their positions (to horizontal lines) to compute the size of the *rotated* bbox of the text (and its position as well); this is used solely when drawing a (text-aligned) bbox around the text (`plt.text(..., bbox=...)`).

The back-and-forth rotation seems a bit complicated; one can instead simply return the relevant info in Text._get_layout as well: the rotated bbox size is already available (in the variable previously named `corners_horiz`), and getting its position is also simple.  Do that, and get rid of mpl.text._get_textbox (and also adjust the callers of Text._get_layout accordingly).  Also add some additional drive-by reformatting of Text._get_layout.

Note: This would result in merge conflicts with @scottshambaugh's #31001, but the two PRs target different branches (this one is on text-overhaul because it goes on top of the "fix ascent/height confusion" PR).  I don't mind rebasing this on top of #31001 if (the text-related parts of) that one also get retargeted to text-overhaul.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
