### PR TITLE
Fix marker fillstyle rotation when updating fillstyle in Line2D

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -547,7 +547,14 @@ class Line2D(Artist):
 
             For examples see :ref:`marker_fill_styles`.
         """
-        self.set_marker(MarkerStyle(self._marker.get_marker(), fs))
+
+        old_marker = self._marker
+
+        marker = MarkerStyle(old_marker.get_marker(), fillstyle=fs)
+
+        marker._user_transform = old_marker._user_transform
+
+        self._marker = marker
         self.stale = True
 
     def set_markevery(self, every):


### PR DESCRIPTION
Closes #31257

### Description

Calling `Line2D.set_fillstyle()` recreated the  `MarkerStyle` object without preserving the existing user transform. As a result, markers that had a rotation transform applied lost their rotation when the fillstyle was updated.

This patch recreates the `MarkerStyle` with the requested fillstyle while preserving the existing  `_user_transform`, ensuring that rotated markers retain their orientation.

### Testing
* Verified using the reproduction example from the issue.

