### PR TITLE
ENH: Ignore empty text for tightbbox

### DIFF
--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1042,6 +1042,8 @@ class Text(Artist):
             return bbox
 
     def get_tightbbox(self, renderer=None):
+        if not self.get_visible() or self.get_text() == "":
+            return Bbox.null()
         # Exclude text at data coordinates outside the valid domain of the axes
         # scales (e.g., negative coordinates with a log scale).
         if (self.axes


### PR DESCRIPTION
## PR summary
This ignores empty or hidden text for tightbbox, dedicating more space to the plot in tight & constrained layouts. Some of the constrained layout images are larger for reasons I don't fully understand, but it's probably something to do with those invisible text bboxes being used to calculate internal padding.

Targeting the text-overhaul branch.

@QuLogic when I regenerate baseline images, it adds a much larger diff than expected. How are you handling those on this branch?

## AI Disclosure
None.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
