### PR TITLE
DOC: clarify parameters of FFMpegFileWriter

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -606,18 +606,28 @@ class FFMpegFileWriter(FFMpegBase, FileMovieWriter):
     """
     File-based ffmpeg writer.
 
-    Frames are written to temporary files on disk and then stitched together at the end.
+    Frames are written to temporary files on disk and then stitched
+    together at the end.
 
-    This effectively works as a slideshow input to ffmpeg with the fps passed as
-    ``-framerate``, so see also `their notes on frame rates`_ for further details.
-
-    .. _their notes on frame rates: https://trac.ffmpeg.org/wiki/Slideshow#Framerates
+    This effectively works as a slideshow input to ffmpeg with the fps
+    passed as ``-framerate``.
 
     Parameters
     ----------
-    *args, **kwargs
-        All arguments are forwarded to `FileMovieWriter`. See
-        `FileMovieWriter` for a list of all possible parameters.
+    fps : int, default: 5
+        Frames per second of the resulting video.
+
+    codec : str, optional
+        Video codec used by ffmpeg to encode the animation.
+
+    bitrate : int, optional
+        Bitrate used for encoding the video.
+
+    metadata : dict, optional
+        Metadata to include in the output video.
+
+    extra_args : list of str, optional
+        Additional arguments passed directly to ffmpeg.
     """
     supported_formats = ['png', 'jpeg', 'tiff', 'raw', 'rgba']
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?


Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
This PR improves the documentation of FFMpegFileWriter by expanding the parameter section of the docstring . The previous documentation only forwarde parameters to FileMovieWriter without describing them.
This change clarifies commonly used parameters such as fps, codec, bitrate, metadata, and extra_args to make the documentation easier to understand for users.

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
AI assistance was used to help understand the documentation structure and draft improved parameter descriptions. The final code and wording were reviewed and edited by the contributor.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
