### PR TITLE
Adds `plot_skip_execution` config to temporarily disable plot_directive.

### DIFF
--- a/doc/release/next_whats_new/plot_skip_execution.rst
+++ b/doc/release/next_whats_new/plot_skip_execution.rst
@@ -1,0 +1,11 @@
+New config option for ``matplotlib.sphinxext.plot_directive``: ``plot_skip_execution``
+--------------------------------------------------------------------------------------
+
+This configuration option allows users to temporarily skip the execution of all
+plot directives, not running the code or generating the plots. It is intended to
+be used during development to speed up building documentation that contains many
+plot directives.
+
+It can be temporarily enabled from the command line by passing ``-D
+plot_skip_execution=1`` to ``sphinx-build``, e.g.,: ``make html O="-D
+plot_skip_execution=1"``.

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -166,7 +166,7 @@ plot_skip_execution
     If True, will not run any plot directives. Code, captions, etc. will all
     still be rendered, but no plots will be created.
 
-    .. versionadded:: 3.11
+    .. versionadded:: 3.12
 
 Notes on how it works
 ---------------------

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -162,6 +162,12 @@ plot_srcset
     The plot_srcset option is incompatible with *singlehtml* builds, and an
     error will be raised.
 
+plot_skip_execution
+    If True, will not run any plot directives. Code, captions, etc. will all
+    still be rendered, but no plots will be created.
+
+    .. versionadded:: 3.11
+
 Notes on how it works
 ---------------------
 
@@ -323,6 +329,7 @@ def setup(app):
     app.add_config_value('plot_working_directory', None, True)
     app.add_config_value('plot_template', None, True)
     app.add_config_value('plot_srcset', [], True)
+    app.add_config_value('plot_skip_execution', False, True)
     app.connect('doctree-read', mark_plot_labels)
     app.add_css_file('plot_directive.css')
     app.connect('build-finished', _copy_css_file)
@@ -925,16 +932,19 @@ def run(arguments, content, options, state_machine, state, lineno):
 
     # make figures
     try:
-        results = render_figures(code=code,
-                                 code_path=source_file_name,
-                                 output_dir=build_dir,
-                                 output_base=output_base,
-                                 context=keep_context,
-                                 function_name=function_name,
-                                 config=config,
-                                 context_reset=context_opt == 'reset',
-                                 close_figs=context_opt == 'close-figs',
-                                 code_includes=source_file_includes)
+        if config.plot_skip_execution:
+            results = [(code, [])]
+        else:
+            results = render_figures(code=code,
+                                     code_path=source_file_name,
+                                     output_dir=build_dir,
+                                     output_base=output_base,
+                                     context=keep_context,
+                                     function_name=function_name,
+                                     config=config,
+                                     context_reset=context_opt == 'reset',
+                                     close_figs=context_opt == 'close-figs',
+                                     code_includes=source_file_includes)
         errors = []
     except PlotError as err:
         reporter = state.memo.reporter

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -269,3 +269,51 @@ def test_srcset_version(tmp_path):
     st = ('srcset="../_images/nestedpage2-index-2.png, '
           '../_images/nestedpage2-index-2.2x.png 2.00x"')
     assert st in (html_dir / 'nestedpage2/index.html').read_text(encoding='utf-8')
+
+
+def test_plot_skip_execution(tmp_path):
+    # test that modifying plot_exclude_patterns in config leads to skipping files
+    shutil.copyfile(tinypages / 'conf.py', tmp_path / 'conf.py')
+    shutil.copytree(tinypages / '_static', tmp_path / '_static')
+    shutil.copyfile(tinypages / 'range4.py', tmp_path / 'range4.py')
+    shutil.copyfile(tinypages / 'range6.py', tmp_path / 'range6.py')
+
+    html_dir = tmp_path / '_build' / 'html'
+    img_dir = html_dir / '_images'
+    doctree_dir = tmp_path / 'doctrees'
+
+    (tmp_path / 'index.rst').write_text("""
+.. plot::
+
+    plt.plot(range(2))
+
+.. toctree::
+
+    script_func
+    script_nofunc
+""")
+    (tmp_path / 'script_func.rst').write_text("""
+##########
+Some plots
+##########
+
+.. plot:: range6.py range6
+
+.. plot:: range6.py range10
+""")
+    (tmp_path / 'script_nofunc.rst').write_text("""
+##########
+Some plots
+##########
+
+.. plot:: range4.py
+""")
+
+    # Build the pages with warnings turned into errors
+    build_sphinx_html(tmp_path, doctree_dir, html_dir,
+                      extra_args=["-D", "plot_skip_execution=1"])
+
+    assert not (img_dir / "index-1.png").exists()
+    assert not (img_dir / "range6_range6.png").exists()
+    assert not (img_dir / "range6_range10.png").exists()
+    assert not (img_dir / "range4.png").exists()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

I opened a discussion on [discourse](https://discourse.matplotlib.org/t/temporarily-disable-sphinxext-plot-directive/26123/4) asking whether it was possible to temporarily disable the plot_directive, and was told by @timhoffm that "There is currently no clean way of doing this. One could add a config value. It’s not important enough that I’d work on this myself, but I’d accept a PR for it." This is my attempt at that change.

Inspired by [myst-nb's `nb_execution_excludepatterns` config option](https://myst-nb.readthedocs.io/en/latest/computation/execute.html#exclude-notebooks-from-execution), this allows users to specify in their sphinx configuration a list of patterns to selectively avoid running some plot directives. The goal is to speed up build time when developing, especially when making changes to project documentation. It does this in a simple way, by checking `re.match` against the `output_base` for the created plots for all patterns in the list. If any match, we do not run the code, set `result = [(code, [])]`, and continue. Setting `result` in this way makes it so the appearance in the built docs is the same as if an error was encountered: code is displayed if so configured, no associated plot.

- I had originally wanted to check against `function_name` or something more specific, but it looks like that is often not visible to the sphinx extension, especially when building examples found in docstrings (which is my most common use case).
- I had considered using `re.fullmatch` against `output_base`, but it seems to me that the full output_base might be difficult for a user to predict. Using just `re.match` may be over-zealous, but given that this is intended to speed up builds during development (not during production), false positives seem more acceptable to me.
- I figure regex match is the best way to match patterns here. I think glob patterns (like in `nb_execution_excludepatterns`) are most common for filenames, and the use of `re.match` means that simple matches (e.g., just `"plot"`) will function as a substring check, while still allowing for more complicated logic.
- I named this `plot_exclude_patterns` (with the underscore) rather than `plot_excludepatterns` (which would match myst-nb's value) to be more consistent with the naming pattern of the other config values.
- Having this check where it is feels like it might be inefficient to me, but it's not clear how much of the other plot directive code can be skipped without causing other problems. Happy to move it somewhere else if it belongs in a different location!

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

No LLMs were used in this contribution.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
    - I think the only place to edit is the module-level docstring in `plot_directive.py`, from grepping for the other config values.

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
