### PR TITLE
CI: Explicitly define CI workflow permissions

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -18,8 +18,7 @@ on:
       - reopened
       - labeled
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build_sdist:
@@ -37,6 +36,8 @@ jobs:
       )
     name: Build sdist
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       SDIST_NAME: ${{ steps.sdist.outputs.SDIST_NAME }}
 
@@ -93,6 +94,8 @@ jobs:
       )
     needs: build_sdist
     name: Build wheels on ${{ matrix.os }} for ${{ matrix.cibw_archs }}
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
     env:
       CIBW_BEFORE_BUILD: >-

--- a/.github/workflows/circleci.yml
+++ b/.github/workflows/circleci.yml
@@ -1,6 +1,9 @@
 ---
 name: "CircleCI artifact handling"
 on: [status]
+
+permissions: {}
+
 jobs:
   circleci_artifacts_redirector_job:
     if: "${{ github.event.context == 'ci/circleci: docs-python3' }}"

--- a/.github/workflows/clean_pr.yml
+++ b/.github/workflows/clean_pr.yml
@@ -2,12 +2,13 @@
 name: PR cleanliness
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pr_clean:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -10,6 +10,8 @@ on:
   schedule:
     - cron: '45 19 * * 1'
 
+permissions: {}
+
 jobs:
   analyze:
     if: github.repository == 'matplotlib/matplotlib'

--- a/.github/workflows/conflictcheck.yml
+++ b/.github/workflows/conflictcheck.yml
@@ -9,6 +9,8 @@ on:
   pull_request_target:
     types: [synchronize]
 
+permissions: {}
+
 jobs:
   main:
     if: github.repository == 'matplotlib/matplotlib'

--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -30,8 +30,7 @@ on:
     - cron: "47 5 * * 6"
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 env:
   NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.
@@ -47,6 +46,8 @@ jobs:
 
   test-cygwin:
     runs-on: windows-latest
+    permissions:
+      contents: read
     name: Python 3.${{ matrix.python-minor-version }} on Cygwin
     # Enable these when Cygwin has Python 3.12.
     if: >-

--- a/.github/workflows/good-first-issue.yml
+++ b/.github/workflows/good-first-issue.yml
@@ -4,6 +4,9 @@ on:
   issues:
     types:
       - labeled
+
+permissions: {}
+
 jobs:
   add-comment:
     if: github.event.label.name == 'Good first issue'

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,6 +3,8 @@ name: "Pull Request Labeler"
 on:
   - pull_request_target
 
+permissions: {}
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,13 +2,14 @@
 name: Linting
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   pre-commit:
     name: precommit
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
@@ -25,6 +26,7 @@ jobs:
     name: ruff
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -54,6 +56,7 @@ jobs:
     name: mypy
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -85,6 +88,7 @@ jobs:
     name: eslint
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/mypy-stubtest.yml
+++ b/.github/workflows/mypy-stubtest.yml
@@ -2,14 +2,14 @@
 name: Mypy Stubtest
 on: [pull_request]
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   mypy-stubtest:
     name: mypy-stubtest
     runs-on: ubuntu-latest
     permissions:
+      contents: read
       checks: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -8,8 +8,7 @@ on:
   # Run on demand with workflow dispatch
   workflow_dispatch:
 
-permissions:
-  actions: read
+permissions: {}
 
 jobs:
   upload_nightly_wheels:
@@ -21,6 +20,8 @@ jobs:
         # to work in subsequent jobs.
         # https://github.com/mamba-org/setup-micromamba#about-login-shells
         shell: bash -e -l {0}
+    permissions:
+      actions: read
     if: github.repository_owner == 'matplotlib'
 
     steps:

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -7,6 +7,8 @@ on:
   issues:
     types: opened
 
+permissions: {}
+
 jobs:
   greeting:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale-tidy.yml
+++ b/.github/workflows/stale-tidy.yml
@@ -4,10 +4,14 @@ on:
   schedule:
     - cron: '30 1 * * 2,4,6'
 
+permissions: {}
+
 jobs:
   stale:
     if: github.repository == 'matplotlib/matplotlib'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,10 +4,15 @@ on:
   schedule:
     - cron: '30 1 * * 1'
 
+permissions: {}
+
 jobs:
   stale:
     if: github.repository == 'matplotlib/matplotlib'
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f  # v10.2.0
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,8 @@ on:
     - cron: "47 5 * * 6"
   workflow_dispatch:
 
+permissions: {}
+
 env:
   NO_AT_BRIDGE: 1  # Necessary for GTK3 interactive test.
   OPENBLAS_NUM_THREADS: 1


### PR DESCRIPTION
## PR summary
Inspired by the recent CI attacks here: https://www.stepsecurity.io/blog/hackerbot-claw-github-actions-exploitation#summary-of-results

This tightens up permissions on CI runners by zeroing out permissions to start, and adding them back in per-job. I would characterize this as low priority hardening.

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
