### PR TITLE
DOC: fix math rendering in pyplot.quiver scale_units docs

### DIFF
--- a/lib/matplotlib/quiver.py
+++ b/lib/matplotlib/quiver.py
@@ -143,9 +143,9 @@ scale_units : {'width', 'height', 'dots', 'inches', 'x', 'y', 'xy'}, default: 'w
 
     The rendered arrow length is given by
 
-        length in x direction = $\\frac{u}{\\mathrm{scale}} \\mathrm{scale_unit}$
+        length in x direction = :math:`\\frac{u}{\\mathrm{scale}} \\mathrm{scale\_units}`
 
-        length in y direction = $\\frac{v}{\\mathrm{scale}} \\mathrm{scale_unit}$
+        length in y direction = :math:`\\frac{v}{\\mathrm{scale}} \\mathrm{scale\_units}`
 
     For example, ``(u, v) = (0.5, 0)`` with ``scale=10, scale_units="width"`` results
     in a horizontal arrow with a length of *0.5 / 10 * "width"*, i.e. 0.05 times the


### PR DESCRIPTION
## Summary\n- replace inline LaTeX  in  docs with Sphinx  roles\n- escape  underscore in math expressions\n\n## Why\nFixes bad rendering reported in #31235 for the  API docs page.\n\n## Testing\n- docs-only change