### PR TITLE
TST: Reset tolerances on tests changed by text overhaul

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -239,9 +239,8 @@ def test_matshow(fig_test, fig_ref):
     ax_ref.xaxis.set_ticks_position('both')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison([f'formatter_ticker_{i:03d}.png' for i in range(1, 6)], style='mpl20',
-                  tol=0.02 if platform.machine() == 'x86_64' else 0.04)
+                  tol=0.03 if sys.platform == 'darwin' else 0)
 def test_formatter_ticker():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -811,8 +810,7 @@ def test_annotate_signature():
         assert p1 == p2
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['fill_units.png'], savefig_kwarg={'dpi': 60}, style='mpl20', tol=0.2)
+@image_comparison(['fill_units.png'], savefig_kwarg={'dpi': 60}, style='mpl20')
 def test_fill_units():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -951,7 +949,7 @@ def test_axvspan_epoch():
     ax.set_xlim(t0 - 5.0*dt, tf + 5.0*dt)
 
 
-@image_comparison(['axhspan_epoch.png'], style='mpl20', tol=0.02)
+@image_comparison(['axhspan_epoch.png'], style='mpl20')
 def test_axhspan_epoch():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -1515,8 +1513,7 @@ def test_pcolormesh_log_scale(fig_test, fig_ref):
     ax.set_xscale('log')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20', tol=0.3)
+@image_comparison(['pcolormesh_datetime_axis.png'], style='mpl20')
 def test_pcolormesh_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -1541,8 +1538,7 @@ def test_pcolormesh_datetime_axis():
             label.set_rotation(30)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['pcolor_datetime_axis.png'], style='mpl20', tol=0.3)
+@image_comparison(['pcolor_datetime_axis.png'], style='mpl20')
 def test_pcolor_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -1852,12 +1848,8 @@ def test_markevery():
     ax.legend()
 
 
-@image_comparison(['markevery_line.png'], remove_text=True, style='mpl20', tol=0.005)
+@image_comparison(['markevery_line.png'], remove_text=True, style='mpl20')
 def test_markevery_line():
-    # TODO: a slight change in rendering between Inkscape versions may explain
-    # why one had to introduce a small non-zero tolerance for the SVG test
-    # to pass. One may try to remove this hack once Travis' Inkscape version
-    # is modern enough. FWIW, no failure with 0.92.3 on my computer (#11358).
     x = np.linspace(0, 10, 100)
     y = np.sin(x) * np.sqrt(x/10 + 0.5)
 
@@ -2778,8 +2770,7 @@ def test_stairs_options():
     ax.legend(loc=0)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['test_stairs_datetime.png'], style='mpl20', tol=0.2)
+@image_comparison(['test_stairs_datetime.png'], style='mpl20')
 def test_stairs_datetime():
     f, ax = plt.subplots(constrained_layout=True)
     ax.stairs(np.arange(36),
@@ -3403,8 +3394,7 @@ def test_log_scales_invalid():
 
 
 @image_comparison(['stackplot_test_image.png', 'stackplot_test_image.png'],
-                  style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.031)
+                  style='mpl20')
 def test_stackplot():
     fig = plt.figure()
     x = np.linspace(0, 10, 10)
@@ -3565,10 +3555,7 @@ def test_bxp_horizontal():
     _bxp_test_helper(bxp_kwargs=dict(orientation='horizontal'))
 
 
-@image_comparison(['bxp_with_ylabels.png'],
-                  savefig_kwarg={'dpi': 40},
-                  style='default',
-                  tol=0.1)
+@image_comparison(['bxp_with_ylabels.png'], savefig_kwarg={'dpi': 40}, style='default')
 def test_bxp_with_ylabels():
     def transform(stats):
         for s, label in zip(stats, list('ABCD')):
@@ -3769,7 +3756,7 @@ def test_bxp_bad_capwidths():
         _bxp_test_helper(bxp_kwargs=dict(capwidths=[1]))
 
 
-@image_comparison(['boxplot.png', 'boxplot.png'], tol=1.28, style='default')
+@image_comparison(['boxplot.png', 'boxplot.png'], tol=0.43, style='default')
 def test_boxplot():
     # Randomness used for bootstrapping.
     np.random.seed(937)
@@ -5551,7 +5538,7 @@ def test_marker_styles():
 
 
 @image_comparison(['rc_markerfill.png'], style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.037)
+                  tol=0.033 if sys.platform == 'darwin' else 0)
 def test_markers_fillstyle_rcparams():
     fig, ax = plt.subplots()
     x = np.arange(7)
@@ -5574,7 +5561,7 @@ def test_vertex_markers():
 
 
 @image_comparison(['vline_hline_zorder.png', 'errorbar_zorder.png'], style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.026)
+                  tol=0.02 if sys.platform == 'darwin' else 0)
 def test_eb_line_zorder():
     x = list(range(10))
 
@@ -6487,12 +6474,7 @@ def test_text_labelsize():
     ax.tick_params(direction='out')
 
 
-# Note: The `pie` image tests were affected by Numpy 2.0 changing promotions
-# (NEP 50). While the changes were only marginal, tolerances were introduced.
-# These tolerances could likely go away when numpy 2.0 is the minimum supported
-# numpy and the images are regenerated.
-
-@image_comparison(['pie_default.png'], style='mpl20', tol=0.01)
+@image_comparison(['pie_default.png'], style='mpl20')
 def test_pie_default():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6505,7 +6487,7 @@ def test_pie_default():
 
 
 @image_comparison(['pie_linewidth_0.png', 'pie_linewidth_0.png', 'pie_linewidth_0.png'],
-                  style='mpl20', tol=0.01)
+                  style='mpl20')
 def test_pie_linewidth_0():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6537,7 +6519,8 @@ def test_pie_linewidth_0():
     plt.axis('equal')
 
 
-@image_comparison(['pie_center_radius.png'], style='mpl20', tol=0.011)
+@image_comparison(['pie_center_radius.png'], style='mpl20',
+                  tol=0.01 if sys.platform == 'darwin' else 0)
 def test_pie_center_radius():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6557,7 +6540,7 @@ def test_pie_center_radius():
     plt.axis('equal')
 
 
-@image_comparison(['pie_linewidth_2.png'], style='mpl20', tol=0.01)
+@image_comparison(['pie_linewidth_2.png'], style='mpl20')
 def test_pie_linewidth_2():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6572,7 +6555,7 @@ def test_pie_linewidth_2():
     plt.axis('equal')
 
 
-@image_comparison(['pie_ccw_true.png'], style='mpl20', tol=0.01)
+@image_comparison(['pie_ccw_true.png'], style='mpl20')
 def test_pie_ccw_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6587,7 +6570,7 @@ def test_pie_ccw_true():
     plt.axis('equal')
 
 
-@image_comparison(['pie_frame_grid.png'], style='mpl20', tol=0.002)
+@image_comparison(['pie_frame_grid.png'], style='mpl20')
 def test_pie_frame_grid():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -6614,8 +6597,7 @@ def test_pie_frame_grid():
     plt.axis('equal')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['pie_rotatelabels_true.png'], style='mpl20', tol=0.1)
+@image_comparison(['pie_rotatelabels_true.png'], style='mpl20')
 def test_pie_rotatelabels_true():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Hogwarts', 'Frogs', 'Dogs', 'Logs'
@@ -6630,7 +6612,7 @@ def test_pie_rotatelabels_true():
     plt.axis('equal')
 
 
-@image_comparison(['pie_no_label.png'], style='mpl20', tol=0.01)
+@image_comparison(['pie_no_label.png'], style='mpl20')
 def test_pie_nolabel_but_legend():
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
     sizes = [15, 30, 45, 10]
@@ -8356,7 +8338,7 @@ class _Translation(mtransforms.Transform):
 
 
 @image_comparison(['secondary_xy.png'], style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.027)
+                  tol=0 if platform.machine() == 'x86_64' else 0.024)
 def test_secondary_xy():
     fig, axs = plt.subplots(1, 2, figsize=(10, 5), constrained_layout=True)
 
@@ -9648,7 +9630,7 @@ def test_zorder_and_explicit_rasterization():
 
 
 @image_comparison(["preset_clip_paths.png"], remove_text=True, style="mpl20",
-                  tol=0 if platform.machine() == 'x86_64' else 0.027)
+                  tol=0.01 if sys.platform == 'darwin' else 0)
 def test_preset_clip_paths():
     fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -152,14 +152,13 @@ def test_colorbar_extension_inverted_axis(orientation, extend, expected):
         assert len(cbar._extend_patches) == 1
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @pytest.mark.parametrize('use_gridspec', [True, False])
 @image_comparison(['cbar_with_orientation.png',
                    'cbar_locationing.png',
                    'double_cbar.png',
                    'cbar_sharing.png',
                    ],
-                  remove_text=True, savefig_kwarg={'dpi': 40}, style='mpl20', tol=0.05)
+                  remove_text=True, savefig_kwarg={'dpi': 40}, style='mpl20')
 def test_colorbar_positioning(use_gridspec):
     data = np.arange(1200).reshape(30, 40)
     levels = [0, 200, 400, 600, 800, 1000, 1200]
@@ -728,8 +727,7 @@ def test_colorbar_label():
     assert cbar3.ax.get_xlabel() == 'horizontal cbar'
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['colorbar_keeping_xlabel.png'], style='mpl20', tol=0.03)
+@image_comparison(['colorbar_keeping_xlabel.png'], style='mpl20')
 def test_keeping_xlabel():
     # github issue #23398 - xlabels being ignored in colorbar axis
     arr = np.arange(25).reshape((5, 5))

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -844,7 +844,7 @@ def test_cmap_and_norm_from_levels_and_colors():
     ax.tick_params(labelleft=False, labelbottom=False)
 
 
-@image_comparison(['boundarynorm_and_colorbar.png'], tol=1.0)
+@image_comparison(['boundarynorm_and_colorbar.png'])
 def test_boundarynorm_and_colorbarbase():
     # Make a figure and axes with dimensions as desired.
     fig = plt.figure()

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -94,7 +94,7 @@ def test_contour_set_paths(fig_test, fig_ref):
     cs_test.set_paths(cs_ref.get_paths())
 
 
-@image_comparison(['contour_manual_labels'], remove_text=True, style='mpl20', tol=0.26)
+@image_comparison(['contour_manual_labels'], remove_text=True, style='mpl20')
 def test_contour_manual_labels():
     x, y = np.meshgrid(np.arange(0, 10), np.arange(0, 10))
     z = np.max(np.dstack([abs(x), abs(y)]), 2)
@@ -127,9 +127,8 @@ def test_contour_manual_moveto():
     assert clabels[0].get_text() == "0"
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['contour_disconnected_segments.png'],
-                  remove_text=True, style='mpl20', tol=0.01)
+                  remove_text=True, style='mpl20')
 def test_contour_label_with_disconnected_segments():
     x, y = np.mgrid[-1:1:21j, -1:1:21j]
     z = 1 / np.sqrt(0.01 + (x + 0.3) ** 2 + y ** 2)
@@ -229,8 +228,7 @@ def test_lognorm_levels(n_levels):
     assert len(visible_levels) <= n_levels + 1
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['contour_datetime_axis.png'], style='mpl20', tol=0.3)
+@image_comparison(['contour_datetime_axis.png'], style='mpl20')
 def test_contour_datetime_axis():
     fig = plt.figure()
     fig.subplots_adjust(hspace=0.4, top=0.98, bottom=.15)
@@ -256,7 +254,8 @@ def test_contour_datetime_axis():
 
 
 @image_comparison(['contour_test_label_transforms.png'],
-                  remove_text=True, style='mpl20', tol=1.1)
+                  remove_text=True, style='mpl20',
+                  tol=0 if platform.machine() == 'x86_64' else 0.005)
 def test_labels():
     # Adapted from pylab_examples example code: contour_demo.py
     # see issues #2475, #2843, and #2818 for explanation

--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -152,8 +152,7 @@ def test_date_axhspan():
     fig.subplots_adjust(left=0.25)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['date_axvspan.png'], style='mpl20', tol=0.07)
+@image_comparison(['date_axvspan.png'], style='mpl20')
 def test_date_axvspan():
     # test axvspan with date inputs
     t0 = datetime.datetime(2000, 1, 20)
@@ -177,8 +176,7 @@ def test_date_axhline():
     fig.subplots_adjust(left=0.25)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['date_axvline.png'], style='mpl20', tol=0.09)
+@image_comparison(['date_axvline.png'], style='mpl20')
 def test_date_axvline():
     # test axvline with date inputs
     t0 = datetime.datetime(2000, 1, 20)
@@ -228,8 +226,7 @@ def _new_epoch_decorator(thefunc):
     return wrapper
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['RRuleLocator_bounds.png'], style='mpl20', tol=0.07)
+@image_comparison(['RRuleLocator_bounds.png'], style='mpl20')
 def test_RRuleLocator():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -273,8 +270,7 @@ def test_RRuleLocator_close_minmax():
     assert list(map(str, mdates.num2date(loc.tick_values(d1, d2)))) == expected
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['DateFormatter_fractionalSeconds.png'], style='mpl20', tol=0.11)
+@image_comparison(['DateFormatter_fractionalSeconds.png'], style='mpl20')
 def test_DateFormatter():
     import matplotlib.testing.jpl_units as units
     units.register()

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -26,9 +26,8 @@ import matplotlib.pyplot as plt
 import matplotlib.dates as mdates
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['figure_align_labels'], extensions=['png', 'svg'], style='mpl20',
-                  tol=0.1 if platform.machine() == 'x86_64' else 0.1)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_align_labels():
     fig = plt.figure(layout='tight')
     gs = gridspec.GridSpec(3, 3)
@@ -68,11 +67,9 @@ def test_align_labels():
     fig.align_labels()
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['figure_align_titles_tight.png',
                    'figure_align_titles_constrained.png'],
-                  tol=0.3 if platform.machine() == 'x86_64' else 0.04,
-                  style='mpl20')
+                  style='mpl20', tol=0 if platform.machine() == 'x86_64' else 0.021)
 def test_align_titles():
     for layout in ['tight', 'constrained']:
         fig, axs = plt.subplots(1, 2, layout=layout, width_ratios=[2, 1])
@@ -323,8 +320,7 @@ def test_add_subplot_invalid():
         fig.add_subplot(ax)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['figure_suptitle.png'], style='mpl20', tol=0.02)
+@image_comparison(['figure_suptitle.png'], style='mpl20')
 def test_suptitle():
     fig, _ = plt.subplots()
     fig.suptitle('hello', color='r')
@@ -1401,7 +1397,7 @@ def test_subfigure_dpi():
 
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'},
-                  tol=0.022)
+                  tol=0.022 if sys.platform == 'darwin' else 0)
 def test_subfigure_ss():
     # test assigning the subfigure via subplotspec
     np.random.seed(19680801)
@@ -1423,9 +1419,8 @@ def test_subfigure_ss():
     fig.suptitle('Figure suptitle', fontsize='xx-large')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['test_subfigure_double.png'], style='mpl20',
-                  savefig_kwarg={'facecolor': 'teal'}, tol=0.02)
+                  savefig_kwarg={'facecolor': 'teal'})
 def test_subfigure_double():
     # test assigning the subfigure via subplotspec
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1487,7 +1487,7 @@ def test_nonuniform_logscale():
         ax.add_image(im)
 
 
-@image_comparison(['rgba_antialias.png'], style='mpl20', remove_text=True, tol=0.02)
+@image_comparison(['rgba_antialias.png'], style='mpl20', remove_text=True)
 def test_rgba_antialias():
     fig, axs = plt.subplots(2, 2, figsize=(3.5, 3.5), sharex=False,
                             sharey=False, constrained_layout=True)
@@ -1741,8 +1741,8 @@ def test_non_transdata_image_does_not_touch_aspect():
     assert ax.get_aspect() == 2
 
 
-@image_comparison(
-    ['downsampling.png'], style='mpl20', remove_text=True, tol=0.09)
+@image_comparison(['downsampling.png'], style='mpl20', remove_text=True,
+                  tol=0 if platform.machine() == 'x86_64' else 0.07)
 def test_downsampling():
     N = 450
     x = np.arange(N) / N - 0.5
@@ -1776,8 +1776,7 @@ def test_downsampling():
         ax.set_title(f"interpolation='{interp}'\nspace='{space}'")
 
 
-@image_comparison(
-    ['downsampling_speckle.png'], style='mpl20', remove_text=True, tol=0.09)
+@image_comparison(['downsampling_speckle.png'], style='mpl20', remove_text=True)
 def test_downsampling_speckle():
     fig, axs = plt.subplots(1, 2, figsize=(5, 2.7), sharex=True, sharey=True,
                             layout="compressed")

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -2,6 +2,7 @@ import collections
 import io
 import itertools
 import platform
+import sys
 import time
 from unittest import mock
 import warnings
@@ -201,10 +202,9 @@ def test_alpha_rcparam():
         leg.legendPatch.set_facecolor([1, 0, 0, 0.5])
 
 
-@image_comparison(['fancy.png'], remove_text=True, style='mpl20', tol=0.05)
+@image_comparison(['fancy.png'], remove_text=True, style='mpl20',
+                  tol=0.01 if sys.platform == 'darwin' else 0)
 def test_fancy():
-    # Tolerance caused by changing default shadow "shade" from 0.3 to 1 - 0.7 =
-    # 0.30000000000000004
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.subplot(121)
     plt.plot([5] * 10, 'o--', label='XX')
@@ -216,7 +216,7 @@ def test_fancy():
 
 
 @image_comparison(['framealpha'], remove_text=True, style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.024)
+                  tol=0 if platform.machine() == 'x86_64' else 0.021)
 def test_framealpha():
     x = np.linspace(1, 100, 100)
     y = x
@@ -529,8 +529,7 @@ def test_figure_legend_outside():
                         rtol=1e-4)
 
 
-@image_comparison(['legend_stackplot.png'], style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.031)
+@image_comparison(['legend_stackplot.png'], style='mpl20')
 def test_legend_stackplot():
     """Test legend for PolyCollection using stackplot."""
     # related to #1341, #1943, and PR #3303
@@ -666,7 +665,7 @@ def test_empty_bar_chart_with_legend():
 
 
 @image_comparison(['shadow_argument_types.png'], remove_text=True, style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.028)
+                  tol=0.028 if sys.platform == 'darwin' else 0)
 def test_shadow_argument_types():
     # Test that different arguments for shadow work as expected
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -1,4 +1,4 @@
-import platform
+import sys
 
 import numpy as np
 
@@ -30,7 +30,7 @@ def test_patheffect1():
 
 
 @image_comparison(['patheffect2'], remove_text=True, style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.06)
+                  tol=0.051 if sys.platform == 'darwin' else 0)
 def test_patheffect2():
 
     ax2 = plt.subplot()
@@ -46,7 +46,7 @@ def test_patheffect2():
 
 
 @image_comparison(['patheffect3'], style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.019)
+                  tol=0.02 if sys.platform == 'darwin' else 0)
 def test_patheffect3():
     plt.figure(figsize=(8, 6))
     p1, = plt.plot([1, 3, 5, 4, 3], 'o-b', lw=4)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -1,3 +1,5 @@
+import sys
+
 import numpy as np
 from numpy.testing import assert_allclose
 import pytest
@@ -9,7 +11,8 @@ from matplotlib.testing.decorators import image_comparison, check_figures_equal
 import matplotlib.ticker as mticker
 
 
-@image_comparison(['polar_axes.png'], style='default', tol=0.012)
+@image_comparison(['polar_axes.png'], style='default',
+                  tol=0.009 if sys.platform == 'darwin' else 0)
 def test_polar_annotations():
     # You can specify the xypoint and the xytext in different positions and
     # coordinate systems, and optionally turn on a connecting line and mark the
@@ -44,7 +47,7 @@ def test_polar_annotations():
 
 
 @image_comparison(['polar_coords.png'], style='default', remove_text=True,
-                  tol=0.014)
+                  tol=0.013 if sys.platform == 'darwin' else 0)
 def test_polar_coord_annotations():
     # You can also use polar notation on a cartesian axes.  Here the native
     # coordinate system ('data') is cartesian, so you need to specify the
@@ -214,8 +217,7 @@ def test_polar_theta_position():
     ax.set_theta_direction('clockwise')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['polar_rlabel_position.png'], style='default', tol=0.07)
+@image_comparison(['polar_rlabel_position.png'], style='default')
 def test_polar_rlabel_position():
     fig = plt.figure()
     ax = fig.add_subplot(projection='polar')
@@ -230,8 +232,7 @@ def test_polar_title_position():
     ax.set_title('foo')
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['polar_theta_wedge.png'], style='default', tol=0.2)
+@image_comparison(['polar_theta_wedge.png'], style='default')
 def test_polar_theta_limits():
     r = np.arange(0, 3.0, 0.01)
     theta = 2*np.pi*r

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -159,8 +159,7 @@ def test_multiline():
     ax.set_yticks([])
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['multiline2'], style='mpl20', tol=0.05)
+@image_comparison(['multiline2'], style='mpl20')
 def test_multiline2():
     fig, ax = plt.subplots()
 
@@ -228,8 +227,7 @@ def test_antialiasing():
     mpl.rcParams['text.antialiased'] = False  # Should not affect existing text.
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['text_contains.png'], style='mpl20', tol=0.05)
+@image_comparison(['text_contains.png'], style='mpl20')
 def test_contains():
     fig = plt.figure(figsize=(8, 6))
     ax = plt.axes()
@@ -298,8 +296,7 @@ def test_titles():
     ax.set_yticks([])
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['text_alignment'], style='mpl20', tol=0.08)
+@image_comparison(['text_alignment'], style='mpl20')
 def test_alignment():
     plt.figure()
     ax = plt.subplot(1, 1, 1)
@@ -1141,8 +1138,7 @@ def test_empty_annotation_get_window_extent():
     assert points[0, 1] == 50.0
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['basictext_wrap.png'], style='mpl20', tol=0.3)
+@image_comparison(['basictext_wrap.png'], style='mpl20')
 def test_basic_wrap():
     fig = plt.figure(figsize=(8, 6))
     plt.axis([0, 10, 0, 10])
@@ -1158,8 +1154,7 @@ def test_basic_wrap():
     plt.text(-1, 0, t, ha='left', rotation=-15, wrap=True)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['fonttext_wrap.png'], style='mpl20', tol=0.3)
+@image_comparison(['fonttext_wrap.png'], style='mpl20')
 def test_font_wrap():
     fig = plt.figure(figsize=(8, 6))
     plt.axis([0, 10, 0, 10])
@@ -1191,9 +1186,7 @@ def test_va_for_angle():
         assert alignment in ['center', 'top', 'baseline']
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['xtick_rotation_mode.png'], remove_text=False, style='mpl20',
-                  tol=0.3)
+@image_comparison(['xtick_rotation_mode.png'], remove_text=False, style='mpl20')
 def test_xtick_rotation_mode():
     fig, ax = plt.subplots(figsize=(12, 1))
     ax.set_yticks([])
@@ -1212,9 +1205,7 @@ def test_xtick_rotation_mode():
     plt.subplots_adjust(left=0.01, right=0.99, top=.6, bottom=.4)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['ytick_rotation_mode.png'], remove_text=False, style='mpl20',
-                  tol=0.3)
+@image_comparison(['ytick_rotation_mode.png'], remove_text=False, style='mpl20')
 def test_ytick_rotation_mode():
     fig, ax = plt.subplots(figsize=(1, 12))
     ax.set_xticks([])

--- a/lib/matplotlib/tests/test_units.py
+++ b/lib/matplotlib/tests/test_units.py
@@ -80,9 +80,8 @@ def quantity_converter():
 
 # Tests that the conversion machinery works properly for classes that
 # work as a facade over numpy arrays (like pint)
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['plot_pint.png'], style='mpl20',
-                  tol=0.03 if platform.machine() == 'x86_64' else 0.04)
+                  tol=0 if platform.machine() == 'x86_64' else 0.03)
 def test_numpy_facade(quantity_converter):
     # use former defaults to match existing baseline image
     plt.rcParams['axes.formatter.limits'] = -7, 7
@@ -143,9 +142,8 @@ def test_jpl_bar_units():
     ax.set_ylim([b - 1 * day, b + w[-1] + (1.001) * day])
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(['jpl_barh_units.png'],
-                  savefig_kwarg={'dpi': 120}, style='mpl20', tol=0.02)
+                  savefig_kwarg={'dpi': 120}, style='mpl20')
 def test_jpl_barh_units():
     import matplotlib.testing.jpl_units as units
     units.register()

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -226,9 +226,8 @@ except mpl.ExecutableNotFoundError:
     _old_gs_version = True
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
 @image_comparison(baseline_images=['rotation'], extensions=['eps', 'pdf', 'png', 'svg'],
-                  style='mpl20', tol=3.91 if _old_gs_version else 0.2)
+                  style='mpl20', tol=3.91 if _old_gs_version else 0)
 def test_rotation():
     mpl.rcParams['text.usetex'] = True
 

--- a/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
+++ b/lib/mpl_toolkits/axes_grid1/tests/test_axes_grid1.py
@@ -1,6 +1,7 @@
 from itertools import product
 import io
 import platform
+import sys
 
 import matplotlib as mpl
 import matplotlib.pyplot as plt
@@ -61,7 +62,7 @@ def test_divider_append_axes():
     assert bboxes["top"].x1 == bboxes["main"].x1 == bboxes["bottom"].x1
 
 
-@image_comparison(['twin_axes_empty_and_removed.png'], tol=1, style='mpl20')
+@image_comparison(['twin_axes_empty_and_removed.png'], style='mpl20')
 def test_twin_axes_empty_and_removed():
     # Purely cosmetic font changes (avoid overlap)
     mpl.rcParams.update({"font.size": 8, "xtick.labelsize": 8, "ytick.labelsize": 8})
@@ -357,9 +358,8 @@ def test_zooming_with_inverted_axes():
     inset_ax.axis([1.4, 1.1, 1.4, 1.1])
 
 
-@image_comparison(['anchored_direction_arrows.png'],
-                  tol=0 if platform.machine() == 'x86_64' else 0.01,
-                  style='mpl20')
+@image_comparison(['anchored_direction_arrows.png'], style='mpl20',
+                  tol=0 if platform.machine() == 'x86_64' else 0.006)
 def test_anchored_direction_arrows():
     fig, ax = plt.subplots()
     ax.imshow(np.zeros((10, 10)), interpolation='nearest')
@@ -368,7 +368,8 @@ def test_anchored_direction_arrows():
     ax.add_artist(simple_arrow)
 
 
-@image_comparison(['anchored_direction_arrows_many_args.png'], style='mpl20')
+@image_comparison(['anchored_direction_arrows_many_args.png'], style='mpl20',
+                  tol=0.002 if sys.platform == 'win32' else 0)
 def test_anchored_direction_arrows_many_args():
     fig, ax = plt.subplots()
     ax.imshow(np.ones((10, 10)))

--- a/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
@@ -24,8 +24,7 @@ def test_ticks():
     ax.add_artist(ticks_out)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['axis_artist_labelbase.png'], style='default', tol=0.02)
+@image_comparison(['axis_artist_labelbase.png'], style='default')
 def test_labelbase():
     fig, ax = plt.subplots()
 
@@ -39,8 +38,7 @@ def test_labelbase():
     ax.add_artist(label)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['axis_artist_ticklabels.png'], style='default', tol=0.03)
+@image_comparison(['axis_artist_ticklabels.png'], style='default')
 def test_ticklabels():
     fig, ax = plt.subplots()
 
@@ -72,8 +70,7 @@ def test_ticklabels():
     ax.set_ylim(0, 1)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['axis_artist.png'], style='default', tol=0.03)
+@image_comparison(['axis_artist.png'], style='default')
 def test_axis_artist():
     fig, ax = plt.subplots()
 

--- a/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_grid_helper_curvelinear.py
@@ -1,3 +1,5 @@
+import platform
+
 import numpy as np
 
 import matplotlib.pyplot as plt
@@ -15,7 +17,8 @@ from mpl_toolkits.axisartist.grid_helper_curvelinear import \
     GridHelperCurveLinear
 
 
-@image_comparison(['custom_transform.png'], style='mpl20', tol=0.2)
+@image_comparison(['custom_transform.png'], style='mpl20',
+                  tol=0 if platform.machine() == 'x86_64' else 0.04)
 def test_custom_transform():
     plt.rcParams.update({"xtick.direction": "in", "ytick.direction": "inout"})
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -117,7 +117,7 @@ def test_axes3d_repr():
 
 
 @mpl3d_image_comparison(['axes3d_primary_views.png'], style='mpl20',
-                        tol=0.05 if sys.platform == "darwin" else 0)
+                        tol=0.045 if sys.platform == 'darwin' else 0)
 def test_axes3d_primary_views():
     # (elev, azim, roll)
     views = [(90, -90, 0),  # XY
@@ -647,8 +647,7 @@ def test_surface3d():
     fig.colorbar(surf, shrink=0.5, aspect=5)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@image_comparison(['surface3d_label_offset_tick_position.png'], style='mpl20', tol=0.07)
+@image_comparison(['surface3d_label_offset_tick_position.png'], style='mpl20')
 def test_surface3d_label_offset_tick_position():
     ax = plt.figure().add_subplot(projection="3d")
 
@@ -743,8 +742,7 @@ def test_surface3d_masked_strides():
     ax.view_init(60, -45, 0)
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@mpl3d_image_comparison(['text3d.png'], remove_text=False, style='mpl20', tol=0.1)
+@mpl3d_image_comparison(['text3d.png'], remove_text=False, style='mpl20')
 def test_text3d():
     fig = plt.figure()
     ax = fig.add_subplot(projection='3d')
@@ -1123,9 +1121,7 @@ def test_poly3dCollection_autoscaling():
     assert np.allclose(ax.get_zlim3d(), (-0.0833333333333333, 4.083333333333333))
 
 
-# TODO: tighten tolerance after baseline image is regenerated for text overhaul
-@mpl3d_image_comparison(['axes3d_labelpad.png'],
-                        remove_text=False, style='mpl20', tol=0.06)
+@mpl3d_image_comparison(['axes3d_labelpad.png'], remove_text=False, style='mpl20')
 def test_axes3d_labelpad():
     fig = plt.figure()
     ax = fig.add_axes(Axes3D(fig))
@@ -1500,8 +1496,8 @@ class TestVoxels:
             assert voxels[coord], "faces returned for absent voxel"
             assert isinstance(poly, art3d.Poly3DCollection)
 
-    @mpl3d_image_comparison(['voxels-xyz.png'],
-                            tol=0.01, remove_text=False, style='mpl20')
+    @mpl3d_image_comparison(['voxels-xyz.png'], remove_text=False, style='mpl20',
+                            tol=0.002 if sys.platform == 'win32' else 0)
     def test_xyz(self):
         fig, ax = plt.subplots(subplot_kw={"projection": "3d"})
 
@@ -1714,7 +1710,7 @@ def test_errorbar3d_errorevery():
 
 
 @mpl3d_image_comparison(['errorbar3d.png'], style='mpl20',
-                        tol=0 if platform.machine() == 'x86_64' else 0.02)
+                        tol=0.015 if sys.platform == 'darwin' else 0)
 def test_errorbar3d():
     """Tests limits, color styling, and legend for 3D errorbars."""
     fig = plt.figure()
@@ -1730,7 +1726,8 @@ def test_errorbar3d():
     ax.legend()
 
 
-@image_comparison(['stem3d.png'], style='mpl20', tol=0.009)
+@image_comparison(['stem3d.png'], style='mpl20',
+                  tol=0 if platform.machine() == 'x86_64' else 0.008)
 def test_stem3d():
     fig, axs = plt.subplots(2, 3, figsize=(8, 6),
                             constrained_layout=True,
@@ -2876,7 +2873,7 @@ def _make_triangulation_data():
 
 
 @mpl3d_image_comparison(['scale3d_artists_log.png'], style='mpl20',
-                        remove_text=False, tol=0.032)
+                        remove_text=False, tol=0.016)
 def test_scale3d_artists_log():
     """Test all 3D artist types with log scale."""
     fig = plt.figure(figsize=(16, 12))

--- a/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
@@ -1,4 +1,4 @@
-import platform
+import sys
 
 import numpy as np
 
@@ -28,7 +28,7 @@ def test_legend_bar():
 
 
 @image_comparison(['fancy.png'], remove_text=True, style='mpl20',
-                  tol=0 if platform.machine() == 'x86_64' else 0.011)
+                  tol=0.01 if sys.platform == 'darwin' else 0)
 def test_fancy():
     fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
     ax.plot(np.arange(10), np.full(10, 5), np.full(10, 5), 'o--', label='line')


### PR DESCRIPTION
## PR summary
Now that these have been regenerated, we can reset the tolerances. It is possible that we may still need some architecture-specific tolerances; I will restore them if we find that to be the case in CI here.

Only the last commit is relevant here.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines