### PR TITLE
Implement conditional autoscaling for Collections using Artist autoscale flag

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -29,6 +29,7 @@ import matplotlib.table as mtable
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
+import matplotlib.collections as mcollections
 
 _log = logging.getLogger(__name__)
 
@@ -1132,6 +1133,11 @@ class _AxesBase(martist.Artist):
         self.transScale.set(
             mtransforms.blended_transform_factory(
                 self.xaxis.get_transform(), self.yaxis.get_transform()))
+
+    def _update_collection_limits(self, collection):
+     offsets = collection.get_offsets()
+     if offsets is not None and len(offsets):
+        self.update_datalim(offsets)
 
     def get_position(self, original=False):
         """
@@ -2412,6 +2418,7 @@ class _AxesBase(martist.Artist):
                 self._request_autoscale_view()
 
         self.stale = True
+        collection._set_in_autoscale(autolim)
         return collection
 
     def add_image(self, image):
@@ -2626,6 +2633,8 @@ class _AxesBase(martist.Artist):
                     self._update_patch_limits(artist)
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
+                elif isinstance(artist, mcollections.Collection):
+                    self._update_collection_limits(artist)
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1133,10 +1133,30 @@ class _AxesBase(martist.Artist):
             mtransforms.blended_transform_factory(
                 self.xaxis.get_transform(), self.yaxis.get_transform()))
 
-    def _update_collection_limits(self, collection):
-        offsets = collection.get_offsets()
-        if offsets is not None and len(offsets):
-            self.update_datalim(offsets)
+    def _update_collection_limits(self, collection, autolim):
+        self._unstale_viewLim()
+
+        datalim = collection.get_datalim(self.transData)
+        points = datalim.get_points()
+
+        if not np.isinf(datalim.minpos).all():
+            points = np.concatenate([points, [datalim.minpos]])
+
+        x_is_data, y_is_data = (
+            collection.get_transform().contains_branch_separately(self.transData)
+       )
+        ox_is_data, oy_is_data = (
+             collection.get_offset_transform().contains_branch_separately(self.transData)
+       )
+
+        self.update_datalim(
+         points,
+         updatex=x_is_data or ox_is_data,
+         updatey=y_is_data or oy_is_data,
+       )
+
+        if autolim != "_datalim_only":
+            self._request_autoscale_view()
 
     def get_position(self, original=False):
         """
@@ -2398,35 +2418,12 @@ class _AxesBase(martist.Artist):
         if collection.get_clip_path() is None:
             collection.set_clip_path(self.patch)
 
+        collection._set_in_autoscale(autolim)
+
         if autolim:
-            # Make sure viewLim is not stale (mostly to match
-            # pre-lazy-autoscale behavior, which is not really better).
-            self._unstale_viewLim()
-            datalim = collection.get_datalim(self.transData)
-            points = datalim.get_points()
-            if not np.isinf(datalim.minpos).all():
-                # By definition, if minpos (minimum positive value) is set
-                # (i.e., non-inf), then min(points) <= minpos <= max(points),
-                # and minpos would be superfluous. However, we add minpos to
-                # the call so that self.dataLim will update its own minpos.
-                # This ensures that log scales see the correct minimum.
-                points = np.concatenate([points, [datalim.minpos]])
-            # only update the dataLim for x/y if the collection uses transData
-            # in this direction.
-            x_is_data, y_is_data = (collection.get_transform()
-                                    .contains_branch_separately(self.transData))
-            ox_is_data, oy_is_data = (collection.get_offset_transform()
-                                      .contains_branch_separately(self.transData))
-            self.update_datalim(
-                points,
-                updatex=x_is_data or ox_is_data,
-                updatey=y_is_data or oy_is_data,
-            )
-            if autolim != "_datalim_only":
-                self._request_autoscale_view()
+            self._update_collection_limits(collection, autolim)
 
         self.stale = True
-        collection._set_in_autoscale(autolim)
         return collection
 
     def add_image(self, image):
@@ -2656,7 +2653,7 @@ class _AxesBase(martist.Artist):
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
                 elif isinstance(artist, mcoll.Collection):
-                    self._update_collection_limits(artist)
+                    self._update_collection_limits(artist, autolim="_datalim_only")
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -29,7 +29,6 @@ import matplotlib.table as mtable
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
-import matplotlib.collections as mcollections
 
 _log = logging.getLogger(__name__)
 
@@ -1135,9 +1134,9 @@ class _AxesBase(martist.Artist):
                 self.xaxis.get_transform(), self.yaxis.get_transform()))
 
     def _update_collection_limits(self, collection):
-     offsets = collection.get_offsets()
-     if offsets is not None and len(offsets):
-        self.update_datalim(offsets)
+        offsets = collection.get_offsets()
+        if offsets is not None and len(offsets):
+            self.update_datalim(offsets)
 
     def get_position(self, original=False):
         """
@@ -2656,7 +2655,7 @@ class _AxesBase(martist.Artist):
                     self._update_patch_limits(artist)
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
-                elif isinstance(artist, mcollections.Collection):
+                elif isinstance(artist, mcoll.Collection):
                     self._update_collection_limits(artist)
 
     def update_datalim(self, xys, updatex=True, updatey=True):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1133,31 +1133,6 @@ class _AxesBase(martist.Artist):
             mtransforms.blended_transform_factory(
                 self.xaxis.get_transform(), self.yaxis.get_transform()))
 
-    def _update_collection_limits(self, collection, autolim):
-        self._unstale_viewLim()
-
-        datalim = collection.get_datalim(self.transData)
-        points = datalim.get_points()
-
-        if not np.isinf(datalim.minpos).all():
-            points = np.concatenate([points, [datalim.minpos]])
-
-        x_is_data, y_is_data = (
-            collection.get_transform().contains_branch_separately(self.transData)
-       )
-        ox_is_data, oy_is_data = (
-             collection.get_offset_transform().contains_branch_separately(self.transData)
-       )
-
-        self.update_datalim(
-         points,
-         updatex=x_is_data or ox_is_data,
-         updatey=y_is_data or oy_is_data,
-       )
-
-        if autolim != "_datalim_only":
-            self._request_autoscale_view()
-
     def get_position(self, original=False):
         """
         Return the position of the Axes within the figure as a `.Bbox`.
@@ -2425,6 +2400,44 @@ class _AxesBase(martist.Artist):
 
         self.stale = True
         return collection
+
+    def _update_collection_limits(self, collection, autolim):
+        """
+        Update Axes data limits using the data from a Collection.
+
+        This helper extracts the limit update logic previously embedded
+        in `Axes.add_collection`. It ensures that collections participating
+        in autoscaling correctly contribute their data limits to the Axes.
+
+        Parameters
+        ----------
+        collection : matplotlib.collections.Collection
+        The collection whose data limits should be incorporated into
+        the Axes data limits.
+        """
+        self._unstale_viewLim()
+
+        datalim = collection.get_datalim(self.transData)
+        points = datalim.get_points()
+
+        if not np.isinf(datalim.minpos).all():
+            points = np.concatenate([points, [datalim.minpos]])
+
+        x_is_data, y_is_data = (
+            collection.get_transform().contains_branch_separately(self.transData)
+       )
+        ox_is_data, oy_is_data = (
+             collection.get_offset_transform().contains_branch_separately(self.transData)
+       )
+
+        self.update_datalim(
+         points,
+         updatex=x_is_data or ox_is_data,
+         updatey=y_is_data or oy_is_data,
+       )
+
+        if autolim != "_datalim_only":
+            self._request_autoscale_view()
 
     def add_image(self, image):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2393,15 +2393,16 @@ class _AxesBase(martist.Artist):
         if collection.get_clip_path() is None:
             collection.set_clip_path(self.patch)
 
-        collection._set_in_autoscale(autolim)
-
         if autolim:
-            self._update_collection_limits(collection, autolim)
+            self._update_collection_limits(collection)
+
+        if autolim != "_datalim_only":
+            self._request_autoscale_view()
 
         self.stale = True
         return collection
 
-    def _update_collection_limits(self, collection, autolim):
+    def _update_collection_limits(self, collection):
         """
         Update Axes data limits using the data from a Collection.
 
@@ -2435,9 +2436,6 @@ class _AxesBase(martist.Artist):
          updatex=x_is_data or ox_is_data,
          updatey=y_is_data or oy_is_data,
        )
-
-        if autolim != "_datalim_only":
-            self._request_autoscale_view()
 
     def add_image(self, image):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2396,8 +2396,8 @@ class _AxesBase(martist.Artist):
         if autolim:
             self._update_collection_limits(collection)
 
-        if autolim != "_datalim_only":
-            self._request_autoscale_view()
+            if autolim != "_datalim_only":
+              self._request_autoscale_view()
 
         self.stale = True
         return collection

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2403,19 +2403,6 @@ class _AxesBase(martist.Artist):
         return collection
 
     def _update_collection_limits(self, collection):
-        """
-        Update Axes data limits using the data from a Collection.
-
-        This helper extracts the limit update logic previously embedded
-        in `Axes.add_collection`. It ensures that collections participating
-        in autoscaling correctly contribute their data limits to the Axes.
-
-        Parameters
-        ----------
-        collection : matplotlib.collections.Collection
-        The collection whose data limits should be incorporated into
-        the Axes data limits.
-        """
         self._unstale_viewLim()
 
         datalim = collection.get_datalim(self.transData)
@@ -2424,18 +2411,16 @@ class _AxesBase(martist.Artist):
         if not np.isinf(datalim.minpos).all():
             points = np.concatenate([points, [datalim.minpos]])
 
-        x_is_data, y_is_data = (
-            collection.get_transform().contains_branch_separately(self.transData)
-       )
-        ox_is_data, oy_is_data = (
-             collection.get_offset_transform().contains_branch_separately(self.transData)
-       )
+        transform = collection.get_transform()
+        offset_trf = collection.get_offset_transform()
 
-        self.update_datalim(
-         points,
-         updatex=x_is_data or ox_is_data,
-         updatey=y_is_data or oy_is_data,
-       )
+        x_is_data, y_is_data = transform.contains_branch_separately(self.transData)
+        ox_is_data, oy_is_data = offset_trf.contains_branch_separately(self.transData)
+
+        updatex = x_is_data or ox_is_data
+        updatey = y_is_data or oy_is_data
+
+        self.update_datalim(points, updatex=updatex, updatey=updatey)
 
     def add_image(self, image):
         """
@@ -2655,8 +2640,8 @@ class _AxesBase(martist.Artist):
 
         for artist in self._children:
             if not visible_only or artist.get_visible():
-                if not artist._get_in_autoscale():
-                    continue
+                if hasattr(artist, "get_in_autoscale") and not artist.get_in_autoscale():  # noqa: E501
+                   continue
                 if isinstance(artist, mlines.Line2D):
                     self._update_line_limits(artist)
                 elif isinstance(artist, mpatches.Patch):
@@ -2664,7 +2649,7 @@ class _AxesBase(martist.Artist):
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
                 elif isinstance(artist, mcoll.Collection):
-                    self._update_collection_limits(artist, autolim="_datalim_only")
+                    self._update_collection_limits(artist)
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10174,3 +10174,27 @@ def test_errorbar_uses_rcparams():
     assert_allclose([cap.get_markeredgewidth() for cap in caplines], 2.5)
     for barcol in barlinecols:
         assert_allclose(barcol.get_linewidths(), 1.75)
+
+
+def test_relim_updates_scatter_offsets():
+    import numpy as np
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots()
+
+    xs = np.linspace(0, 10, 100)
+    ys = np.sin(xs)
+    scatter = ax.scatter(xs, ys)
+
+    # Shift scatter upward
+    new_ys = np.sin(xs) + 5
+    scatter.set_offsets(np.column_stack((xs, new_ys)))
+
+    ax.relim()
+    ax.autoscale_view()
+
+    ymin, ymax = ax.get_ylim()
+
+    # New limits should reflect shifted data
+    assert ymin > 3
+    assert ymax > 5

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10192,9 +10192,6 @@ def test_errorbar_uses_rcparams():
 
 
 def test_relim_updates_scatter_offsets():
-    import numpy as np
-    import matplotlib.pyplot as plt
-
     fig, ax = plt.subplots()
 
     xs = np.linspace(0, 10, 100)


### PR DESCRIPTION
Fixes conditional autoscaling behavior for Collections by using the
Artist autoscale participation flag introduced in PR1.

Previously, the `autolim` parameter in `Axes.add_collection()` did not
fully control whether a Collection participates in autoscaling.

This PR connects the `autolim` argument with the Artist autoscale
participation mechanism, ensuring that Collections are included or
excluded from autoscaling depending on the provided parameter.

Changes
-------
- Use Artist autoscale participation flag when adding Collections
- Ensure `add_collection(..., autolim=True)` excludes the collection
  from autoscaling
- Add/update tests verifying autoscaling behavior

Related to discussion in PR #31128 .

Follow-up to maintainer suggestion by @timhoffm regarding conditional
autoscaling of Collections.