### PR TITLE
ci: add scheduled sphinx linkcheck workflow

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,50 @@
+---
+name: Sphinx linkcheck
+
+on:
+  # Run weekly on Sunday at 6:00 UTC
+  schedule:
+    - cron: "0 6 * * 0"
+  # Allow manual triggering
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  linkcheck:
+    name: Check documentation links
+    runs-on: ubuntu-latest
+    if: github.repository_owner == 'matplotlib'
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Matplotlib and doc dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --no-build-isolation --editable .[dev]
+          python -m pip install -r requirements/doc/doc-requirements.txt
+
+      - name: Run sphinx linkcheck
+        continue-on-error: true
+        run: |
+          cd doc
+          python -msphinx -b linkcheck -D plot_gallery=0 . build/linkcheck
+        env:
+          PYTHONFAULTHANDLER: 1
+
+      - name: Upload linkcheck results
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        with:
+          name: linkcheck-results
+          path: doc/build/linkcheck/
+          retention-days: 30

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -281,6 +281,29 @@ intersphinx_mapping = {
     'pip': ('https://pip.pypa.io/en/stable/', None),
 }
 
+# Linkcheck settings
+# URLs to skip during link checking (known redirect chains, rate-limited hosts,
+# or URLs that require authentication).
+linkcheck_ignore = [
+    # DOIs redirect through doi.org resolver — always reachable but flagged as
+    # redirect by linkcheck.
+    r'https?://doi\.org/',
+    # GitHub may rate-limit the linkcheck bot.
+    r'https://github\.com/matplotlib/matplotlib/(issues|pull|commit|blob|tree)/',
+    # Raw GitHub content redirects.
+    r'https://raw\.githubusercontent\.com/',
+    # SourceForge mailing-list archives are frequently slow or unreachable in CI.
+    r'https?://sourceforge\.net/mailarchive/',
+    # Zenodo DOI badges redirect to the resolver.
+    r'https://zenodo\.org/badge/',
+]
+
+# Timeout (seconds) for each linkcheck request.
+linkcheck_timeout = 30
+
+# Retry failed links up to 3 times before reporting a failure.
+linkcheck_retries = 3
+
 
 gallery_dirs = [f'{ed}' for ed in
                 ['gallery', 'tutorials', 'plot_types', 'users/explain']


### PR DESCRIPTION
## Summary

Closes #5380.

This PR adds a weekly scheduled GitHub Actions workflow that runs `sphinx-build -b linkcheck` on the Matplotlib documentation. The goal is to proactively detect broken or redirected links in the docs before users encounter them.

### What's added

**`.github/workflows/linkcheck.yml`**
- Runs every Sunday at 06:00 UTC via a `schedule` trigger.
- Can also be triggered on-demand with `workflow_dispatch`.
- Sets up Python 3.12, installs Matplotlib in editable mode (`.[dev]`), and installs doc requirements from `requirements/doc/doc-requirements.txt`.
- Runs `python -msphinx -b linkcheck -D plot_gallery=0 . build/linkcheck` (skipping gallery plot generation for speed).
- Uses `continue-on-error: true` so the workflow reports link failures without blocking the repository.
- Uploads the `output.txt` / `output.json` linkcheck results as a downloadable artifact (retained for 30 days) for easy triage.
- Guarded by `github.repository_owner == 'matplotlib'` so it only runs on the upstream repo, not on forks.

**`doc/conf.py`**
- Adds `linkcheck_ignore` patterns to suppress known false-positives:
  - `doi.org` redirects (always resolve but linkcheck flags them).
  - GitHub issue/PR/commit/blob URLs (subject to rate-limiting in CI).
  - `raw.githubusercontent.com` (returns redirect responses).
  - SourceForge mailing-list archives (slow/unreachable in CI).
  - Zenodo badge URLs (redirect to the DOI resolver).
- Sets `linkcheck_timeout = 30` and `linkcheck_retries = 3` for reliable results.

## Test plan

- [ ] Trigger the workflow manually via **Actions → Sphinx linkcheck → Run workflow** on the upstream repo after merge and confirm the run completes without unexpected failures.
- [ ] Verify that the `linkcheck-results` artifact is uploaded and contains `output.txt` / `output.json`.
- [ ] Confirm the scheduled run appears in the Actions tab the following Sunday.