### PR TITLE
Fix restoring 'auto' aspect in 3D axes after switching from 'equal'

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -360,9 +360,7 @@ class Axes3D(Axes):
                     if limits[4] is not None:
                         self.set_zlim3d(limits[4], limits[5], auto=True)
                     del self._auto_aspect_restore_limits
-            return
-
-        if aspect in ('equal', 'equalxy', 'equalxz', 'equalyz'):
+        else:
             ax_indices = self._equal_aspect_axis_indices(aspect)
 
             view_intervals = np.array([self.xaxis.get_view_interval(),

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -340,10 +340,7 @@ class Axes3D(Axes):
 
         self.set_adjustable(adjustable)
 
-        if (
-            self._aspect == "auto"
-            and aspect in ('equal', 'equalxy', 'equalxz', 'equalyz')
-        ):
+        if self._aspect == 'auto' and aspect != 'auto':
             self._auto_aspect_restore_limits = list(self.get_w_lims())
 
         self._aspect = aspect

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -339,7 +339,31 @@ class Axes3D(Axes):
                            aspect=aspect)
 
         self.set_adjustable(adjustable)
+
+        if (
+            self._aspect == "auto"
+            and aspect in ('equal', 'equalxy', 'equalxz', 'equalyz')
+        ):
+            self._auto_aspect_restore_limits = list(self.get_w_lims())
+
         self._aspect = aspect
+
+        if aspect == "auto":
+            if self._adjustable == "box":
+                self.set_box_aspect(None)
+
+            elif self._adjustable == "datalim":
+                if hasattr(self, "_auto_aspect_restore_limits"):
+                    limits = self._auto_aspect_restore_limits
+
+                    if limits[0] is not None:
+                        self.set_xlim3d(limits[0], limits[1], auto=True)
+                    if limits[2] is not None:
+                        self.set_ylim3d(limits[2], limits[3], auto=True)
+                    if limits[4] is not None:
+                        self.set_zlim3d(limits[4], limits[5], auto=True)
+                    del self._auto_aspect_restore_limits
+            return
 
         if aspect in ('equal', 'equalxy', 'equalxz', 'equalyz'):
             ax_indices = self._equal_aspect_axis_indices(aspect)
@@ -871,6 +895,11 @@ class Axes3D(Axes):
             delta = (upper - lower) * view_margin
             lower -= delta
             upper += delta
+
+        if not auto and hasattr(self, '_auto_aspect_restore_limits'):
+            idx = {self.xaxis: 0, self.yaxis: 2, self.zaxis: 4}[axis]
+            self._auto_aspect_restore_limits[idx] = None
+            self._auto_aspect_restore_limits[idx + 1] = None
         return axis._set_lim(lower, upper, emit=emit, auto=auto)
 
     def set_xlim(self, left=None, right=None, *, emit=True, auto=False,

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -97,6 +97,47 @@ def test_axis_positions_inverted():
         ax.set(xlabel='x', ylabel='y', zlabel='z', title=title)
 
 
+def test_set_aspect_datalim_restores_limits():
+
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+
+    ax.plot([0,1], [0,2], [0,3])
+
+    fig.canvas.draw()
+    default_limits = ax.get_w_lims()
+
+    ax.set_aspect('equal', adjustable='datalim')
+    fig.canvas.draw()
+    equal_limits = ax.get_w_lims()
+
+    ax.set_aspect('auto', adjustable='datalim')
+    fig.canvas.draw()
+    final_limits = ax.get_w_lims()
+
+    # equal should change limits
+    assert not np.allclose(default_limits, equal_limits)
+
+    # auto should restore original limits
+    assert np.allclose(default_limits, final_limits)
+
+
+def test_set_aspect_datalim_restores_untouched_axes():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    ax.plot([1, 2], [3, 4], [5, 6])
+    orig_lims = ax.get_w_lims()
+
+    ax.set_aspect('equal', adjustable='datalim')
+    ax.set_xlim(-50, 50)  # explicit user change mid-'equal'
+    ax.set_aspect('auto', adjustable='datalim')
+
+    xlim, ylim, zlim = ax.get_xlim3d(), ax.get_ylim3d(), ax.get_zlim3d()
+    assert xlim == (-50, 50)               # explicit value preserved
+    assert ylim == orig_lims[2:4]          # untouched axis restored
+    assert zlim == orig_lims[4:6]          # untouched axis restored
+
+
 @mpl3d_image_comparison(['aspects.png'], remove_text=False, style='mpl20')
 def test_aspects():
     aspects = ('auto', 'equal', 'equalxy', 'equalyz', 'equalxz', 'equal')


### PR DESCRIPTION
Closes #31276

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

### Problem
Switching the aspect of a 3D axis from "auto" to "equal" and back to "auto" did not restore the original plot correctly. The logic for handling "auto" continued executing the equal-aspect adjustments, which modified the axis limits and box aspect.
### Fix
This change ensures that when `aspect == "auto"`:

* For `adjustable='box'`, the box aspect is reset and the function exits early, preventing further equal-aspect logic from running.
* For `adjustable='datalim'`, the axis limits are restored per-axis from a snapshot taken when 'equal' was set — any axis given an explicit limit change while in 'equal' mode keeps that change instead of being silently overwritten.

### Testing

* Added `test_set_aspect_datalim_restores_limits`, verifying that switching `'auto'` → `'equal'` → `'auto'` correctly restores the original axis limits when nothing is changed in between.
* Added `test_set_aspect_datalim_restores_untouched_axes`, covering the case where an explicit `set_xlim` is called while in `'equal'` mode — the explicit value is preserved on switching back to `'auto'`, while untouched axes `(ylim, zlim)` still restore correctly.
* Full test suite passes locally.

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure

I used Claude to debug the root cause of the (stale limit restoration when explicit limits are set while aspect is 'equal').
 All code was written and verified by me locally. 
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->