### PR TITLE
Fix:Allow 'mid' as a valid pivot synonym for 'middle' in quiver pivot

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -534,7 +534,7 @@ class Quiver(mcollections.PolyCollection):
         if pivot.lower() == 'mid':
             pivot = 'middle'
         self.pivot = pivot.lower()
-        _api.check_in_list(self._PIVOT_VALS, pivot=self.pivot)
+        _api.check_in_list(['tail', 'mid', 'middle', 'tip'], pivot=self.pivot)
 
         self.transform = kwargs.pop('transform', ax.transData)
         kwargs.setdefault('facecolors', color)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
     To fix Value Error when using the documented mid pivot option.
- What problem does it solve?
   It makes the code match the documentation.
- What is the reasoning for this implementation?
      Added 'mid' to the validation and mapped it to 'middle'.

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.  If you have used
generative AI as an aid in preparing this PR, see

https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
