### PR TITLE
Doc: clarify that matplotlib prefers squash merging foll pull requests

### DIFF
--- a/doc/devel/development_workflow.rst
+++ b/doc/devel/development_workflow.rst
@@ -168,6 +168,8 @@ Open a pull request
 
 When you are ready to ask for someone to review your code and consider a merge,
 `submit your Pull Request (PR) <https://docs.github.com/pull-requests>`_.
+Matplotlib generally prefers squash merging when integrating pull requests. 
+Squash merging combines all commits from a pull request into a single commit in the main branch, helping keep the project history clean and easy to follow.
 
 Go to the web page of *your fork* of the Matplotlib repo, and click
 ``Compare & pull request`` to send your changes to the maintainers for review.


### PR DESCRIPTION
## PR summary
This PR clarifies in the development workflow documentation that
Matplotlib generally prefers squash merging when integrating pull
requests. Adding this explanation helps contributors understand the
preferred merge strategy used in the project.

## AI Disclosure
AI was used to help understand the documentation structure and draft
the wording for the clarification.

## PR checklist
- [ ] "closes #0000" is in the body of the PR description
- [N/A] new and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted
- [x] Documentation complies with guidelines