### PR TITLE
DOC: make nightly download command one line so it works on Windows

### DIFF
--- a/doc/install/index.rst
+++ b/doc/install/index.rst
@@ -101,13 +101,6 @@ scientific-python-nightly-wheels as the package index to query::
 
   python -m pip install --upgrade --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple matplotlib
 
-    .. note::
-
-   On Windows Command Prompt, line continuation using ``\`` is not supported.
-   Run the above command as a single line instead, e.g.:
-
-   ``python -m pip install --upgrade --pre --index-url https://pypi.anaconda.org/scientific-python-nightly-wheels/simple --extra-index-url https://pypi.org/simple matplotlib``
-
 .. _install-source:
 
 Install from source


### PR DESCRIPTION
This PR adds a clarification note for Windows Command Prompt users
in the "Install a nightly build" section.

Windows CMD does not support line continuation using "\".
Without this clarification, the multi-line pip command may fail
for Windows users.

This change improves clarity and avoids installation errors.