### PR TITLE
SEC: Block `figure.hooks` from being loaded from file

### DIFF
--- a/galleries/examples/user_interfaces/mplcvd.py
+++ b/galleries/examples/user_interfaces/mplcvd.py
@@ -3,8 +3,10 @@ mplcvd -- an example of figure hook
 ===================================
 
 To use this hook, ensure that this module is in your ``PYTHONPATH``, and set
-``rcParams["figure.hooks"] = ["mplcvd:setup"]``.  This hook depends on
-the ``colorspacious`` third-party module.
+``rcParams["figure.hooks"] = ["mplcvd:setup"]`` in your Python code. Note
+that ``figure.hooks`` must be set programmatically and cannot be set from
+``matplotlibrc`` or style files. This hook depends on the ``colorspacious``
+third-party module.
 """
 
 import functools

--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -876,7 +876,8 @@ def _open_file_or_url(fname):
             yield f
 
 
-def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
+def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False,
+                       use_file_blacklist=True):
     """
     Construct a `RcParams` instance from file *fname*.
 
@@ -892,6 +893,9 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
         before further parsing.
     fail_on_error : bool, default: False
         Whether invalid entries should result in an exception or a warning.
+    use_file_blacklist : bool, default: True
+        If True, filter out rcParams in `_RCPARAMS_FROM_FILE_BLACKLIST` that
+        should only be set programmatically (e.g. ``figure.hooks``).
     """
     import matplotlib as mpl
     rc_temp = {}
@@ -924,6 +928,13 @@ def _rc_params_in_file(fname, transform=lambda x: x, fail_on_error=False):
     config = RcParams()
 
     for key, (val, line, line_no) in rc_temp.items():
+        if use_file_blacklist and key in rcsetup._RCPARAMS_FROM_FILE_BLACKLIST:
+            _log.warning('%r is not supported in config files and will be '
+                         'ignored; set it programmatically with '
+                         '`matplotlib.rcParams[%r] = ...` instead. '
+                         '(file %r, line %d)',
+                         key, key, fname, line_no)
+            continue
         if key in rcsetup._validators:
             if fail_on_error:
                 config[key] = val  # try to convert to proper type or raise
@@ -988,7 +999,8 @@ rcParamsDefault = _rc_params_in_file(
     cbook._get_data_path("matplotlibrc"),
     # Strip leading comment.
     transform=lambda line: line[1:] if line.startswith("#") else line,
-    fail_on_error=True)
+    fail_on_error=True,
+    use_file_blacklist=False)
 rcParamsDefault._update_raw(rcsetup._hardcoded_defaults)
 rcParamsDefault._ensure_has_backend()
 

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -103,7 +103,8 @@
 #backend_fallback: True
 
 #interactive: False
-#figure.hooks:          # list of dotted.module.name:dotted.callable.name
+#figure.hooks:          # list of dotted.module.name:dotted.callable.name (must be set
+                        # programmatically; ignored if set in this file or a style file)
 #toolbar:     toolbar2  # {None, toolbar2, toolmanager}
 #timezone:    UTC       # a pytz timezone string, e.g., US/Central or Europe/Paris
 

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1445,6 +1445,10 @@ _hardcoded_defaults = {  # Defaults not inferred from
 _validators = {k: _convert_validator_spec(k, conv)
                for k, conv in _validators.items()}
 
+# rcParams that can execute arbitrary code and should only be set
+# programmatically, never loaded from config files.
+_RCPARAMS_FROM_FILE_BLACKLIST = {'figure.hooks'}
+
 
 @dataclass
 class _Param:

--- a/lib/matplotlib/style/__init__.py
+++ b/lib/matplotlib/style/__init__.py
@@ -37,7 +37,8 @@ _STYLE_BLACKLIST = {
     'webagg.port_retries', 'webagg.open_in_browser', 'backend_fallback',
     'toolbar', 'timezone', 'figure.max_open_warning',
     'figure.raise_window', 'savefig.directory', 'tk.window_focus',
-    'docstring.hardcopy', 'date.epoch'}
+    'docstring.hardcopy', 'date.epoch',
+    'figure.hooks'}
 
 
 @_docstring.Substitution(

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -657,6 +657,20 @@ def test_rcparams_path_sketch_from_file(tmp_path, value):
         assert mpl.rcParams["path.sketch"] == (1, 2, 3)
 
 
+def test_file_blacklist(tmp_path, caplog):
+    """Blacklisted rcParams should be ignored with a warning when loaded."""
+    rc_path = tmp_path / "matplotlibrc"
+    rc_path.write_text("figure.hooks: my_module:my_func\nlines.linewidth: 42")
+
+    with caplog.at_level("WARNING", logger="matplotlib"):
+        with mpl.rc_context(fname=rc_path):
+            # Blacklisted param should be unchanged (default is []).
+            assert mpl.rcParams["figure.hooks"] == []
+            # Non-blacklisted param should load normally.
+            assert mpl.rcParams["lines.linewidth"] == 42
+    assert "not supported in config files" in caplog.text
+
+
 @pytest.mark.parametrize('group, option, alias, value', [
     ('lines',  'linewidth',        'lw', 3),
     ('lines',  'linestyle',        'ls', 'dashed'),


### PR DESCRIPTION
## PR summary
This adds `figure.hooks` to a new `_RCPARAMS_FROM_FILE_BLACKLIST` variable which blocks specific rcparams from being loaded from style files or matplotlibrc. Programmatic use like `plt.rcParams["figure.hooks"] = ...` is unaffected.

The `figure.hooks` rcParam accepts a list of `"module:callable"` strings that are processed via `importlib.import_module()` and called on every new figure. A malicious style or matplotlibrc file combined with a python file in the working directory could load and execute that module.

This is definitely a more involved attack vector since it requires a module on PATH, so I definitely see an argument for not bothering to restrict it. But I don't see a single non-empty `figure.hooks` when searching github, so IMO there's no downside: https://github.com/search?q=%22figure.hooks%3A+[%22&type=code

```
project/
  theme.mplstyle  # figure.hooks: payload:run
  payload.py  # contains a run function that is automatically executed on every figure creation
```

I think the new `_RCPARAMS_FROM_FILE_BLACKLIST` variable is more broadly useful, and we may (?) want to revisit gating LaTeX preambles this way (https://github.com/matplotlib/matplotlib/pull/31249).

This is basically a more restrictive version of  `style._STYLE_BLACKLIST`, which should stay on its own since it's for blocking things that aren't style changes.

## AI Disclosure
Claude used for the audit, code changes made manually.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
