### PR TITLE
TST: Cleanup back-compat code in tests touched by text overhaul

### DIFF
--- a/lib/matplotlib/tests/test_agg_filter.py
+++ b/lib/matplotlib/tests/test_agg_filter.py
@@ -7,9 +7,6 @@ from matplotlib.testing.decorators import image_comparison
 @image_comparison(baseline_images=['agg_filter_alpha'],
                   extensions=['gif', 'png', 'pdf'])
 def test_agg_filter_alpha():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     ax = plt.axes()
     x, y = np.mgrid[0:7, 0:8]
     data = x**2 - y**2

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1030,9 +1030,6 @@ def test_hexbin_pickable():
 def test_hexbin_log():
     # Issue #1636 (and also test log scaled colorbar)
 
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     np.random.seed(19680801)
     n = 100000
     x = np.random.standard_normal(n)
@@ -1520,9 +1517,6 @@ def test_pcolormesh_log_scale(fig_test, fig_ref):
 # TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20', tol=0.3)
 def test_pcolormesh_datetime_axis():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
     base = datetime.datetime(2013, 1, 1)
@@ -5159,7 +5153,7 @@ def test_hist_stacked_bar():
     colors = [(0.5759849696758961, 1.0, 0.0), (0.0, 1.0, 0.350624650815206),
               (0.0, 1.0, 0.6549834156005998), (0.0, 0.6569064625276622, 1.0),
               (0.28302699607823545, 0.0, 1.0), (0.6849123462299822, 0.0, 1.0)]
-    labels = ['green', 'orange', ' yellow', 'magenta', 'black']
+    labels = ['first', 'second', 'third', 'fourth', 'fifth']
     fig, ax = plt.subplots()
     ax.hist(d, bins=10, histtype='barstacked', align='mid', color=colors,
             label=labels)

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -161,9 +161,6 @@ def test_colorbar_extension_inverted_axis(orientation, extend, expected):
                    ],
                   remove_text=True, savefig_kwarg={'dpi': 40}, tol=0.05)
 def test_colorbar_positioning(use_gridspec):
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     data = np.arange(1200).reshape(30, 40)
     levels = [0, 200, 400, 600, 800, 1000, 1200]
 

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -830,9 +830,6 @@ def _mask_tester(norm_instance, vals):
 
 @image_comparison(['levels_and_colors.png'])
 def test_cmap_and_norm_from_levels_and_colors():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     data = np.linspace(-2, 4, 49).reshape(7, 7)
     levels = [-1, 2, 2.5, 3]
     colors = ['red', 'green', 'blue', 'yellow', 'black']
@@ -849,9 +846,6 @@ def test_cmap_and_norm_from_levels_and_colors():
 
 @image_comparison(['boundarynorm_and_colorbar.png'], tol=1.0)
 def test_boundarynorm_and_colorbarbase():
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     # Make a figure and axes with dimensions as desired.
     fig = plt.figure()
     ax1 = fig.add_axes((0.05, 0.80, 0.9, 0.15))

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -411,9 +411,6 @@ def test_colorbar_location():
     Test that colorbar handling is as expected for various complicated
     cases...
     """
-    # Remove this line when this test image is regenerated.
-    plt.rcParams['pcolormesh.snap'] = False
-
     fig, axs = plt.subplots(4, 5, layout="constrained")
     for ax in axs.flat:
         pcm = example_pcolor(ax)

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -562,15 +562,6 @@ def test_anchored_artists():
     box.drawing_area.add_artist(el)
     ax.add_artist(box)
 
-    # This block used to test the AnchoredEllipse class, but that was removed. The block
-    # remains, though it duplicates the above ellipse, so that the test image doesn't
-    # need to be regenerated.
-    box = AnchoredAuxTransformBox(ax.transData, loc='lower left', frameon=True,
-                                  pad=0.5, borderpad=0.4)
-    el = Ellipse((0, 0), width=0.1, height=0.25, angle=-60)
-    box.drawing_area.add_artist(el)
-    ax.add_artist(box)
-
     asb = AnchoredSizeBar(ax.transData, 0.2, r"0.2 units", loc='lower right',
                           pad=0.3, borderpad=0.4, sep=4, fill_bar=True,
                           frameon=False, label_top=True, prop={'size': 20},

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -650,7 +650,6 @@ def test_surface3d():
 # TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['surface3d_label_offset_tick_position.png'], style='mpl20', tol=0.07)
 def test_surface3d_label_offset_tick_position():
-    plt.rcParams['axes3d.automargin'] = True  # Remove when image is regenerated
     ax = plt.figure().add_subplot(projection="3d")
 
     x, y = np.mgrid[0:6 * np.pi:0.25, 0:4 * np.pi:0.25]
@@ -1733,7 +1732,6 @@ def test_errorbar3d():
 
 @image_comparison(['stem3d.png'], style='mpl20', tol=0.009)
 def test_stem3d():
-    plt.rcParams['axes3d.automargin'] = True  # Remove when image is regenerated
     fig, axs = plt.subplots(2, 3, figsize=(8, 6),
                             constrained_layout=True,
                             subplot_kw={'projection': '3d'})


### PR DESCRIPTION
## PR summary
These tests had previously kept some code or settings to prevent regenerating the test image, but since they are now going to be regnerated from the text overhaul, we can remove those.

This includes several merges preemptively; only the last commit is relevant here.

## AI Disclosure
None

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines