### PR TITLE
DOC: Correct `byweekday` description in `WeekdayLocator`

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -1530,13 +1530,15 @@ class WeekdayLocator(RRuleLocator):
         """
         Parameters
         ----------
-        byweekday : int or list of int, default: all days
+        byweekday : int, list of int, constant from :mod:`dateutil.rrule`, or \
+            list of constants, default: 1 (Tuesday)
             Ticks will be placed on every weekday in *byweekday*. Default is
-            every day.
+            every Tuesday.
 
-            Elements of *byweekday* must be one of MO, TU, WE, TH, FR, SA,
-            SU, the constants from :mod:`dateutil.rrule`, which have been
-            imported into the :mod:`matplotlib.dates` namespace.
+            Elements of *byweekday* (if a sequence) must be either integers or
+            MO, TU, WE, TH, FR, SA, SU, the constants from
+            :mod:`dateutil.rrule`, which have been imported into the
+            :mod:`matplotlib.dates` namespace.
         interval : int, default: 1
             The interval between each iteration. For example, if
             ``interval=2``, mark every second occurrence.


### PR DESCRIPTION
## PR summary

The description of the default for `byweekday` in `WeekdayLocator` does not match the default in the signature.

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
