### PR TITLE
SEC: Remove eval() from validate_cycler

### DIFF
--- a/doc/api/next_api_changes/deprecations/31248-SS.rst
+++ b/doc/api/next_api_changes/deprecations/31248-SS.rst
@@ -1,7 +1,9 @@
 Arbitrary code in ``axes.prop_cycle`` rcParam strings
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The ``axes.prop_cycle`` rcParam previously accepted arbitrary Python
-expressions by passing the string to ``eval()``. This is deprecated immediately
-without replacement for security reasons. The previously documented cycler
-operations at https://matplotlib.org/cycler/ are still supported.
+The ``axes.prop_cycle`` rcParam accepts Python expressions that are evaluated
+in a limited context.  The evaluation context has been further limited and some
+expressions that previously worked (list comprehensions, for example) no longer
+will. This change is made without a deprecation period to improve security.
+The previously documented cycler operations at
+https://matplotlib.org/cycler/ are still supported.

--- a/doc/api/next_api_changes/deprecations/31248-SS.rst
+++ b/doc/api/next_api_changes/deprecations/31248-SS.rst
@@ -1,0 +1,7 @@
+Arbitrary code in ``axes.prop_cycle`` rcParam strings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``axes.prop_cycle`` rcParam previously accepted arbitrary Python
+expressions by passing the string to ``eval()``. This is deprecated immediately
+without replacement for security reasons. The previously documented cycler
+operations at https://matplotlib.org/cycler/ are still supported.

--- a/doc/release/next_whats_new/cycler_rcparam_security.rst
+++ b/doc/release/next_whats_new/cycler_rcparam_security.rst
@@ -1,0 +1,10 @@
+``axes.prop_cycle`` rcParam must be literal
+--------------------------------------------
+
+The ``axes.prop_cycle`` rcParam is now parsed safely without ``eval()``. Only
+literal ``cycler()`` calls combined with ``+`` and ``*`` are allowed. All
+previously valid cycler strings continue to work, for example:
+
+.. code-block:: none
+
+   axes.prop_cycle : cycler('color', ['r', 'g', 'b']) + cycler('linewidth', [1, 2, 3])

--- a/doc/release/next_whats_new/cycler_rcparam_security.rst
+++ b/doc/release/next_whats_new/cycler_rcparam_security.rst
@@ -1,10 +1,10 @@
-``axes.prop_cycle`` rcParam must be literal
---------------------------------------------
+``axes.prop_cycle`` rcParam security improvements
+-------------------------------------------------
 
-The ``axes.prop_cycle`` rcParam is now parsed safely without ``eval()``. Only
-literal ``cycler()`` and ``concat()`` calls combined with ``+``, ``*``, and
-slicing are allowed. All previously valid cycler strings continue to work,
-for example:
+The ``axes.prop_cycle`` rcParam is now parsed in a safer and more restricted
+manner. Only literals, ``cycler()`` and ``concat()`` calls, the operators
+``+`` and ``*``, and slicing are allowed. All previously valid cycler strings
+documented at https://matplotlib.org/cycler/ are still supported, for example:
 
 .. code-block:: none
 

--- a/doc/release/next_whats_new/cycler_rcparam_security.rst
+++ b/doc/release/next_whats_new/cycler_rcparam_security.rst
@@ -2,9 +2,13 @@
 --------------------------------------------
 
 The ``axes.prop_cycle`` rcParam is now parsed safely without ``eval()``. Only
-literal ``cycler()`` calls combined with ``+`` and ``*`` are allowed. All
-previously valid cycler strings continue to work, for example:
+literal ``cycler()`` and ``concat()`` calls combined with ``+``, ``*``, and
+slicing are allowed. All previously valid cycler strings continue to work,
+for example:
 
 .. code-block:: none
 
    axes.prop_cycle : cycler('color', ['r', 'g', 'b']) + cycler('linewidth', [1, 2, 3])
+   axes.prop_cycle : 2 * cycler('color', 'rgb')
+   axes.prop_cycle : concat(cycler('color', 'rgb'), cycler('color', 'cmk'))
+   axes.prop_cycle : cycler('color', 'rgbcmk')[:3]

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -851,7 +851,7 @@ def _eval_cycler_expr(node):
                 "only the 'cycler()' and 'concat()' functions are allowed")
         func = cycler if node.func.id == 'cycler' else cconcat
         args = [_eval_cycler_expr(a) for a in node.args]
-        kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in node.keywords}
+        kwargs = {kw.arg: _eval_cycler_expr(kw.value) for kw in node.keywords}
         return func(*args, **kwargs)
     if isinstance(node, ast.Subscript):
         sl = node.slice

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -847,9 +847,8 @@ def _eval_cycler_expr(node):
     if isinstance(node, ast.Call):
         if not (isinstance(node.func, ast.Name) and node.func.id == 'cycler'):
             raise ValueError("only the 'cycler()' function is allowed")
-        args = [ast.literal_eval(ast.unparse(a)) for a in node.args]
-        kwargs = {kw.arg: ast.literal_eval(ast.unparse(kw.value))
-                  for kw in node.keywords}
+        args = [ast.literal_eval(a) for a in node.args]
+        kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in node.keywords}
         return cycler(*args, **kwargs)
     raise ValueError(
         f"Unsupported expression in cycler string: {ast.dump(node)}")

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -815,11 +815,44 @@ def cycler(*args, **kwargs):
     return reduce(operator.add, (ccycler(k, v) for k, v in validated))
 
 
-class _DunderChecker(ast.NodeVisitor):
-    def visit_Attribute(self, node):
-        if node.attr.startswith("__") and node.attr.endswith("__"):
-            raise ValueError("cycler strings with dunders are forbidden")
-        self.generic_visit(node)
+def _parse_cycler_string(s):
+    """
+    Parse a string representation of a cycler into a Cycler object safely,
+    without using eval().
+
+    Accepts expressions like::
+
+        cycler('color', ['r', 'g', 'b'])
+        cycler('color', 'rgb') + cycler('linewidth', [1, 2, 3])
+        cycler(c='rgb', lw=[1, 2, 3])
+        cycler('c', 'rgb') * cycler('linestyle', ['-', '--'])
+    """
+    try:
+        tree = ast.parse(s, mode='eval')
+    except SyntaxError as e:
+        raise ValueError(f"Could not parse {s!r}: {e}") from e
+    return _eval_cycler_expr(tree.body)
+
+
+def _eval_cycler_expr(node):
+    """Recursively evaluate an AST node to build a Cycler object."""
+    if isinstance(node, ast.BinOp):
+        left = _eval_cycler_expr(node.left)
+        right = _eval_cycler_expr(node.right)
+        if isinstance(node.op, ast.Add):
+            return left + right
+        if isinstance(node.op, ast.Mult):
+            return left * right
+        raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
+    if isinstance(node, ast.Call):
+        if not (isinstance(node.func, ast.Name) and node.func.id == 'cycler'):
+            raise ValueError("only the 'cycler()' function is allowed")
+        args = [ast.literal_eval(ast.unparse(a)) for a in node.args]
+        kwargs = {kw.arg: ast.literal_eval(ast.unparse(kw.value))
+                  for kw in node.keywords}
+        return cycler(*args, **kwargs)
+    raise ValueError(
+        f"Unsupported expression in cycler string: {ast.dump(node)}")
 
 
 # A validator dedicated to the named legend loc
@@ -870,25 +903,11 @@ def _validate_legend_loc(loc):
 def validate_cycler(s):
     """Return a Cycler object from a string repr or the object itself."""
     if isinstance(s, str):
-        # TODO: We might want to rethink this...
-        # While I think I have it quite locked down, it is execution of
-        # arbitrary code without sanitation.
-        # Combine this with the possibility that rcparams might come from the
-        # internet (future plans), this could be downright dangerous.
-        # I locked it down by only having the 'cycler()' function available.
-        # UPDATE: Partly plugging a security hole.
-        # I really should have read this:
-        # https://nedbatchelder.com/blog/201206/eval_really_is_dangerous.html
-        # We should replace this eval with a combo of PyParsing and
-        # ast.literal_eval()
         try:
-            _DunderChecker().visit(ast.parse(s))
-            s = eval(s, {'cycler': cycler, '__builtins__': {}})
-        except BaseException as e:
+            s = _parse_cycler_string(s)
+        except Exception as e:
             raise ValueError(f"{s!r} is not a valid cycler construction: {e}"
                              ) from e
-    # Should make sure what comes from the above eval()
-    # is a Cycler object.
     if isinstance(s, Cycler):
         cycler_inst = s
     else:

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -36,7 +36,7 @@ from matplotlib._fontconfig_pattern import parse_fontconfig_pattern
 from matplotlib._enums import JoinStyle, CapStyle
 
 # Don't let the original cycler collide with our validating cycler
-from cycler import Cycler, cycler as ccycler
+from cycler import Cycler, concat as cconcat, cycler as ccycler
 
 
 class ValidateInStrings:
@@ -845,13 +845,32 @@ def _eval_cycler_expr(node):
             return left * right
         raise ValueError(f"Unsupported operator: {type(node.op).__name__}")
     if isinstance(node, ast.Call):
-        if not (isinstance(node.func, ast.Name) and node.func.id == 'cycler'):
-            raise ValueError("only the 'cycler()' function is allowed")
-        args = [ast.literal_eval(a) for a in node.args]
+        if not (isinstance(node.func, ast.Name)
+                and node.func.id in ('cycler', 'concat')):
+            raise ValueError(
+                "only the 'cycler()' and 'concat()' functions are allowed")
+        func = cycler if node.func.id == 'cycler' else cconcat
+        args = [_eval_cycler_expr(a) for a in node.args]
         kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in node.keywords}
-        return cycler(*args, **kwargs)
-    raise ValueError(
-        f"Unsupported expression in cycler string: {ast.dump(node)}")
+        return func(*args, **kwargs)
+    if isinstance(node, ast.Subscript):
+        value = _eval_cycler_expr(node.value)
+        sl = node.slice
+        if isinstance(sl, ast.Slice):
+            s = slice(
+                ast.literal_eval(sl.lower) if sl.lower else None,
+                ast.literal_eval(sl.upper) if sl.upper else None,
+                ast.literal_eval(sl.step) if sl.step else None,
+            )
+            return value[s]
+        raise ValueError("only slicing is supported, not indexing")
+    # Allow literal values (int, strings, lists, tuples) as arguments
+    # to cycler() and concat().
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, TypeError):
+        raise ValueError(
+            f"Unsupported expression in cycler string: {ast.dump(node)}")
 
 
 # A validator dedicated to the named legend loc

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1179,7 +1179,7 @@ _validators = {
     "axes.formatter.offset_threshold": validate_int,
     "axes.unicode_minus": validate_bool,
     # This entry can be either a cycler object or a string repr of a
-    # cycler-object, which gets eval()'ed to create the object.
+    # cycler-object, which is parsed safely via AST.
     "axes.prop_cycle": validate_cycler,
     # If "data", axes limits are set close to the data.
     # If "round_numbers" axes limits are set to the nearest round numbers.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -854,16 +854,16 @@ def _eval_cycler_expr(node):
         kwargs = {kw.arg: ast.literal_eval(kw.value) for kw in node.keywords}
         return func(*args, **kwargs)
     if isinstance(node, ast.Subscript):
-        value = _eval_cycler_expr(node.value)
         sl = node.slice
-        if isinstance(sl, ast.Slice):
-            s = slice(
-                ast.literal_eval(sl.lower) if sl.lower else None,
-                ast.literal_eval(sl.upper) if sl.upper else None,
-                ast.literal_eval(sl.step) if sl.step else None,
-            )
-            return value[s]
-        raise ValueError("only slicing is supported, not indexing")
+        if not isinstance(sl, ast.Slice):
+            raise ValueError("only slicing is supported, not indexing")
+        s = slice(
+            ast.literal_eval(sl.lower) if sl.lower else None,
+            ast.literal_eval(sl.upper) if sl.upper else None,
+            ast.literal_eval(sl.step) if sl.step else None,
+        )
+        value = _eval_cycler_expr(node.value)
+        return value[s]
     # Allow literal values (int, strings, lists, tuples) as arguments
     # to cycler() and concat().
     try:

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -300,6 +300,9 @@ def generate_validator_testcases(valid):
                    ValueError),
                   ("cycler('c', [j.__class__(j).lower() for j in ['r', 'b']])",
                    ValueError),
+                  # list comprehensions are arbitrary code, even if "safe"
+                  ("cycler('color', [x for x in ['r', 'g', 'b']])",
+                   ValueError),
                   ('1 + 2', ValueError),  # doesn't produce a Cycler object
                   ('os.system("echo Gotcha")', ValueError),  # os not available
                   ('import os', ValueError),  # should not be able to import
@@ -464,14 +467,6 @@ def test_validate_cycler_bad_color_string():
     msg = "'foo' is neither a color sequence name nor can it be interpreted as a list"
     with pytest.raises(ValueError, match=msg):
         validate_cycler("cycler('color', 'foo')")
-
-
-def test_validate_cycler_no_code_execution():
-    # List comprehensions are arbitrary code. The old eval()-based parser
-    # would execute this successfully, but the AST-based parser rejects it
-    # because only literal values are allowed in cycler arguments.
-    with pytest.raises(ValueError):
-        validate_cycler("cycler('color', [x for x in ['r', 'g', 'b']])")
 
 
 @pytest.mark.parametrize('weight, parsed_weight', [

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -277,6 +277,8 @@ def generate_validator_testcases(valid):
                       cycler('markeredgewidth', [2, 5])),
                      ("2 * cycler('color', 'rgb')", 2 * cycler('color', 'rgb')),
                      ("2 * cycler('color', 'r' + 'gb')", 2 * cycler('color', 'rgb')),
+                     ("cycler(c='r' + 'gb', lw=[1, 2, 3])",
+                      cycler('color', 'rgb') + cycler('linewidth', [1, 2, 3])),
                      ("cycler('color', 'rgb') * 2", cycler('color', 'rgb') * 2),
                      ("concat(cycler('color', 'rgb'), cycler('color', 'cmk'))",
                       cycler('color', list('rgbcmk'))),

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -276,13 +276,9 @@ def generate_validator_testcases(valid):
                      (cycler(mew=[2, 5]),
                       cycler('markeredgewidth', [2, 5])),
                      ),
-         # This is *so* incredibly important: validate_cycler() eval's
-         # an arbitrary string! I think I have it locked down enough,
-         # and that is what this is testing.
-         # TODO: Note that these tests are actually insufficient, as it may
-         # be that they raised errors, but still did an action prior to
-         # raising the exception. We should devise some additional tests
-         # for that...
+         # validate_cycler() parses an arbitrary string using a safe
+         # AST-based parser (no eval). These tests verify that only valid
+         # cycler expressions are accepted.
          'fail': ((4, ValueError),  # Gotta be a string or Cycler object
                   ('cycler("bleh, [])', ValueError),  # syntax error
                   ('Cycler("linewidth", [1, 2, 3])',
@@ -462,6 +458,14 @@ def test_validate_cycler_bad_color_string():
     msg = "'foo' is neither a color sequence name nor can it be interpreted as a list"
     with pytest.raises(ValueError, match=msg):
         validate_cycler("cycler('color', 'foo')")
+
+
+def test_validate_cycler_no_code_execution():
+    # List comprehensions are arbitrary code. The old eval()-based parser
+    # would execute this successfully, but the AST-based parser rejects it
+    # because only literal values are allowed in cycler arguments.
+    with pytest.raises(ValueError):
+        validate_cycler("cycler('color', [x for x in ['r', 'g', 'b']])")
 
 
 @pytest.mark.parametrize('weight, parsed_weight', [

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -276,6 +276,7 @@ def generate_validator_testcases(valid):
                      (cycler(mew=[2, 5]),
                       cycler('markeredgewidth', [2, 5])),
                      ("2 * cycler('color', 'rgb')", 2 * cycler('color', 'rgb')),
+                     ("2 * cycler('color', 'r' + 'gb')", 2 * cycler('color', 'rgb')),
                      ("cycler('color', 'rgb') * 2", cycler('color', 'rgb') * 2),
                      ("concat(cycler('color', 'rgb'), cycler('color', 'cmk'))",
                       cycler('color', list('rgbcmk'))),
@@ -287,6 +288,8 @@ def generate_validator_testcases(valid):
          # cycler expressions are accepted.
          'fail': ((4, ValueError),  # Gotta be a string or Cycler object
                   ('cycler("bleh, [])', ValueError),  # syntax error
+                  ("cycler('color', 'rgb') * * cycler('color', 'rgb')",  # syntax error
+                  ValueError),
                   ('Cycler("linewidth", [1, 2, 3])',
                    ValueError),  # only 'cycler()' function is allowed
                   # do not allow dunder in string literals

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -275,6 +275,12 @@ def generate_validator_testcases(valid):
                       cycler('linestyle', ['-', '--'])),
                      (cycler(mew=[2, 5]),
                       cycler('markeredgewidth', [2, 5])),
+                     ("2 * cycler('color', 'rgb')", 2 * cycler('color', 'rgb')),
+                     ("cycler('color', 'rgb') * 2", cycler('color', 'rgb') * 2),
+                     ("concat(cycler('color', 'rgb'), cycler('color', 'cmk'))",
+                      cycler('color', list('rgbcmk'))),
+                     ("cycler('color', 'rgbcmk')[:3]", cycler('color', list('rgb'))),
+                     ("cycler('color', 'rgb')[::-1]", cycler('color', list('bgr'))),
                      ),
          # validate_cycler() parses an arbitrary string using a safe
          # AST-based parser (no eval). These tests verify that only valid


### PR DESCRIPTION
## PR summary
`validate_cycler()` uses `eval()` to parse `axes.prop_cycle` rcParam strings. Combined with automatic matplotlibrc loading from the current working directory, this allows arbitrary code execution on `import matplotlib` via a malicious config file in a local directory. This poses a security risk.

## AI Disclosure
Claude was used to run the audit. Code manually reviewed

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
