### PR TITLE
mplot3d: add set_offsets3d for 3D patch/path collections

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -419,7 +419,51 @@ def _paths_to_3d_segments_with_codes(paths, zs=0, zdir='z'):
 
 
 class Collection3D(Collection):
-    """A collection of 3D paths."""
+    """
+    A collection of 3D paths.
+
+    .. note:: Use `get_verts_and_codes3d` and `set_verts_and_codes3d` to
+              obtain and set collection geometry in data coordinates.
+              `get_paths` returns projected 2D paths.
+    """
+
+    def set_verts_and_codes3d(self, verts_codes, *, axlim_clip=None):
+        """
+        Set the collection geometry in 3D space.
+
+        Parameters
+        ----------
+        verts_codes : sequence of (verts, codes)
+            Sequence where *verts* is a (N, 3) array-like in data coordinates
+            and *codes* are the corresponding path codes.
+        axlim_clip : bool or None, default: None
+            Whether to hide paths with a vertex outside the axes view limits.
+            If *None*, preserve the current setting.
+        """
+        verts_codes_3d = []
+        for verts, codes in verts_codes:
+            verts = np.asanyarray(verts)
+            if verts.size == 0:
+                verts = np.empty((0, 3), dtype=float)
+            _api.check_shape((None, 3), verts=verts)
+            verts_codes_3d.append((verts, codes))
+        self._3dverts_codes = verts_codes_3d
+        if axlim_clip is None:
+            axlim_clip = getattr(self, "_axlim_clip", False)
+        self._axlim_clip = axlim_clip
+        self.stale = True
+
+    def get_verts_and_codes3d(self):
+        """
+        Get the collection geometry in 3D data coordinates.
+
+        Returns
+        -------
+        verts_codes : list of (verts, codes)
+            Sequence where *verts* is a (N, 3) array-like and *codes* are the
+            corresponding path codes.
+        """
+        return self._3dverts_codes
 
     def do_3d_projection(self):
         """Project the points according to renderer matrix."""
@@ -439,14 +483,14 @@ class Collection3D(Collection):
 def collection_2d_to_3d(col, zs=0, zdir='z', axlim_clip=False):
     """Convert a `.Collection` to a `.Collection3D` object."""
     zs = np.broadcast_to(zs, len(col.get_paths()))
-    col._3dverts_codes = [
+    verts_codes = [
         (np.column_stack(juggle_axes(
             *np.column_stack([p.vertices, np.broadcast_to(z, len(p.vertices))]).T,
             zdir)),
          p.codes)
         for p, z in zip(col.get_paths(), zs)]
     col.__class__ = cbook._make_class_factory(Collection3D, "{}3D")(type(col))
-    col._axlim_clip = axlim_clip
+    col.set_verts_and_codes3d(verts_codes, axlim_clip=axlim_clip)
 
 
 class Line3DCollection(LineCollection):
@@ -619,7 +663,7 @@ class Patch3D(Patch):
             axlim_clip=axlim_clip,
         )
 
-    def set_verts3d(self, verts, *, axlim_clip=False):
+    def set_verts3d(self, verts, *, axlim_clip=None):
         """
         Set the patch vertices in 3D space.
 
@@ -627,9 +671,12 @@ class Patch3D(Patch):
         ----------
         verts : (N, 3) array-like
             The patch vertices in data coordinates.
-        axlim_clip : bool, default: False
+        axlim_clip : bool or None, default: None
             Whether to hide patches with a vertex outside the axes view limits.
+            If *None*, preserve the current setting.
         """
+        if axlim_clip is None:
+            axlim_clip = getattr(self, "_axlim_clip", False)
         self._verts3d = np.asanyarray(verts)
         self._segment3d = self._verts3d
         self._axlim_clip = axlim_clip
@@ -722,7 +769,7 @@ class PathPatch3D(Patch3D):
             axlim_clip=axlim_clip,
         )
 
-    def set_verts_and_codes3d(self, verts, codes, *, axlim_clip=False):
+    def set_verts_and_codes3d(self, verts, codes, *, axlim_clip=None):
         """
         Set the path patch geometry in 3D space.
 
@@ -732,8 +779,9 @@ class PathPatch3D(Patch3D):
             The path vertices in data coordinates.
         codes : array-like or None
             The corresponding path codes.
-        axlim_clip : bool, default: False
+        axlim_clip : bool or None, default: None
             Whether to hide path patches with a point outside the axes view limits.
+            If *None*, preserve the current setting.
         """
         self.set_verts3d(verts, axlim_clip=axlim_clip)
         self._code3d = codes
@@ -955,7 +1003,7 @@ class Patch3DCollection(PatchCollection):
         if hasattr(self, "_offsets3d_data"):
             return self._offsets3d_data
         # Backward compatibility for instances that pre-date get_offsets3d.
-        return _backjuggle_axes(*self._offsets3d, self._zdir)
+        return _backjuggle_axes(*self._offsets3d, getattr(self, "_zdir", "z"))
 
     def do_3d_projection(self):
         if self._axlim_clip:
@@ -1161,7 +1209,7 @@ class Path3DCollection(PathCollection):
         if hasattr(self, "_offsets3d_data"):
             return self._offsets3d_data
         # Backward compatibility for instances that pre-date get_offsets3d.
-        return _backjuggle_axes(*self._offsets3d, self._zdir)
+        return _backjuggle_axes(*self._offsets3d, getattr(self, "_zdir", "z"))
 
     def set_sizes(self, sizes, dpi=72.0):
         super().set_sizes(sizes, dpi)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -696,6 +696,10 @@ def pathpatch_2d_to_3d(pathpatch, z=0, zdir='z'):
 class Patch3DCollection(PatchCollection):
     """
     A collection of 3D patches.
+
+    .. note:: Use `get_offsets3d` and `set_offsets3d` to obtain and set the
+              collection offsets in data coordinates. `~.Collection.get_offsets`
+              and `~.Collection.set_offsets` access the projected 2D offsets.
     """
 
     def __init__(
@@ -810,11 +814,34 @@ class Patch3DCollection(PatchCollection):
             Plane to plot patches orthogonal to.
             See `.get_dir_vector` for a description of the values.
         """
+        xs = np.asanyarray(xs)
+        ys = np.asanyarray(ys)
+        zs = np.asanyarray(np.atleast_1d(zs))
+        self._offsets3d_data = (xs, ys, zs)
         self._zdir = zdir
-        self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
+        self._offsets3d = juggle_axes(xs, ys, zs, zdir)
         self._z_markers_idx = slice(-1)
         self._vzs = None
         self.stale = True
+
+    def get_offsets3d(self):
+        """
+        Get the collection offsets in 3D data coordinates.
+
+        Returns
+        -------
+        xs, ys, zs : array-like
+            The x, y, and z coordinates of the collection offsets.
+        """
+        if hasattr(self, "_offsets3d_data"):
+            return self._offsets3d_data
+        # Backward compatibility for instances that pre-date get_offsets3d.
+        xs3d, ys3d, zs3d = self._offsets3d
+        if cbook._str_equal(self._zdir, 'x'):
+            return ys3d, zs3d, xs3d
+        if cbook._str_equal(self._zdir, 'y'):
+            return xs3d, zs3d, ys3d
+        return xs3d, ys3d, zs3d
 
     def do_3d_projection(self):
         if self._axlim_clip:
@@ -886,6 +913,10 @@ def _get_data_scale(X, Y, Z):
 class Path3DCollection(PathCollection):
     """
     A collection of 3D paths.
+
+    .. note:: Use `get_offsets3d` and `set_offsets3d` to obtain and set the
+              collection offsets in data coordinates. `~.Collection.get_offsets`
+              and `~.Collection.set_offsets` access the projected 2D offsets.
     """
 
     def __init__(
@@ -993,12 +1024,35 @@ class Path3DCollection(PathCollection):
             Plane to plot paths orthogonal to.
             See `.get_dir_vector` for a description of the values.
         """
+        xs = np.asanyarray(xs)
+        ys = np.asanyarray(ys)
+        zs = np.asanyarray(np.atleast_1d(zs))
+        self._offsets3d_data = (xs, ys, zs)
         self._zdir = zdir
-        self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
+        self._offsets3d = juggle_axes(xs, ys, zs, zdir)
         self._z_markers_idx = slice(-1)
         self._vzs = None
         self._offset_zordered = None
         self.stale = True
+
+    def get_offsets3d(self):
+        """
+        Get the collection offsets in 3D data coordinates.
+
+        Returns
+        -------
+        xs, ys, zs : array-like
+            The x, y, and z coordinates of the collection offsets.
+        """
+        if hasattr(self, "_offsets3d_data"):
+            return self._offsets3d_data
+        # Backward compatibility for instances that pre-date get_offsets3d.
+        xs3d, ys3d, zs3d = self._offsets3d
+        if cbook._str_equal(self._zdir, 'x'):
+            return ys3d, zs3d, xs3d
+        if cbook._str_equal(self._zdir, 'y'):
+            return xs3d, zs3d, ys3d
+        return xs3d, ys3d, zs3d
 
     def set_sizes(self, sizes, dpi=72.0):
         super().set_sizes(sizes, dpi)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -722,7 +722,7 @@ class PathPatch3D(Patch3D):
 
     .. note:: Use `get_verts_and_codes3d` and `set_verts_and_codes3d` to
               obtain and set the path patch geometry in data coordinates.
-              `get_path` returns the projected 2D path.
+              ``get_path`` returns the projected 2D path.
     """
 
     def __init__(self, path, *, zs=(), zdir='z', axlim_clip=False, **kwargs):
@@ -1392,7 +1392,7 @@ class Poly3DCollection(PolyCollection):
 
     .. note:: Use `get_verts3d`, `set_verts3d`, `get_verts_and_codes3d`,
               and `set_verts_and_codes3d` to obtain and set the collection
-              geometry in data coordinates. `get_paths` returns the projected
+              geometry in data coordinates. ``get_paths`` returns the projected
               2D paths. `set_verts` and `set_verts_and_codes` remain
               backward-compatible aliases for the 3D setters.
 

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -452,6 +452,11 @@ def collection_2d_to_3d(col, zs=0, zdir='z', axlim_clip=False):
 class Line3DCollection(LineCollection):
     """
     A collection of 3D lines.
+
+    .. note:: Use `get_segments3d` and `set_segments3d` to obtain and set the
+              collection segments in data coordinates. `~.LineCollection.get_segments`
+              returns the projected 2D segments. `set_segments` remains a
+              backward-compatible alias for `set_segments3d`.
     """
     def __init__(self, lines, axlim_clip=False, **kwargs):
         super().__init__(lines, **kwargs)
@@ -490,8 +495,31 @@ class Line3DCollection(LineCollection):
         """
         Set 3D segments.
         """
+        self.set_segments3d(segments)
+
+    def set_segments3d(self, segments):
+        """
+        Set the collection segments in 3D space.
+
+        Parameters
+        ----------
+        segments : sequence of (N, 3) array-like
+            The 3D line segments to draw.
+        """
         self._segments3d = segments
         super().set_segments([])
+        self.stale = True
+
+    def get_segments3d(self):
+        """
+        Get the collection segments in 3D data coordinates.
+
+        Returns
+        -------
+        segments : sequence of (N, 3) array-like
+            The 3D line segments.
+        """
+        return self._segments3d
 
     def do_3d_projection(self):
         """
@@ -543,6 +571,10 @@ def line_collection_2d_to_3d(col, zs=0, zdir='z', axlim_clip=False):
 class Patch3D(Patch):
     """
     3D patch object.
+
+    .. note:: Use `get_verts3d` and `set_verts3d` to obtain and set the
+              patch vertices in data coordinates. `get_path` returns the
+              projected 2D path.
     """
 
     def __init__(self, *args, zs=(), zdir='z', axlim_clip=False, **kwargs):
@@ -582,10 +614,39 @@ class Patch3D(Patch):
 
             .. versionadded:: 3.10
         """
-        zs = np.broadcast_to(zs, len(verts))
-        self._segment3d = [juggle_axes(x, y, z, zdir)
-                           for ((x, y), z) in zip(verts, zs)]
+        self.set_verts3d(
+            _planar_patch_to_3d(verts, zs=zs, zdir=zdir),
+            axlim_clip=axlim_clip,
+        )
+
+    def set_verts3d(self, verts, *, axlim_clip=False):
+        """
+        Set the patch vertices in 3D space.
+
+        Parameters
+        ----------
+        verts : (N, 3) array-like
+            The patch vertices in data coordinates.
+        axlim_clip : bool, default: False
+            Whether to hide patches with a vertex outside the axes view limits.
+        """
+        self._verts3d = np.asanyarray(verts)
+        self._segment3d = self._verts3d
         self._axlim_clip = axlim_clip
+        self.stale = True
+
+    def get_verts3d(self):
+        """
+        Get the patch vertices in 3D data coordinates.
+
+        Returns
+        -------
+        verts : (N, 3) array-like
+            The patch vertices in data coordinates.
+        """
+        if hasattr(self, "_verts3d"):
+            return self._verts3d
+        return np.asanyarray(self._segment3d)
 
     def get_path(self):
         # docstring inherited
@@ -611,6 +672,10 @@ class Patch3D(Patch):
 class PathPatch3D(Patch3D):
     """
     3D PathPatch object.
+
+    .. note:: Use `get_verts_and_codes3d` and `set_verts_and_codes3d` to
+              obtain and set the path patch geometry in data coordinates.
+              `get_path` returns the projected 2D path.
     """
 
     def __init__(self, path, *, zs=(), zdir='z', axlim_clip=False, **kwargs):
@@ -651,9 +716,52 @@ class PathPatch3D(Patch3D):
 
             .. versionadded:: 3.10
         """
-        Patch3D.set_3d_properties(self, path.vertices, zs=zs, zdir=zdir,
-                                  axlim_clip=axlim_clip)
-        self._code3d = path.codes
+        self.set_verts_and_codes3d(
+            _planar_patch_to_3d(path.vertices, zs=zs, zdir=zdir),
+            path.codes,
+            axlim_clip=axlim_clip,
+        )
+
+    def set_verts_and_codes3d(self, verts, codes, *, axlim_clip=False):
+        """
+        Set the path patch geometry in 3D space.
+
+        Parameters
+        ----------
+        verts : (N, 3) array-like
+            The path vertices in data coordinates.
+        codes : array-like or None
+            The corresponding path codes.
+        axlim_clip : bool, default: False
+            Whether to hide path patches with a point outside the axes view limits.
+        """
+        self.set_verts3d(verts, axlim_clip=axlim_clip)
+        self._code3d = codes
+        self.stale = True
+
+    def get_codes3d(self):
+        """
+        Get the path codes associated with the 3D vertices.
+
+        Returns
+        -------
+        codes : array-like or None
+            The path codes.
+        """
+        return self._code3d
+
+    def get_verts_and_codes3d(self):
+        """
+        Get the path patch geometry in 3D data coordinates.
+
+        Returns
+        -------
+        verts : (N, 3) array-like
+            The path vertices in data coordinates.
+        codes : array-like or None
+            The corresponding path codes.
+        """
+        return self.get_verts3d(), self.get_codes3d()
 
     def do_3d_projection(self):
         s = self._segment3d
@@ -674,6 +782,17 @@ def _get_patch_verts(patch):
     path = patch.get_path()
     polygons = path.to_polygons(trans)
     return polygons[0] if len(polygons) else np.array([])
+
+
+def _planar_patch_to_3d(verts, zs=0, zdir='z'):
+    """Return planar patch vertices as explicit 3D data coordinates."""
+    verts = np.asanyarray(verts)
+    if verts.size == 0:
+        return np.empty((0, 3), dtype=float)
+    verts = np.atleast_2d(verts)
+    zs = np.broadcast_to(zs, len(verts))
+    xs, ys, zs = juggle_axes(verts[:, 0], verts[:, 1], zs, zdir)
+    return np.column_stack([xs, ys, zs])
 
 
 def patch_2d_to_3d(patch, z=0, zdir='z', axlim_clip=False):
@@ -810,7 +929,7 @@ class Patch3DCollection(PatchCollection):
         ----------
         xs, ys, zs : array-like
             The x, y, and z coordinates of the collection offsets.
-        zdir : {'x', 'y', 'z'}, default: 'z'
+        zdir : {'x', 'y', 'z', '-x', '-y', '-z'}, default: 'z'
             Plane to plot patches orthogonal to.
             See `.get_dir_vector` for a description of the values.
         """
@@ -836,12 +955,7 @@ class Patch3DCollection(PatchCollection):
         if hasattr(self, "_offsets3d_data"):
             return self._offsets3d_data
         # Backward compatibility for instances that pre-date get_offsets3d.
-        xs3d, ys3d, zs3d = self._offsets3d
-        if cbook._str_equal(self._zdir, 'x'):
-            return ys3d, zs3d, xs3d
-        if cbook._str_equal(self._zdir, 'y'):
-            return xs3d, zs3d, ys3d
-        return xs3d, ys3d, zs3d
+        return _backjuggle_axes(*self._offsets3d, self._zdir)
 
     def do_3d_projection(self):
         if self._axlim_clip:
@@ -1020,7 +1134,7 @@ class Path3DCollection(PathCollection):
         ----------
         xs, ys, zs : array-like
             The x, y, and z coordinates of the collection offsets.
-        zdir : {'x', 'y', 'z'}, default: 'z'
+        zdir : {'x', 'y', 'z', '-x', '-y', '-z'}, default: 'z'
             Plane to plot paths orthogonal to.
             See `.get_dir_vector` for a description of the values.
         """
@@ -1047,12 +1161,7 @@ class Path3DCollection(PathCollection):
         if hasattr(self, "_offsets3d_data"):
             return self._offsets3d_data
         # Backward compatibility for instances that pre-date get_offsets3d.
-        xs3d, ys3d, zs3d = self._offsets3d
-        if cbook._str_equal(self._zdir, 'x'):
-            return ys3d, zs3d, xs3d
-        if cbook._str_equal(self._zdir, 'y'):
-            return xs3d, zs3d, ys3d
-        return xs3d, ys3d, zs3d
+        return _backjuggle_axes(*self._offsets3d, self._zdir)
 
     def set_sizes(self, sizes, dpi=72.0):
         super().set_sizes(sizes, dpi)
@@ -1233,6 +1342,12 @@ class Poly3DCollection(PolyCollection):
     """
     A collection of 3D polygons.
 
+    .. note:: Use `get_verts3d`, `set_verts3d`, `get_verts_and_codes3d`,
+              and `set_verts_and_codes3d` to obtain and set the collection
+              geometry in data coordinates. `get_paths` returns the projected
+              2D paths. `set_verts` and `set_verts_and_codes` remain
+              backward-compatible aliases for the 3D setters.
+
     .. note::
         **Filling of 3D polygons**
 
@@ -1383,18 +1498,85 @@ class Poly3DCollection(PolyCollection):
             Whether the polygon should be closed by adding a CLOSEPOLY
             connection at the end.
         """
+        self.set_verts3d(verts, closed=closed)
+
+    def set_verts3d(self, verts, closed=True):
+        """
+        Set the collection vertices in 3D space.
+
+        Parameters
+        ----------
+        verts : list of (N, 3) array-like
+            The sequence of polygons in data coordinates.
+        closed : bool, default: True
+            Whether the polygon should be closed by adding a CLOSEPOLY
+            connection at the end.
+        """
         self._get_vector(verts)
-        # 2D verts will be updated at draw time
+        self._verts3d_data = verts
+        self._codes3d = None
+        self._codes3d_data = None
+        # 2D verts will be updated at draw time.
         super().set_verts([], False)
         self._closed = closed
+        self.stale = True
+
+    def get_verts3d(self):
+        """
+        Get the collection vertices in 3D data coordinates.
+
+        Returns
+        -------
+        verts : list of (N, 3) array-like or ndarray
+            The collection vertices in data coordinates.
+        """
+        if hasattr(self, "_verts3d_data"):
+            return self._verts3d_data
+        if np.isscalar(self._invalid_vertices) and not self._invalid_vertices:
+            return self._faces
+        invalid_vertices = np.broadcast_to(
+            self._invalid_vertices, self._faces.shape[:-1]
+        )
+        return [face[~mask] for face, mask in zip(self._faces, invalid_vertices)]
 
     def set_verts_and_codes(self, verts, codes):
         """Set 3D vertices with path codes."""
-        # set vertices with closed=False to prevent PolyCollection from
-        # setting path codes
-        self.set_verts(verts, closed=False)
-        # and set our own codes instead.
+        self.set_verts_and_codes3d(verts, codes)
+
+    def set_verts_and_codes3d(self, verts, codes):
+        """Set the collection vertices and path codes in 3D space."""
+        # Set vertices with closed=False to prevent PolyCollection from
+        # setting path codes.
+        self.set_verts3d(verts, closed=False)
+        # And set our own codes instead.
         self._codes3d = codes
+        self._codes3d_data = codes
+
+    def get_codes3d(self):
+        """
+        Get the path codes associated with the 3D vertices.
+
+        Returns
+        -------
+        codes : array-like or None
+            The path codes.
+        """
+        if hasattr(self, "_codes3d_data"):
+            return self._codes3d_data
+        return self._codes3d
+
+    def get_verts_and_codes3d(self):
+        """
+        Get the collection geometry in 3D data coordinates.
+
+        Returns
+        -------
+        verts : list of (N, 3) array-like or ndarray
+            The collection vertices in data coordinates.
+        codes : array-like or None
+            The corresponding path codes.
+        """
+        return self.get_verts3d(), self.get_codes3d()
 
     def set_3d_properties(self, axlim_clip=False):
         # Force the collection to initialize the face and edgecolors
@@ -1591,6 +1773,17 @@ def juggle_axes(xs, ys, zs, zdir):
         return rotate_axes(xs, ys, zs, zdir)
     else:
         return xs, ys, zs
+
+
+def _backjuggle_axes(xs, ys, zs, zdir):
+    """Invert `juggle_axes` for data stored in 3D coordinates."""
+    if cbook._str_equal(zdir, 'x') or cbook._str_equal(zdir, '-x'):
+        return ys, zs, xs
+    if cbook._str_equal(zdir, 'y'):
+        return xs, zs, ys
+    if cbook._str_equal(zdir, '-y'):
+        return zs, xs, ys
+    return xs, ys, zs
 
 
 def rotate_axes(xs, ys, zs, zdir):

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -794,10 +794,26 @@ class Patch3DCollection(PatchCollection):
         else:
             xs = []
             ys = []
+        self.set_offsets3d(xs, ys, zs, zdir=zdir)
+        self._axlim_clip = axlim_clip
+        self.stale = True
+
+    def set_offsets3d(self, xs, ys, zs, *, zdir='z'):
+        """
+        Set the collection offsets in 3D space.
+
+        Parameters
+        ----------
+        xs, ys, zs : array-like
+            The x, y, and z coordinates of the collection offsets.
+        zdir : {'x', 'y', 'z'}, default: 'z'
+            Plane to plot patches orthogonal to.
+            See `.get_dir_vector` for a description of the values.
+        """
+        self._zdir = zdir
         self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
         self._z_markers_idx = slice(-1)
         self._vzs = None
-        self._axlim_clip = axlim_clip
         self.stale = True
 
     def do_3d_projection(self):
@@ -948,8 +964,7 @@ class Path3DCollection(PathCollection):
         else:
             xs = []
             ys = []
-        self._zdir = zdir
-        self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
+        self.set_offsets3d(xs, ys, zs, zdir=zdir)
         # In the base draw methods we access the attributes directly which
         # means we cannot resolve the shuffling in the getter methods like
         # we do for the edge and face colors.
@@ -962,15 +977,27 @@ class Path3DCollection(PathCollection):
         # Grab the current sizes and linewidths to preserve them.
         self._sizes3d = self._sizes
         self._linewidths3d = np.array(self._linewidths)
-        xs, ys, zs = self._offsets3d
-
-        # Sort the points based on z coordinates
-        # Performance optimization: Create a sorted index array and reorder
-        # points and point properties according to the index array
-        self._z_markers_idx = slice(-1)
-        self._vzs = None
 
         self._axlim_clip = axlim_clip
+        self.stale = True
+
+    def set_offsets3d(self, xs, ys, zs, *, zdir='z'):
+        """
+        Set the collection offsets in 3D space.
+
+        Parameters
+        ----------
+        xs, ys, zs : array-like
+            The x, y, and z coordinates of the collection offsets.
+        zdir : {'x', 'y', 'z'}, default: 'z'
+            Plane to plot paths orthogonal to.
+            See `.get_dir_vector` for a description of the values.
+        """
+        self._zdir = zdir
+        self._offsets3d = juggle_axes(xs, ys, np.atleast_1d(zs), zdir)
+        self._z_markers_idx = slice(-1)
+        self._vzs = None
+        self._offset_zordered = None
         self.stale = True
 
     def set_sizes(self, sizes, dpi=72.0):

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -500,6 +500,24 @@ def test_scatter3d_offsets3d_modification(fig_ref, fig_test):
 
 
 @check_figures_equal()
+def test_scatter3d_set_array_modification(fig_ref, fig_test):
+    # Changing Path3DCollection scalar-mappable array post-creation should work.
+    x = np.linspace(0.1, 0.9, 10)
+    y = np.linspace(0.9, 0.1, 10)
+    z = np.linspace(0.1, 0.9, 10)
+    colors = np.arange(10)
+
+    ax_test = fig_test.add_subplot(projection='3d')
+    c_test = ax_test.scatter(x, y, z, c=colors, cmap='viridis',
+                             marker='o', s=75, depthshade=False)
+    c_test.set_array(colors[::-1])
+
+    ax_ref = fig_ref.add_subplot(projection='3d')
+    ax_ref.scatter(x, y, z, c=colors[::-1], cmap='viridis',
+                   marker='o', s=75, depthshade=False)
+
+
+@check_figures_equal()
 def test_scatter3d_sorting(fig_ref, fig_test):
     """Test that marker properties are correctly sorted."""
 
@@ -1041,6 +1059,43 @@ def test_patch_collection_offsets3d_modification(fig_test, fig_ref):
     )
     ax_ref = fig_ref.add_subplot(projection='3d')
     ax_ref.add_collection3d(c_ref)
+    ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
+
+
+@check_figures_equal()
+def test_patch_collection_set_array_modification(fig_test, fig_ref):
+    # Changing Patch3DCollection scalar-mappable array post-creation should work.
+    offsets = np.column_stack([
+        np.linspace(0.2, 0.8, 5),
+        np.linspace(0.8, 0.2, 5),
+    ])
+    zs = np.linspace(0.2, 0.8, 5)
+    colors = np.arange(5)
+
+    c_test = art3d.Patch3DCollection(
+        [Circle((0, 0), 0.04)],
+        offsets=offsets,
+        zs=zs,
+        cmap='viridis',
+        depthshade=False,
+    )
+    ax_test = fig_test.add_subplot(projection='3d')
+    ax_test.add_collection3d(c_test)
+    c_test.set_array(colors)
+    fig_test.canvas.draw()
+    c_test.set_array(colors[::-1])
+    ax_test.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
+
+    c_ref = art3d.Patch3DCollection(
+        [Circle((0, 0), 0.04)],
+        offsets=offsets,
+        zs=zs,
+        cmap='viridis',
+        depthshade=False,
+    )
+    ax_ref = fig_ref.add_subplot(projection='3d')
+    ax_ref.add_collection3d(c_ref)
+    c_ref.set_array(colors[::-1])
     ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
 
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -567,7 +567,11 @@ def test_collection3d_set_get_verts_and_codes3d():
     assert len(verts_codes) == len(cset.get_paths())
 
     delta = np.array([0.0, 0.0, 0.1])
-    verts_codes_new = [(verts + delta, codes) for verts, codes in verts_codes]
+    verts_codes_new = []
+    for i, (verts, codes) in enumerate(verts_codes):
+        # Cover both branches in code-handling assertions below.
+        new_codes = None if (i == 0 and len(verts_codes) > 1) else codes
+        verts_codes_new.append((verts + delta, new_codes))
     cset.set_verts_and_codes3d(verts_codes_new)
 
     actual_verts_codes = cset.get_verts_and_codes3d()
@@ -596,6 +600,19 @@ def test_collection3d_set_verts_and_codes3d_empty_preserves_axlim_clip():
     verts_codes = cset.get_verts_and_codes3d()
     assert verts_codes[0][0].shape == (0, 3)
     assert verts_codes[0][1] is None
+
+
+def test_patch3d_get_verts3d_legacy_fallback():
+    circle = Circle((0, 0), radius=0.1)
+    art3d.patch_2d_to_3d(circle, z=0.2, zdir='z')
+    verts = circle.get_verts3d()
+    del circle._verts3d
+    np.testing.assert_allclose(circle.get_verts3d(), verts)
+
+
+def test_planar_patch_to_3d_empty():
+    verts = art3d._planar_patch_to_3d(np.empty((0, 2)), zs=0.3, zdir='y')
+    assert verts.shape == (0, 3)
 
 
 @check_figures_equal()
@@ -1278,14 +1295,26 @@ def test_poly3dcollection_set_get_verts_and_codes3d():
 
 
 def test_poly3dcollection_get_verts3d_legacy_fallback():
-    verts = [
-        np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]], float),
-        np.array([[1, 0, 0], [1, 1, 0], [1, 0, 1]], float),
-    ]
+    verts = np.array([
+        [[0, 0, 0], [0, 1, 0], [0, 0, 1]],
+        [[1, 0, 0], [1, 1, 0], [1, 0, 1]],
+    ], dtype=float)
     c = art3d.Poly3DCollection(verts)
     del c._verts3d_data
     actual = c.get_verts3d()
     np.testing.assert_allclose(actual, verts)
+
+
+def test_poly3dcollection_get_verts3d_legacy_fallback_ragged():
+    verts = [
+        np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]], dtype=float),
+        np.array([[1, 0, 0], [1, 1, 0], [1, 0, 1], [1, 1, 1]], dtype=float),
+    ]
+    c = art3d.Poly3DCollection(verts)
+    del c._verts3d_data
+    actual = c.get_verts3d()
+    for actual_face, expected_face in zip(actual, verts):
+        np.testing.assert_allclose(actual_face, expected_face)
 
 
 def test_poly3dcollection_get_codes3d_legacy_fallback():

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -538,6 +538,33 @@ def test_add_collection3d_patch_collection_offsets3d_roundtrip(zdir):
     np.testing.assert_allclose(actual_zs, zs)
 
 
+def test_collection3d_set_get_verts_and_codes3d():
+    x = y = np.linspace(-1, 1, 5)
+    X, Y = np.meshgrid(x, y)
+    Z = X**2 + Y**2
+
+    _, ax = plt.subplots()
+    cset = ax.contour(X, Y, Z, levels=[0.5, 1.0])
+    art3d.collection_2d_to_3d(cset, zs=cset.levels, zdir='z')
+
+    verts_codes = cset.get_verts_and_codes3d()
+    assert len(verts_codes) == len(cset.get_paths())
+
+    delta = np.array([0.0, 0.0, 0.1])
+    verts_codes_new = [(verts + delta, codes) for verts, codes in verts_codes]
+    cset.set_verts_and_codes3d(verts_codes_new)
+
+    actual_verts_codes = cset.get_verts_and_codes3d()
+    for (actual_verts, actual_codes), (expected_verts, expected_codes) in zip(
+        actual_verts_codes, verts_codes_new
+    ):
+        np.testing.assert_allclose(actual_verts, expected_verts)
+        if expected_codes is None:
+            assert actual_codes is None
+        else:
+            np.testing.assert_array_equal(actual_codes, expected_codes)
+
+
 @check_figures_equal()
 def test_scatter3d_sorting(fig_ref, fig_test):
     """Test that marker properties are correctly sorted."""
@@ -1030,6 +1057,14 @@ def test_patch3d_set_get_verts3d():
     np.testing.assert_allclose(circle.get_verts3d(), verts_new)
 
 
+def test_patch3d_set_verts3d_preserves_axlim_clip():
+    circle = Circle((0, 0), radius=0.1)
+    art3d.patch_2d_to_3d(circle, z=0.2, zdir='z', axlim_clip=True)
+    assert circle._axlim_clip
+    circle.set_verts3d(circle.get_verts3d())
+    assert circle._axlim_clip
+
+
 @check_figures_equal()
 def test_patch_collection_modification(fig_test, fig_ref):
     # Test that modifying Patch3DCollection properties after creation works.
@@ -1118,6 +1153,24 @@ def test_patch_collection_offsets3d_roundtrip(zdir):
     np.testing.assert_allclose(actual_zs, zs)
 
 
+def test_patch_collection_offsets3d_roundtrip_legacy_without_zdir():
+    offsets = np.column_stack([
+        np.linspace(0.2, 0.8, 4),
+        np.linspace(0.8, 0.2, 4),
+    ])
+    c = art3d.Patch3DCollection([Circle((0, 0), 0.04)], offsets=offsets)
+    xs = np.array([0.1, 0.4, 0.6, 0.9])
+    ys = np.array([0.9, 0.6, 0.4, 0.1])
+    zs = np.array([0.2, 0.3, 0.7, 0.8])
+    c.set_offsets3d(xs, ys, zs, zdir='z')
+    del c._offsets3d_data
+    del c._zdir
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
+
+
 def test_poly3dcollection_verts_validation():
     poly = [[0, 0, 1], [0, 1, 1], [0, 1, 0], [0, 0, 0]]
     with pytest.raises(ValueError, match=r'list of \(N, 3\) array-like'):
@@ -1180,7 +1233,9 @@ def test_poly3dcollection_set_get_verts3d():
 
 def test_poly3dcollection_set_get_verts_and_codes3d():
     path = Path.unit_rectangle()
-    verts = [np.column_stack([path.vertices, np.linspace(0.1, 0.9, len(path.vertices))])]
+    verts = [
+        np.column_stack([path.vertices, np.linspace(0.1, 0.9, len(path.vertices))])
+    ]
     codes = [path.codes]
     c = art3d.Poly3DCollection(verts)
     c.set_verts_and_codes3d(verts, codes)
@@ -2608,6 +2663,16 @@ def test_pathpatch3d_set_get_verts_and_codes3d():
     actual_verts, actual_codes = pp3d.get_verts_and_codes3d()
     np.testing.assert_allclose(actual_verts, verts_new)
     np.testing.assert_array_equal(actual_codes, path.codes)
+
+
+def test_pathpatch3d_set_verts_and_codes3d_preserves_axlim_clip():
+    path = Path.unit_rectangle()
+    pp3d = art3d.PathPatch3D(path, zs=(0, 0.5, 0.7, 1, 0), zdir='y',
+                             axlim_clip=True)
+    assert pp3d._axlim_clip
+    verts, codes = pp3d.get_verts_and_codes3d()
+    pp3d.set_verts_and_codes3d(verts, codes)
+    assert pp3d._axlim_clip
 
 
 @image_comparison(baseline_images=['scatter_spiral.png'],

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -476,6 +476,30 @@ def test_scatter3d_modification(fig_ref, fig_test):
 
 
 @check_figures_equal()
+def test_scatter3d_offsets3d_modification(fig_ref, fig_test):
+    # Changing Path3DCollection offsets in 3D post-creation should work.
+    x = np.linspace(0.1, 0.9, 10)
+    y = np.linspace(0.9, 0.1, 10)
+    z = np.linspace(0.1, 0.9, 10)
+    colors = np.arange(10)
+
+    x_new = x[::-1]
+    y_new = y[::-1]
+    z_new = np.roll(z, 1)
+
+    ax_test = fig_test.add_subplot(projection='3d')
+    c_test = ax_test.scatter(
+        x, y, z, c=colors, cmap='viridis', marker='o', s=75, linewidths=2,
+        depthshade=False)
+    c_test.set_offsets3d(x_new, y_new, z_new)
+
+    ax_ref = fig_ref.add_subplot(projection='3d')
+    ax_ref.scatter(
+        x_new, y_new, z_new, c=colors, cmap='viridis', marker='o', s=75,
+        linewidths=2, depthshade=False)
+
+
+@check_figures_equal()
 def test_scatter3d_sorting(fig_ref, fig_test):
     """Test that marker properties are correctly sorted."""
 
@@ -981,6 +1005,43 @@ def test_patch_collection_modification(fig_test, fig_ref):
 
     ax_ref = fig_ref.add_subplot(projection='3d')
     ax_ref.add_collection3d(c)
+
+
+@check_figures_equal()
+def test_patch_collection_offsets3d_modification(fig_test, fig_ref):
+    # Changing Patch3DCollection offsets in 3D post-creation should work.
+    offsets = np.column_stack([
+        np.linspace(0.2, 0.8, 5),
+        np.linspace(0.8, 0.2, 5),
+    ])
+    offsets_new = offsets[::-1]
+    zs_new = np.roll(np.linspace(0.2, 0.8, 5), 1)
+
+    c_test = art3d.Patch3DCollection(
+        [Circle((0, 0), 0.04)],
+        offsets=offsets,
+        facecolor='C1',
+        edgecolor='C2',
+        linewidths=2,
+        depthshade=False,
+    )
+    ax_test = fig_test.add_subplot(projection='3d')
+    ax_test.add_collection3d(c_test)
+    c_test.set_offsets3d(offsets_new[:, 0], offsets_new[:, 1], zs_new)
+    ax_test.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
+
+    c_ref = art3d.Patch3DCollection(
+        [Circle((0, 0), 0.04)],
+        offsets=offsets_new,
+        zs=zs_new,
+        facecolor='C1',
+        edgecolor='C2',
+        linewidths=2,
+        depthshade=False,
+    )
+    ax_ref = fig_ref.add_subplot(projection='3d')
+    ax_ref.add_collection3d(c_ref)
+    ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
 
 
 def test_poly3dcollection_verts_validation():

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -499,22 +499,20 @@ def test_scatter3d_offsets3d_modification(fig_ref, fig_test):
         linewidths=2, depthshade=False)
 
 
-@check_figures_equal()
-def test_scatter3d_set_array_modification(fig_ref, fig_test):
-    # Changing Path3DCollection scalar-mappable array post-creation should work.
-    x = np.linspace(0.1, 0.9, 10)
-    y = np.linspace(0.9, 0.1, 10)
-    z = np.linspace(0.1, 0.9, 10)
-    colors = np.arange(10)
-
-    ax_test = fig_test.add_subplot(projection='3d')
-    c_test = ax_test.scatter(x, y, z, c=colors, cmap='viridis',
-                             marker='o', s=75, depthshade=False)
-    c_test.set_array(colors[::-1])
-
-    ax_ref = fig_ref.add_subplot(projection='3d')
-    ax_ref.scatter(x, y, z, c=colors[::-1], cmap='viridis',
-                   marker='o', s=75, depthshade=False)
+@pytest.mark.parametrize("zdir", ["x", "y", "z"])
+def test_scatter3d_offsets3d_roundtrip(zdir):
+    # set_offsets3d/get_offsets3d should round-trip data coordinates.
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    c = ax.scatter(np.arange(3), np.arange(3), np.arange(3), marker='o')
+    xs = np.array([0.1, 0.5, 0.9])
+    ys = np.array([0.9, 0.5, 0.1])
+    zs = np.array([0.2, 0.4, 0.8])
+    c.set_offsets3d(xs, ys, zs, zdir=zdir)
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
 
 
 @check_figures_equal()
@@ -1062,41 +1060,22 @@ def test_patch_collection_offsets3d_modification(fig_test, fig_ref):
     ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
 
 
-@check_figures_equal()
-def test_patch_collection_set_array_modification(fig_test, fig_ref):
-    # Changing Patch3DCollection scalar-mappable array post-creation should work.
+@pytest.mark.parametrize("zdir", ["x", "y", "z"])
+def test_patch_collection_offsets3d_roundtrip(zdir):
+    # set_offsets3d/get_offsets3d should round-trip data coordinates.
     offsets = np.column_stack([
-        np.linspace(0.2, 0.8, 5),
-        np.linspace(0.8, 0.2, 5),
+        np.linspace(0.2, 0.8, 4),
+        np.linspace(0.8, 0.2, 4),
     ])
-    zs = np.linspace(0.2, 0.8, 5)
-    colors = np.arange(5)
-
-    c_test = art3d.Patch3DCollection(
-        [Circle((0, 0), 0.04)],
-        offsets=offsets,
-        zs=zs,
-        cmap='viridis',
-        depthshade=False,
-    )
-    ax_test = fig_test.add_subplot(projection='3d')
-    ax_test.add_collection3d(c_test)
-    c_test.set_array(colors)
-    fig_test.canvas.draw()
-    c_test.set_array(colors[::-1])
-    ax_test.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
-
-    c_ref = art3d.Patch3DCollection(
-        [Circle((0, 0), 0.04)],
-        offsets=offsets,
-        zs=zs,
-        cmap='viridis',
-        depthshade=False,
-    )
-    ax_ref = fig_ref.add_subplot(projection='3d')
-    ax_ref.add_collection3d(c_ref)
-    c_ref.set_array(colors[::-1])
-    ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
+    c = art3d.Patch3DCollection([Circle((0, 0), 0.04)], offsets=offsets)
+    xs = np.array([0.1, 0.4, 0.6, 0.9])
+    ys = np.array([0.9, 0.6, 0.4, 0.1])
+    zs = np.array([0.2, 0.3, 0.7, 0.8])
+    c.set_offsets3d(xs, ys, zs, zdir=zdir)
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
 
 
 def test_poly3dcollection_verts_validation():

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -520,6 +520,22 @@ def test_scatter3d_offsets3d_roundtrip(zdir):
     np.testing.assert_allclose(actual_zs, zs)
 
 
+def test_scatter3d_offsets3d_roundtrip_legacy_without_zdir():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    c = ax.scatter(np.arange(3), np.arange(3), np.arange(3), marker='o')
+    xs = np.array([0.1, 0.5, 0.9])
+    ys = np.array([0.9, 0.5, 0.1])
+    zs = np.array([0.2, 0.4, 0.8])
+    c.set_offsets3d(xs, ys, zs, zdir='z')
+    del c._offsets3d_data
+    del c._zdir
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
+
+
 @pytest.mark.parametrize("zdir", ["x", "y", "z", "-x", "-y", "-z"])
 def test_add_collection3d_patch_collection_offsets3d_roundtrip(zdir):
     offsets = np.column_stack([
@@ -563,6 +579,23 @@ def test_collection3d_set_get_verts_and_codes3d():
             assert actual_codes is None
         else:
             np.testing.assert_array_equal(actual_codes, expected_codes)
+
+
+def test_collection3d_set_verts_and_codes3d_empty_preserves_axlim_clip():
+    x = y = np.linspace(-1, 1, 5)
+    X, Y = np.meshgrid(x, y)
+    Z = X**2 + Y**2
+
+    _, ax = plt.subplots()
+    cset = ax.contour(X, Y, Z, levels=[0.5, 1.0])
+    art3d.collection_2d_to_3d(cset, zs=cset.levels, zdir='z', axlim_clip=True)
+    assert cset._axlim_clip
+
+    cset.set_verts_and_codes3d([(np.empty((0, 3)), None)])
+    assert cset._axlim_clip
+    verts_codes = cset.get_verts_and_codes3d()
+    assert verts_codes[0][0].shape == (0, 3)
+    assert verts_codes[0][1] is None
 
 
 @check_figures_equal()
@@ -1241,6 +1274,30 @@ def test_poly3dcollection_set_get_verts_and_codes3d():
     c.set_verts_and_codes3d(verts, codes)
     actual_verts, actual_codes = c.get_verts_and_codes3d()
     np.testing.assert_allclose(actual_verts[0], verts[0])
+    np.testing.assert_array_equal(actual_codes[0], codes[0])
+
+
+def test_poly3dcollection_get_verts3d_legacy_fallback():
+    verts = [
+        np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]], float),
+        np.array([[1, 0, 0], [1, 1, 0], [1, 0, 1]], float),
+    ]
+    c = art3d.Poly3DCollection(verts)
+    del c._verts3d_data
+    actual = c.get_verts3d()
+    np.testing.assert_allclose(actual, verts)
+
+
+def test_poly3dcollection_get_codes3d_legacy_fallback():
+    path = Path.unit_rectangle()
+    verts = [
+        np.column_stack([path.vertices, np.linspace(0.1, 0.9, len(path.vertices))])
+    ]
+    codes = [path.codes]
+    c = art3d.Poly3DCollection(verts)
+    c.set_verts_and_codes3d(verts, codes)
+    del c._codes3d_data
+    actual_codes = c.get_codes3d()
     np.testing.assert_array_equal(actual_codes[0], codes[0])
 
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -14,7 +14,7 @@ from matplotlib.backend_bases import (MouseButton, MouseEvent,
 from matplotlib import cm
 from matplotlib import colors as mcolors, patches as mpatch
 from matplotlib.testing.decorators import image_comparison, check_figures_equal
-from matplotlib.collections import LineCollection, PolyCollection
+from matplotlib.collections import LineCollection, PatchCollection, PolyCollection
 from matplotlib.patches import Circle, PathPatch
 from matplotlib.path import Path
 from matplotlib.text import Text
@@ -499,7 +499,7 @@ def test_scatter3d_offsets3d_modification(fig_ref, fig_test):
         linewidths=2, depthshade=False)
 
 
-@pytest.mark.parametrize("zdir", ["x", "y", "z"])
+@pytest.mark.parametrize("zdir", ["x", "y", "z", "-x", "-y", "-z"])
 def test_scatter3d_offsets3d_roundtrip(zdir):
     # set_offsets3d/get_offsets3d should round-trip data coordinates.
     fig = plt.figure()
@@ -512,6 +512,29 @@ def test_scatter3d_offsets3d_roundtrip(zdir):
     actual_xs, actual_ys, actual_zs = c.get_offsets3d()
     np.testing.assert_allclose(actual_xs, xs)
     np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
+    del c._offsets3d_data
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
+
+
+@pytest.mark.parametrize("zdir", ["x", "y", "z", "-x", "-y", "-z"])
+def test_add_collection3d_patch_collection_offsets3d_roundtrip(zdir):
+    offsets = np.column_stack([
+        np.linspace(0.2, 0.8, 4),
+        np.linspace(0.8, 0.2, 4),
+    ])
+    zs = np.array([0.2, 0.3, 0.7, 0.8])
+    c = PatchCollection([Circle((0, 0), 0.04)], offsets=offsets)
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    ax.add_collection3d(c, zs=zs, zdir=zdir)
+    assert isinstance(c, art3d.Patch3DCollection)
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, offsets[:, 0])
+    np.testing.assert_allclose(actual_ys, offsets[:, 1])
     np.testing.assert_allclose(actual_zs, zs)
 
 
@@ -995,6 +1018,18 @@ def test_patch_modification():
     assert mcolors.same_color(circle.get_facecolor(), (1, 0, 0, 1))
 
 
+def test_patch3d_set_get_verts3d():
+    circle = Circle((0, 0), radius=0.1)
+    art3d.patch_2d_to_3d(circle, z=0.2, zdir='z')
+    verts = circle.get_verts3d()
+    np.testing.assert_allclose(verts[:, 2], 0.2)
+
+    verts_new = verts.copy()
+    verts_new[:, 2] = np.linspace(0.1, 0.9, len(verts_new))
+    circle.set_verts3d(verts_new)
+    np.testing.assert_allclose(circle.get_verts3d(), verts_new)
+
+
 @check_figures_equal()
 def test_patch_collection_modification(fig_test, fig_ref):
     # Test that modifying Patch3DCollection properties after creation works.
@@ -1060,7 +1095,7 @@ def test_patch_collection_offsets3d_modification(fig_test, fig_ref):
     ax_ref.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
 
 
-@pytest.mark.parametrize("zdir", ["x", "y", "z"])
+@pytest.mark.parametrize("zdir", ["x", "y", "z", "-x", "-y", "-z"])
 def test_patch_collection_offsets3d_roundtrip(zdir):
     # set_offsets3d/get_offsets3d should round-trip data coordinates.
     offsets = np.column_stack([
@@ -1072,6 +1107,11 @@ def test_patch_collection_offsets3d_roundtrip(zdir):
     ys = np.array([0.9, 0.6, 0.4, 0.1])
     zs = np.array([0.2, 0.3, 0.7, 0.8])
     c.set_offsets3d(xs, ys, zs, zdir=zdir)
+    actual_xs, actual_ys, actual_zs = c.get_offsets3d()
+    np.testing.assert_allclose(actual_xs, xs)
+    np.testing.assert_allclose(actual_ys, ys)
+    np.testing.assert_allclose(actual_zs, zs)
+    del c._offsets3d_data
     actual_xs, actual_ys, actual_zs = c.get_offsets3d()
     np.testing.assert_allclose(actual_xs, xs)
     np.testing.assert_allclose(actual_ys, ys)
@@ -1116,6 +1156,37 @@ def test_poly_collection_2d_to_3d_empty():
 
     # Ensure drawing actually works.
     fig.canvas.draw()
+
+
+def test_poly3dcollection_set_get_verts3d():
+    verts = [
+        np.array([[0, 0, 0], [0, 1, 0], [0, 0, 1]], float),
+        np.array([[1, 0, 0], [1, 1, 0], [1, 0, 1]], float),
+    ]
+    c = art3d.Poly3DCollection(verts)
+    actual = c.get_verts3d()
+    for actual_face, expected_face in zip(actual, verts):
+        np.testing.assert_allclose(actual_face, expected_face)
+
+    verts_new = [
+        np.array([[0, 0, 1], [0, 1, 1], [0, 0, 2]], float),
+        np.array([[1, 0, 1], [1, 1, 1], [1, 0, 2]], float),
+    ]
+    c.set_verts3d(verts_new)
+    actual = c.get_verts3d()
+    for actual_face, expected_face in zip(actual, verts_new):
+        np.testing.assert_allclose(actual_face, expected_face)
+
+
+def test_poly3dcollection_set_get_verts_and_codes3d():
+    path = Path.unit_rectangle()
+    verts = [np.column_stack([path.vertices, np.linspace(0.1, 0.9, len(path.vertices))])]
+    codes = [path.codes]
+    c = art3d.Poly3DCollection(verts)
+    c.set_verts_and_codes3d(verts, codes)
+    actual_verts, actual_codes = c.get_verts_and_codes3d()
+    np.testing.assert_allclose(actual_verts[0], verts[0])
+    np.testing.assert_array_equal(actual_codes[0], codes[0])
 
 
 @mpl3d_image_comparison(['poly3dcollection_alpha.png'], style='mpl20')
@@ -1206,6 +1277,26 @@ def test_line3dCollection_autoscaling():
     assert np.allclose(ax.get_xlim3d(), (-0.041666666666666664, 2.0416666666666665))
     assert np.allclose(ax.get_ylim3d(), (-0.08333333333333333, 4.083333333333333))
     assert np.allclose(ax.get_zlim3d(), (-0.10416666666666666, 5.104166666666667))
+
+
+def test_line3dcollection_set_get_segments3d():
+    segments = [
+        np.array([[0, 0, 0], [1, 2, 3]], float),
+        np.array([[1, 0, 1], [2, 1, 0]], float),
+    ]
+    lc = art3d.Line3DCollection(segments)
+    actual = lc.get_segments3d()
+    for actual_segment, expected_segment in zip(actual, segments):
+        np.testing.assert_allclose(actual_segment, expected_segment)
+
+    segments_new = [
+        np.array([[0, 1, 0], [1, 3, 2]], float),
+        np.array([[1, 1, 1], [2, 2, 2]], float),
+    ]
+    lc.set_segments3d(segments_new)
+    actual = lc.get_segments3d()
+    for actual_segment, expected_segment in zip(actual, segments_new):
+        np.testing.assert_allclose(actual_segment, expected_segment)
 
 
 def test_poly3dCollection_autoscaling():
@@ -2496,6 +2587,27 @@ def test_pathpatch_3d(fig_test, fig_ref):
     ax = fig_test.add_subplot(projection="3d")
     pp3d = art3d.PathPatch3D(path, zs=(0, 0.5, 0.7, 1, 0), zdir='y')
     ax.add_artist(pp3d)
+
+
+def test_pathpatch3d_set_get_verts_and_codes3d():
+    path = Path.unit_rectangle()
+    zs = (0, 0.5, 0.7, 1, 0)
+    pp3d = art3d.PathPatch3D(path, zs=zs, zdir='y')
+    verts, codes = pp3d.get_verts_and_codes3d()
+    np.testing.assert_array_equal(codes, path.codes)
+    np.testing.assert_allclose(verts[:, 0], path.vertices[:, 0])
+    np.testing.assert_allclose(verts[:, 1], zs)
+    np.testing.assert_allclose(verts[:, 2], path.vertices[:, 1])
+
+    verts_new = np.column_stack([
+        np.linspace(0.1, 0.5, len(path.vertices)),
+        np.linspace(0.2, 0.6, len(path.vertices)),
+        np.linspace(0.3, 0.7, len(path.vertices)),
+    ])
+    pp3d.set_verts_and_codes3d(verts_new, path.codes)
+    actual_verts, actual_codes = pp3d.get_verts_and_codes3d()
+    np.testing.assert_allclose(actual_verts, verts_new)
+    np.testing.assert_array_equal(actual_codes, path.codes)
 
 
 @image_comparison(baseline_images=['scatter_spiral.png'],


### PR DESCRIPTION
## PR summary
This PR improves `mplot3d` offset updates for 3D collections.

`Path3DCollection` and `Patch3DCollection` project 3D offsets to 2D during draw, so updating through `set_offsets()` (2D data) is lossy and does not update the 3D source offsets. This PR adds an explicit `set_offsets3d(xs, ys, zs, *, zdir='z')` method to both classes and routes `set_3d_properties()` through that path.

Tests added:
- visual equality test for post-creation `set_offsets3d()` updates on `Path3DCollection`
- visual equality test for post-creation `set_offsets3d()` updates on `Patch3DCollection`
- visual equality test for post-creation `set_array()` updates on `Path3DCollection`
- visual equality test for post-creation `set_array()` updates on `Patch3DCollection`

Local test command run:
- `python -m pytest -q lib/mpl_toolkits/mplot3d/tests/test_axes3d.py`

Partially addresses #784.

## AI Disclosure
I used AI tooling to help draft and iterate the code and tests. I manually reviewed the implementation, validated behavior locally, and ran the affected test suite before opening this PR.

## PR checklist
- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
