### PR TITLE
SEC: Block shell escapes in latex and ps commands

### DIFF
--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -281,7 +281,7 @@ class LatexManager:
         # it.
         try:
             self.latex = subprocess.Popen(
-                [mpl.rcParams["pgf.texsystem"], "-halt-on-error"],
+                [mpl.rcParams["pgf.texsystem"], "-halt-on-error", "-no-shell-escape"],
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                 encoding="utf-8", cwd=self.tmpdir)
         except FileNotFoundError as err:
@@ -848,7 +848,7 @@ class FigureCanvasPgf(FigureCanvasBase):
             texcommand = mpl.rcParams["pgf.texsystem"]
             cbook._check_and_log_subprocess(
                 [texcommand, "-interaction=nonstopmode", "-halt-on-error",
-                 "figure.tex"], _log, cwd=tmpdir)
+                 "-no-shell-escape", "figure.tex"], _log, cwd=tmpdir)
             with ((tmppath / "figure.pdf").open("rb") as orig,
                   cbook.open_file_cm(fname_or_fh, "wb") as dest):
                 shutil.copyfileobj(orig, dest)  # copy file contents to target
@@ -965,7 +965,7 @@ class PdfPages:
             tex_source.write_bytes(self._file.getvalue())
             cbook._check_and_log_subprocess(
                 [texcommand, "-interaction=nonstopmode", "-halt-on-error",
-                 tex_source],
+                 "-no-shell-escape", tex_source],
                 _log, cwd=tmpdir)
             shutil.move(tex_source.with_suffix(".pdf"), self._output_name)
 

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -1256,8 +1256,9 @@ def _convert_psfrags(tmppath, psfrags, paper_width, paper_height, orientation):
 
     with TemporaryDirectory() as tmpdir:
         psfile = os.path.join(tmpdir, "tmp.ps")
+        # -R1 is a security flag used to prevent shell command execution
         cbook._check_and_log_subprocess(
-            ['dvips', '-q', '-R0', '-o', psfile, dvifile], _log)
+            ['dvips', '-q', '-R1', '-o', psfile, dvifile], _log)
         shutil.move(psfile, tmppath)
 
     # check if the dvips created a ps in landscape paper.  Somehow,
@@ -1301,7 +1302,7 @@ def gs_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
 
     cbook._check_and_log_subprocess(
         [mpl._get_executable_info("gs").executable,
-         "-dBATCH", "-dNOPAUSE", "-r%d" % dpi, "-sDEVICE=ps2write",
+         "-dBATCH", "-dNOPAUSE", "-dSAFER", "-r%d" % dpi, "-sDEVICE=ps2write",
          *paper_option, f"-sOutputFile={psfile}", tmpfile],
         _log)
 
@@ -1345,6 +1346,7 @@ def xpdf_distill(tmpfile, eps=False, ptype='letter', bbox=None, rotated=False):
         # happy (https://ghostscript.com/doc/9.56.1/Use.htm#MS_Windows).
         cbook._check_and_log_subprocess(
             ["ps2pdf",
+             "-dSAFER",
              "-dAutoFilterColorImages#false",
              "-dAutoFilterGrayImages#false",
              "-sAutoRotatePages#None",

--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -196,7 +196,8 @@ def _check_for_pgf(texsystem):
         """, encoding="utf-8")
         try:
             subprocess.check_call(
-                [texsystem, "-halt-on-error", str(tex_path)], cwd=tmpdir,
+                [texsystem, "-halt-on-error", "-no-shell-escape",
+                 str(tex_path)], cwd=tmpdir,
                 stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except (OSError, subprocess.CalledProcessError):
             return False

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -69,9 +69,9 @@ def test_dviread(tmp_path, engine, monkeypatch):
     shutil.copy(dirpath / "test.tex", tmp_path)
     shutil.copy(cbook._get_data_path("fonts/ttf/DejaVuSans.ttf"), tmp_path)
     cmd, fmt = {
-        "pdflatex": (["latex"], "dvi"),
-        "xelatex": (["xelatex", "-no-pdf"], "xdv"),
-        "lualatex": (["lualatex", "-output-format=dvi"], "dvi"),
+        "pdflatex": (["latex", "-no-shell-escape"], "dvi"),
+        "xelatex": (["xelatex", "-no-pdf", "-no-shell-escape"], "xdv"),
+        "lualatex": (["lualatex", "-output-format=dvi", "-no-shell-escape"], "dvi"),
     }[engine]
     if shutil.which(cmd[0]) is None:
         pytest.skip(f"{cmd[0]} is not available")
@@ -119,7 +119,8 @@ def test_dviread_pk(tmp_path):
         \end{document}
         """)
     subprocess_run_for_testing(
-        ["latex", "test.tex"], cwd=tmp_path, check=True, capture_output=True)
+        ["latex", "-no-shell-escape", "test.tex"],
+        cwd=tmp_path, check=True, capture_output=True)
     with dr.Dvi(tmp_path / "test.dvi", None) as dvi:
         pages = [*dvi]
     data = [

--- a/lib/matplotlib/texmanager.py
+++ b/lib/matplotlib/texmanager.py
@@ -299,8 +299,8 @@ class TexManager:
                 Path(tmpdir, "file.tex").write_text(
                     cls._get_tex_source(tex, fontsize), encoding='utf-8')
                 cls._run_checked_subprocess(
-                    ["latex", "-interaction=nonstopmode", "--halt-on-error",
-                     "file.tex"], tex, cwd=tmpdir)
+                    ["latex", "-interaction=nonstopmode", "-halt-on-error",
+                     "-no-shell-escape", "file.tex"], tex, cwd=tmpdir)
                 Path(tmpdir, "file.dvi").replace(dvipath)
                 # Also move the tex source to the main cache directory, but
                 # only for backcompat.


### PR DESCRIPTION
## PR summary
See the discussion in https://github.com/matplotlib/matplotlib/pull/31249

This blocks our LaTeX and ps commands from arbitrary code execution in the shell:
* `--no-shell-escape` added to all latex commands
* dvips flag changed from `-R0` to `-R1` to disallow shell execution. `-R1` is the default, so is there a reason we had this manually set to a lower security level? See the docs here: https://www.tug.org/texinfohtml/dvips.html#Option-details-1
* `-dSAFER` flag added to two ghostscript / ps calls which were missing it. May be the default, but now it's explicit, see the docs here: https://ghostscript.readthedocs.io/en/latest/Use.html#dsafer

## AI Disclosure
Claude used for the audit (found a few more spots to hit!), code manually reviewed

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
