### PR TITLE
ENH: Add figure.titlelocation rcParam for suptitle alignment

### DIFF
--- a/doc/release/next_whats_new/suptitle_location_rcparam.rst
+++ b/doc/release/next_whats_new/suptitle_location_rcparam.rst
@@ -1,0 +1,15 @@
+``figure.titlelocation`` rcParam
+--------------------------------
+
+A new :rc:`figure.titlelocation` rcParam has been added to control the
+default horizontal alignment of the figure suptitle, analogous to the
+existing :rc:`axes.titlelocation` for axes titles.  Supported values are
+``'left'``, ``'center'`` (default), and ``'right'``.
+
+.. code-block:: python
+
+    import matplotlib as mpl
+    mpl.rcParams['figure.titlelocation'] = 'left'
+
+    fig, ax = plt.subplots()
+    fig.suptitle('Left-aligned suptitle')

--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -392,8 +392,12 @@ default: %(va)s
     @_docstring.copy(_suplabels)
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
-        info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
+        loc = mpl.rcParams['figure.titlelocation']
+        x0, ha = {'left': (0, 'left'),
+                  'center': (0.5, 'center'),
+                  'right': (1, 'right')}[loc]
+        info = {'name': '_suptitle', 'x0': x0, 'y0': 0.98,
+                'ha': ha, 'va': 'top', 'rotation': 0,
                 'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
         return self._suplabels(t, info, **kwargs)
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -587,8 +587,9 @@
 ## * FIGURE                                                                  *
 ## ***************************************************************************
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
-#figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
-#figure.titleweight: normal    # weight of the figure title
+#figure.titlesize:     large    # size of the figure title (``Figure.suptitle()``)
+#figure.titleweight:   normal   # weight of the figure title
+#figure.titlelocation: center   # alignment of the figure title: {left, right, center}
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)
 #figure.labelweight: normal    # weight of the figure label
 #figure.figsize:     6.4, 4.8  # figure size in inches

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1310,6 +1310,7 @@ _validators = {
     # figure title
     "figure.titlesize":   validate_fontsize,
     "figure.titleweight": validate_fontweight,
+    "figure.titlelocation": ["left", "center", "right"],
 
     # figure labels
     "figure.labelsize":   validate_fontsize,
@@ -2706,6 +2707,12 @@ _DEFINITION = [
         default="normal",
         validator=validate_fontweight,
         description="weight of the figure title"
+    ),
+    _Param(
+        "figure.titlelocation",
+        default="center",
+        validator=["left", "center", "right"],
+        description="alignment of the figure title: {left, right, center}"
     ),
     _Param(
         "figure.labelsize",

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -352,6 +352,28 @@ def test_suptitle_subfigures():
     assert sf2.get_facecolor() == (1.0, 1.0, 1.0, 1.0)
 
 
+@pytest.mark.parametrize('loc, expected_x, expected_ha', [
+    ('left', 0, 'left'),
+    ('center', 0.5, 'center'),
+    ('right', 1, 'right'),
+])
+def test_suptitle_location_rcparam(loc, expected_x, expected_ha):
+    with mpl.rc_context({'figure.titlelocation': loc}):
+        fig, _ = plt.subplots()
+        txt = fig.suptitle('title')
+        assert txt.get_position()[0] == expected_x
+        assert txt.get_ha() == expected_ha
+
+
+def test_suptitle_location_kwarg_override():
+    """Explicit x/ha kwargs should override the rcParam."""
+    with mpl.rc_context({'figure.titlelocation': 'left'}):
+        fig, _ = plt.subplots()
+        txt = fig.suptitle('title', x=0.7, ha='right')
+        assert txt.get_position()[0] == 0.7
+        assert txt.get_ha() == 'right'
+
+
 def test_get_suptitle_supxlabel_supylabel():
     fig, ax = plt.subplots()
     assert fig.get_suptitle() == ""

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -306,6 +306,7 @@ RcKeyType: TypeAlias = Literal[
     "figure.subplot.right",
     "figure.subplot.top",
     "figure.subplot.wspace",
+    "figure.titlelocation",
     "figure.titlesize",
     "figure.titleweight",
     "font.cursive",


### PR DESCRIPTION
## Summary

Adds a new `figure.titlelocation` rcParam that controls the default horizontal alignment of figure suptitles, matching the existing `axes.titlelocation` for axes titles. Supports `'left'`, `'center'` (default), and `'right'`.

Closes #24090.

## Changes

- New rcParam `figure.titlelocation` with validator and default in `rcsetup.py`
- `figure.suptitle()` reads the rcParam to set default x position and horizontal alignment
- Updated `matplotlibrc`, `typing.py`
- Tests for all three locations and for kwarg override
- What's new entry

## AI disclosure

This PR was developed with assistance from Claude (Anthropic).