### PR TITLE
doc: Add worked example for discrete `colormapping` using `BoundaryNorm`

### DIFF
--- a/galleries/users_explain/colors/colormapnorms.py
+++ b/galleries/users_explain/colors/colormapnorms.py
@@ -280,6 +280,7 @@ bin_centers = np.array(bounds[:-1]) + np.diff(bounds) / 2
 cbar = fig.colorbar(im, ax=ax)
 cbar.set_ticks(bin_centers)
 cbar.set_ticklabels(list(codings.keys()))
+cbar.ax.tick_params(axis='y', which='minor', length=0)
 
 cbar.set_label('Categories')
 ax.set_title("Categorical Colormapping using BoundaryNorm")


### PR DESCRIPTION
**Pull Request Summary**
--This PR adds a practical, worked example to colormapnorms.py demonstrating how to use colors.BoundaryNorm for discrete/categorical colormapping.

The example illustrates:
> Mapping explicit integer IDs (eg., 101, 205, 302) to specific colors using a dictionary-like approach.
> Defining precise boundaries to wrap around these integer IDs to ensure correct mapping.
> Adjusting colorbar ticks to align perfectly with categorical values for a cleaner visualization.

**Motivation**
--Documentation for BoundaryNorm often uses simple sequential ranges. This example helps users understand how to map non-sequential, specific IDs, which is a common real-world use case.

**Changes Made**
--Added a new self-contained code block under the "categorical mapping with BoundaryNorm" section.
--Defined local x_cat and y_cat data to ensure the example runs independently.
--Implemented specific ticks on the colorbar as suggested during the review process.
--Removed unnecessary internal comments as per reviewer feedback.

**AI Disclosure**
--I used Gemini AI to help with terminal troubleshooting and formatting this description. 
