### PR TITLE
MNT: Raise NotImplementedError for 3D semilog plots

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -31,6 +31,7 @@ via ``do_3d_projection()``, then project to 2D for rendering.
 """
 
 from collections import defaultdict
+from functools import partialmethod
 import itertools
 import math
 import textwrap
@@ -1195,6 +1196,17 @@ class Axes3D(Axes):
             For example, ``base=2`` can be passed when using a log scale.
         """
         self._set_axis_scale(self.zaxis, value, **kwargs)
+
+    def _raise_semilog_not_implemented(self, name, *args, **kwargs):
+        raise NotImplementedError(
+            f"Axes3D does not support {name}. Use ax.set_xscale/set_yscale/set_zscale "
+            "and ax.plot(...) instead."
+        )
+
+    semilogx = partialmethod(_raise_semilog_not_implemented, "semilogx")
+    semilogy = partialmethod(_raise_semilog_not_implemented, "semilogy")
+    semilogz = partialmethod(_raise_semilog_not_implemented, "semilogz")
+    loglog = partialmethod(_raise_semilog_not_implemented, "loglog")
 
     get_zticks = _axis_method_wrapper("zaxis", "get_ticklocs")
     set_zticks = _axis_method_wrapper("zaxis", "set_ticks")

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3169,6 +3169,15 @@ def test_scale3d_autoscale_with_log():
         assert lim[1] > 0, f"{name} upper limit should be positive"
 
 
+@pytest.mark.parametrize("method", ["semilogx", "semilogy", "semilogz", "loglog"])
+def test_semilog_loglog_not_implemented(method):
+    """semilogx/y/z and loglog should raise NotImplementedError on Axes3D."""
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    with pytest.raises(NotImplementedError, match="Axes3D does not support"):
+        getattr(ax, method)([1, 10, 100], [1, 2, 3])
+
+
 def test_scale3d_calc_coord():
     """_calc_coord should return data coordinates with correct pane values."""
     fig = plt.figure()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Closes https://github.com/matplotlib/matplotlib/issues/31256.

Ideally this goes in 3.11, since that's the first version to support 3D log axes and it'll be easier to not have to immediately deprecate this.

`semilogz` included here to match the pattern, even though it doesn't have a 2D override.

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
