### PR TITLE
Fix array alpha to multiply with existing RGBA alpha in imshow

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -512,8 +512,11 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                     if A.shape[2] == 3:  # image has no alpha channel
                         A = np.dstack([A, np.ones(A.shape[:2])])
                 elif np.ndim(alpha) > 0:  # Array alpha
-                    # user-specified array alpha overrides the existing alpha channel
-                    A = np.dstack([A[..., :3], alpha])
+                    if A.shape[2] == 3:  # RGB: use array alpha directly
+                        A = np.dstack([A, alpha])
+                    else:  # RGBA: multiply array alpha with existing alpha
+                        A = np.dstack([A[..., :3],
+                                       A[..., 3] * alpha])
                 else:  # Scalar alpha
                     if A.shape[2] == 3:  # broadcast scalar alpha
                         A = np.dstack([A, np.full(A.shape[:2], alpha, np.float32)])


### PR DESCRIPTION
## Summary

Closes #26092

- When passing an array alpha to `imshow()` with an RGBA image, the alpha values now **multiply** with the existing alpha channel instead of replacing it
- This makes array alpha behavior consistent with scalar alpha behavior, which already multiplied with the existing alpha channel
- For RGB images, array alpha continues to be used directly as the alpha channel (no change in behavior)

The fix is in `_ImageBase._make_image()` in `lib/matplotlib/image.py`. Previously, the array alpha code path unconditionally replaced the alpha channel with `A = np.dstack([A[..., :3], alpha])`. Now it distinguishes between RGB (use alpha directly) and RGBA (multiply `A[..., 3] * alpha`).

### Before (RGBA + array alpha replaces):
```python
elif np.ndim(alpha) > 0:  # Array alpha
    A = np.dstack([A[..., :3], alpha])
```

### After (RGBA + array alpha multiplies):
```python
elif np.ndim(alpha) > 0:  # Array alpha
    if A.shape[2] == 3:  # RGB: use array alpha directly
        A = np.dstack([A, alpha])
    else:  # RGBA: multiply array alpha with existing alpha
        A = np.dstack([A[..., :3], A[..., 3] * alpha])
```

## Test plan

- [x] Added `test_image_array_alpha_rgb` - verifies RGB images with array alpha produce same result as manually constructed RGBA
- [x] Added `test_image_array_alpha_rgba` - verifies RGBA images with array alpha multiply the existing alpha channel
- [x] Added RGB + array alpha case to `test_imshow_multi_draw` parametrization to verify original array is not modified
- [x] Updated `test_interpolation_stage_rgba_respects_alpha_param` reference to expect multiplied alpha instead of replaced alpha

🤖 Generated with [Claude Code](https://claude.com/claude-code)