### PR TITLE
ENH: allow non-monotonic contour levels

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1523,8 +1523,8 @@ colors : :mpltype:`color` or list of :mpltype:`color`, optional
     The colors of the levels, i.e. the lines for `.contour` and the
     areas for `.contourf`.
 
-    The sequence is cycled for the levels in ascending order. If the
-    sequence is shorter than the number of levels, it's repeated.
+    The colors are mapped to the levels in the order specified, repeating as
+    necessary if there are fewer colors than levels.
 
     As a shortcut, a single color may be used in place of one-element lists, i.e.
     ``'red'`` instead of ``['red']`` to color all levels with the same color.
@@ -1645,8 +1645,8 @@ linewidths : float or array-like, default: :rc:`contour.linewidth`
 
     If a number, all levels will be plotted with this linewidth.
 
-    If a sequence, the levels in ascending order will be plotted with
-    the linewidths in the order specified.
+    If a sequence, the linewidths are mapped to the levels in order,
+    repeating as necessary if there are fewer linewidths than levels.
 
     If None, this falls back to :rc:`lines.linewidth`.
 

--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1029,8 +1029,12 @@ class ContourSet(ContourLabeler, mcoll.Collection):
 
         if self.filled and len(self.levels) < 2:
             raise ValueError("Filled contours require at least 2 levels.")
-        if len(self.levels) > 1 and np.min(np.diff(self.levels)) <= 0.0:
-            raise ValueError("Contour levels must be increasing")
+
+        # check if filled contours are monotonically increasing:
+        if (self.filled and len(self.levels) > 1 and
+                np.any(np.diff(self.levels) <= 0)):
+            raise ValueError(
+                "Filled contour levels must be monotonically increasing")
 
     def _process_levels(self):
         """
@@ -1496,7 +1500,7 @@ levels : int or array-like, optional
     *n*=7 is the default.
 
     If array-like, draw contour lines at the specified levels.
-    The values must be in increasing order.
+    For filled contours, the values must be in increasing order.
 
     If not specified, a reasonable default is automatically chosen. For
     linear scales, this corresponds to *levels=7*. For logarithmic

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -336,21 +336,19 @@ def test_contourf_decreasing_levels():
 
 
 @check_figures_equal()
-def test_contour_random_levels(fig_ref, fig_test):
-    # test that it doesn't matter if the levels are given in a random order and
-    # that their colors are matched to the correct levels.
+def test_contour_decreasing_levels(fig_ref, fig_test):
+    # Check that contour works with decreasing levels:
     Z = np.arange(100).reshape(10, 10)
     ax_ref = fig_ref.subplots()
     ax_test = fig_test.subplots()
 
-    levels0 = np.array([6, 30, 10, 20, 33, 80, 53])
+    levels0 = np.array([6, 10, 20, 30, 33, 53, 80])
     colors0 = ['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black']
-    ind = np.argsort(levels0)
 
     # sorted:
-    ax_ref.contour(Z, levels=levels0[ind], colors=np.array(colors0)[ind])
-    # unsorted:
-    ax_test.contour(Z, levels=levels0, colors=colors0)
+    ax_ref.contour(Z, levels=levels0, colors=np.array(colors0))
+    # reversed:
+    ax_test.contour(Z, levels=levels0[::-1], colors=colors0[::-1])
 
 
 def test_contourf_symmetric_locator():

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -335,6 +335,24 @@ def test_contourf_decreasing_levels():
         plt.contourf(z, [1.0, 0.0])
 
 
+@check_figures_equal()
+def test_contour_random_levels(fig_ref, fig_test):
+    # test that it doesn't matter if the levels are given in a random order and
+    # that their colors are matched to the correct levels.
+    Z = np.arange(100).reshape(10, 10)
+    ax_ref = fig_ref.subplots()
+    ax_test = fig_test.subplots()
+
+    levels0 = np.array([6, 30, 10, 20, 33, 80, 53])
+    colors0 = ['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black']
+    ind = np.argsort(levels0)
+
+    # sorted:
+    ax_ref.contour(Z, levels=levels0[ind], colors=np.array(colors0)[ind])
+    # unsorted:
+    ax_test.contour(Z, levels=levels0, colors=colors0)
+
+
 def test_contourf_symmetric_locator():
     # github issue 7271
     z = np.arange(12).reshape((3, 4))


### PR DESCRIPTION
This removes the restriction on `contour` needing to have monotonically increasing contour *levels*.  No sorting of the levels is done.  The documentation change is trivial.  

This restriction was put in for `contourf`, https://github.com/matplotlib/matplotlib/issues/5477https://github.com/matplotlib/matplotlib/issues/5477, but doesn't seem necessary for `contour`.  

Addresses #31227


```python

import numpy as np
import matplotlib.pyplot as plt

Z = np.arange(100).reshape(10, 10)
fig, axs = plt.subplots(2, 2, layout='constrained', sharex=True, sharey=True)
levels0 = np.array([0, 30, 10, 20, 33, 80, 53])

axs[0, 0].contour(Z, levels=levels0, colors=['red', 'green', 'blue', 'cyan', 'magenta', 'yellow', 'black'])

axs[0, 1].contour(Z, levels=levels0)
axs[1, 0].contour(Z, levels=np.sort(levels0))
axs[1, 1].contour(Z, levels=np.sort(levels0)[::-1])

plt.show()
```
<img width="640" height="480" alt="Contour" src="https://github.com/user-attachments/assets/bb24d90c-fafd-4366-af1d-5cca503635ed" />


