### PR TITLE
SEC: Blacklist tex and pgf preambles in style files

### DIFF
--- a/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
+++ b/lib/matplotlib/mpl-data/stylelib/classic.mplstyle
@@ -111,21 +111,6 @@ text.usetex         : False  # use latex for all text handling. The following fo
                              # If another font is desired which can loaded using the
                              # LaTeX \usepackage command, please inquire at the
                              # matplotlib mailing list
-text.latex.preamble :  # IMPROPER USE OF THIS FEATURE WILL LEAD TO LATEX FAILURES
-                       # AND IS THEREFORE UNSUPPORTED. PLEASE DO NOT ASK FOR HELP
-                       # IF THIS FEATURE DOES NOT DO WHAT YOU EXPECT IT TO.
-                       # text.latex.preamble is a single line of LaTeX code that
-                       # will be passed on to the LaTeX system. It may contain
-                       # any code that is valid for the LaTeX "preamble", i.e.
-                       # between the "\documentclass" and "\begin{document}"
-                       # statements.
-                       # Note that it has to be put on a single line, which may
-                       # become quite long.
-                       # The following packages are always loaded with usetex, so
-                       # beware of package collisions:
-                       #   color, fix-cm, geometry, graphicx, textcomp.
-                       # Adobe Postscript (PSSNFS) font packages may also be
-                       # loaded, depending on your font settings.
 
 text.hinting : auto   # May be one of the following:
                       #   'none': Perform no hinting
@@ -452,7 +437,6 @@ pdf.use14corefonts : False
 # pgf backend params
 pgf.texsystem       : xelatex
 pgf.rcfonts         : True
-pgf.preamble        :
 
 # svg backend params
 svg.image_inline : True       # write raster image data directly into the svg file

--- a/lib/matplotlib/style/__init__.py
+++ b/lib/matplotlib/style/__init__.py
@@ -37,7 +37,10 @@ _STYLE_BLACKLIST = {
     'webagg.port_retries', 'webagg.open_in_browser', 'backend_fallback',
     'toolbar', 'timezone', 'figure.max_open_warning',
     'figure.raise_window', 'savefig.directory', 'tk.window_focus',
-    'docstring.hardcopy', 'date.epoch'}
+    'docstring.hardcopy', 'date.epoch',
+    # Preamble params allow arbitrary LaTeX command injection.
+    'text.latex.preamble', 'pgf.preamble',
+}
 
 
 @_docstring.Substitution(


### PR DESCRIPTION
## PR summary
Style files can currently set `text.latex.preamble` and `pgf.preamble`, which are interpolated verbatim into LaTeX documents. A malicious style file could inject arbitrary LaTeX commands, including `\write18` for shell execution on TeX distributions with shell-escape enabled.

This adds both params to `_STYLE_BLACKLIST` so they are ignored when loading style files. Users can still set them via rcParams directly. Their entries in `classic.mplstyle` were empty, and removed. `test_up_to_date_blacklist` exercises the blacklist to ensure it's functional.

## AI Disclosure
Claude was used to run the audit. Code manually reviewed

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines