### PR TITLE
Fix set_fillstyle dropping marker transform

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -547,7 +547,11 @@ class Line2D(Artist):
 
             For examples see :ref:`marker_fill_styles`.
         """
-        self.set_marker(MarkerStyle(self._marker.get_marker(), fs))
+        self.set_marker(MarkerStyle(
+            self._marker.get_marker(), fs,
+            transform=self._marker.get_user_transform(),
+            capstyle=self._marker._user_capstyle,
+            joinstyle=self._marker._user_joinstyle))
         self.stale = True
 
     def set_markevery(self, every):

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -184,6 +184,26 @@ def test_markerfacecolor_fillstyle():
     assert l.get_markerfacecolor() == 'none'
 
 
+def test_set_fillstyle_preserves_marker_transform():
+    """Test that set_fillstyle does not drop the user-supplied marker transform."""
+    transform = mtransforms.Affine2D().rotate_deg(45)
+    marker = MarkerStyle('*', transform=transform)
+    line, = plt.plot([0], [0], marker=marker, markersize=20)
+
+    # Before changing fillstyle, the transform should exist
+    assert line._marker.get_user_transform() is not None
+
+    line.set_fillstyle('left')
+
+    # After changing fillstyle, the transform should still be preserved
+    assert line.get_fillstyle() == 'left'
+    user_t = line._marker.get_user_transform()
+    assert user_t is not None
+    expected = mtransforms.Affine2D().rotate_deg(45)
+    np.testing.assert_array_almost_equal(
+        user_t.get_matrix(), expected.get_matrix())
+
+
 @image_comparison(['scaled_lines'], style='default')
 def test_lw_scaling():
     th = np.linspace(0, 32)


### PR DESCRIPTION
## Summary

`Line2D.set_fillstyle()` was constructing a new `MarkerStyle` with only the marker symbol and the new fillstyle, throwing away the user-supplied `transform`, `capstyle`, and `joinstyle` from the existing marker. This meant that markers with rotation transforms lost their rotation when the fillstyle was updated after plotting.

The fix passes through the existing marker's user transform, capstyle, and joinstyle to the replacement `MarkerStyle`.

Closes #31257

## Test

Added `test_set_fillstyle_preserves_marker_transform` in `test_lines.py` that sets a rotation transform on a marker, changes the fillstyle, and asserts the transform is still present.