### PR TITLE
Add troubleshooting note for editable install failures on Ubuntu 24.04

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -294,6 +294,12 @@ variable :envvar:`MESONPY_EDITABLE_VERBOSE` or by setting the ``editable-verbose
 config during installation ::
 
    python -m pip install --no-build-isolation --config-settings=editable-verbose=true --editable .
+.. note:
+   On some Linux systems (for example Ubuntu 24.04 LTS) using conda-forge
+   compilers, the editable install may fail due to LTO configuration issues.
+   If this occurs, installation can succeed by disabling LTO during the build:
+
+       python -m pip install --config-settings=setup-args="-Db_lto=false" --editable .
 
 For more information on installation and other configuration options, see the
 Meson Python :external+meson-python:ref:`editable installs guide <how-to-guides-editable-installs>`.

--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -294,7 +294,9 @@ variable :envvar:`MESONPY_EDITABLE_VERBOSE` or by setting the ``editable-verbose
 config during installation ::
 
    python -m pip install --no-build-isolation --config-settings=editable-verbose=true --editable .
-.. note:
+
+.. note::
+
    On some Linux systems (for example Ubuntu 24.04 LTS) using conda-forge
    compilers, the editable install may fail due to LTO configuration issues.
    If this occurs, installation can succeed by disabling LTO during the build:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
This PR adds a note for troubleshooting to the development setup documentation for
cases where the editable install may fail in a conda-based environment on
Ubuntu 24.04 LTS.

The note documents the discussion in #30961:

python -m pip install --config-settings=setup-args="-Db_lto=false" --editable .

This change is intended to help developers who encounter this setup issue
without modifying the build system itself.

Reference #30961

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
N/A

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ X ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
