### PR TITLE
MNT: Add autoclose bot inspired by scikit-learn

### DIFF
--- a/.github/workflows/autoclose_comment.yml
+++ b/.github/workflows/autoclose_comment.yml
@@ -1,6 +1,6 @@
 ---
 name: autoclose comment
-# Post comment on PRs when labeled with "autoclose candidate".
+# Post comment on PRs when labeled with "status: autoclose candidate".
 # Based on scikit-learn's autoclose bot at
 # https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/autoclose-comment.yml
 
@@ -21,7 +21,7 @@ env:
 jobs:
   post_comment:
     name: post_comment
-    if: "${{ contains(github.event.label.name, 'autoclose candidate') }}"
+    if: "${{ contains(github.event.label.name, 'status: autoclose candidate') }}"
     runs-on: ubuntu-latest
 
     steps:
@@ -39,11 +39,12 @@ jobs:
             ⏰ This pull request might be automatically closed in two weeks from now.
 
 
-            Thank you for your contribution to Matplotlib and for the effort you have
-            put into this PR. This pull request does not yet meet the quality and
-            clarity needed for an effective review. Project maintainers have limited
-            time for code reviews, and our goal is to prioritize well-prepared
-            contributions to keep Matplotlib maintainable.
+            Thank you for your contribution to Matplotlib and for the effort you
+            have put into this PR. This pull request does not yet meet the
+            quality and clarity standards needed for an effective review.
+            Project maintainers have limited time for code reviews, and our goal
+            is to prioritize well-prepared contributions to keep Matplotlib
+            maintainable.
 
 
             Matplotlib maintainers cannot provide one-to-one guidance on this PR.

--- a/.github/workflows/autoclose_schedule.yml
+++ b/.github/workflows/autoclose_schedule.yml
@@ -1,6 +1,6 @@
 ---
 name: autoclose schedule
-# Autoclose PRs labeled with "autoclose candidate" after 2 weeks.
+# Autoclose PRs labeled with "status: autoclose candidate" after 2 weeks.
 # Based on scikit-learn's implementation at
 # https://github.com/scikit-learn/scikit-learn/blob/main/.github/workflows/autoclose-schedule.yml
 

--- a/doc/devel/pr_guide.rst
+++ b/doc/devel/pr_guide.rst
@@ -162,9 +162,9 @@ Labels
   See the `list of labels <https://github.com/matplotlib/matplotlib/labels>`__.
 * If the PR makes changes to the wheel building Action, add the
   "Run cibuildwheel" label to enable testing wheels.
-* If this PR does not yet meet the quality and clarity needed for an effective
-  review, you can use the "autoclose candidate" label. This will trigger a
-  two-weeks countdown after which the PR will be automatically closed if no
+* If the PR does not yet have the quality and clarity needed for an effective
+  review, you can use the "status: autoclose candidate" label. This will trigger
+  a two-weeks countdown after which the PR will be automatically closed if no
   further improvements have been made. See
   `the autoclose workflow <https://github.com/matplotlib/matplotlib/blob/main/.github/workflows/autoclose_comment.yml>`__
   for more details.

--- a/tools/autoclose_prs.py
+++ b/tools/autoclose_prs.py
@@ -1,4 +1,4 @@
-"""Close PRs labeled with 'autoclose candidate' more than 14 days ago.
+"""Close PRs labeled with 'status: autoclose candidate' more than 14 days ago.
 
 Called from .github/workflows/autoclose_schedule.yml.
 
@@ -30,7 +30,7 @@ repo = gh.get_repo(gh_repo)
 
 
 now = datetime.now(timezone.utc)
-label = "autoclose candidate"
+label = "status: autoclose candidate"
 prs = [
     each
     for each in repo.get_issues(labels=[label])


### PR DESCRIPTION
## PR summary
Adds autoclose bot to close any PRs labeled "status: needs work" after 14 days. Heavily inspired by scikit-learn.

Closes #31164

## AI Disclosure
No AI was used.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
