### PR TITLE
DOC: Add thumbnail for multipage_pdf gallery example

### DIFF
--- a/doc/_static/multipage_pdf_thumbnail.svg
+++ b/doc/_static/multipage_pdf_thumbnail.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- back page -->
+  <rect x="44" y="10" width="256" height="176" fill="white" stroke="#cccccc" stroke-width="2"/>
+  <!-- middle page -->
+  <rect x="30" y="22" width="256" height="176" fill="white" stroke="#bbbbbb" stroke-width="2"/>
+  <!-- front page -->
+  <rect x="16" y="34" width="256" height="176" fill="white" stroke="#888888" stroke-width="2.5"/>
+  <!-- text -->
+  <text x="144" y="118" font-family="sans-serif" font-size="24" text-anchor="middle" fill="#333333">Multipage</text>
+  <text x="144" y="146" font-family="sans-serif" font-size="24" text-anchor="middle" fill="#333333">PDF</text>
+</svg>

--- a/galleries/examples/misc/multipage_pdf.py
+++ b/galleries/examples/misc/multipage_pdf.py
@@ -15,6 +15,8 @@ import numpy as np
 
 from matplotlib.backends.backend_pdf import PdfPages
 
+# sphinx_gallery_thumbnail_path = '_static/multipage_pdf_thumbnail.svg'
+
 # Create the PdfPages object to which we will save the pages:
 # The with statement makes sure that the PdfPages object is closed properly at
 # the end of the block, even if an Exception occurs.


### PR DESCRIPTION
## Problem
The multipage_pdf example does not generate a gallery thumbnail.

## Cause
The example uses pdf.savefig() instead of plt.savefig(), so Sphinx Gallery cannot auto-generate a thumbnail.

## Fix
Added a static thumbnail using sphinx_gallery_thumbnail_path.

Closes #17479