### PR TITLE
TST: Switch mathtext tests to mpl20

### DIFF
--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -224,12 +224,12 @@ def baseline_images(request, fontset, index, text):
 @pytest.mark.parametrize(
     'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
 @pytest.mark.parametrize('baseline_images', ['mathtext'], indirect=True)
-@image_comparison(baseline_images=None,
+@image_comparison(baseline_images=None, style='mpl20',
                   tol=0.011 if platform.machine() in ('ppc64le', 's390x') else 0)
 def test_mathtext_rendering(baseline_images, fontset, index, text):
     mpl.rcParams['mathtext.fontset'] = fontset
     fig = plt.figure(figsize=(5.25, 0.75))
-    fig.text(0.5, 0.5, text,
+    fig.text(0.5, 0.5, text, fontsize=12,
              horizontalalignment='center', verticalalignment='center')
 
 
@@ -238,7 +238,7 @@ def test_mathtext_rendering(baseline_images, fontset, index, text):
 @pytest.mark.parametrize('fontset', ['cm', 'dejavusans'])
 @pytest.mark.parametrize('baseline_images', ['mathtext0'], indirect=True)
 @image_comparison(
-    baseline_images=None, extensions=['svg'],
+    baseline_images=None, extensions=['svg'], style='mpl20',
     savefig_kwarg={'metadata': {  # Minimize image size.
         'Creator': None, 'Date': None, 'Format': None, 'Type': None}})
 def test_mathtext_rendering_svgastext(baseline_images, fontset, index, text):
@@ -254,10 +254,10 @@ def test_mathtext_rendering_svgastext(baseline_images, fontset, index, text):
                          ids=range(len(lightweight_math_tests)))
 @pytest.mark.parametrize('fontset', ['dejavusans'])
 @pytest.mark.parametrize('baseline_images', ['mathtext1'], indirect=True)
-@image_comparison(baseline_images=None, extensions=['png'])
+@image_comparison(baseline_images=None, extensions=['png'], style='mpl20')
 def test_mathtext_rendering_lightweight(baseline_images, fontset, index, text):
     fig = plt.figure(figsize=(5.25, 0.75))
-    fig.text(0.5, 0.5, text, math_fontfamily=fontset,
+    fig.text(0.5, 0.5, text, fontsize=12, math_fontfamily=fontset,
              horizontalalignment='center', verticalalignment='center')
 
 
@@ -266,12 +266,12 @@ def test_mathtext_rendering_lightweight(baseline_images, fontset, index, text):
 @pytest.mark.parametrize(
     'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
 @pytest.mark.parametrize('baseline_images', ['mathfont'], indirect=True)
-@image_comparison(baseline_images=None, extensions=['png'],
+@image_comparison(baseline_images=None, extensions=['png'], style='mpl20',
                   tol=0.011 if platform.machine() in ('ppc64le', 's390x') else 0)
 def test_mathfont_rendering(baseline_images, fontset, index, text):
     mpl.rcParams['mathtext.fontset'] = fontset
     fig = plt.figure(figsize=(5.25, 0.75))
-    fig.text(0.5, 0.5, text,
+    fig.text(0.5, 0.5, text, fontsize=12,
              horizontalalignment='center', verticalalignment='center')
 
 
@@ -477,7 +477,7 @@ def test_math_to_image(tmp_path):
 
 
 @image_comparison(baseline_images=['math_fontfamily_image.png'],
-                  savefig_kwarg={'dpi': 40})
+                  savefig_kwarg={'dpi': 40}, style='mpl20')
 def test_math_fontfamily():
     fig = plt.figure(figsize=(10, 3))
     fig.text(0.2, 0.7, r"$This\ text\ should\ have\ one\ font$",


### PR DESCRIPTION
## PR summary

In order to preserve existing images, explicitly set the fontsize to the old setting, which is easier to read anyway.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines