### PR TITLE
DOC: update pandas intersphinx mapping

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -271,7 +271,7 @@ intersphinx_mapping = {
     'dateutil': ('https://dateutil.readthedocs.io/en/stable/', None),
     'ipykernel': ('https://ipykernel.readthedocs.io/en/latest/', None),
     'numpy': ('https://numpy.org/doc/stable/', None),
-    'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'pandas': ('https://pandas.pydata.org/docs/', None),
     'pytest': ('https://pytest.org/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),


### PR DESCRIPTION
Docs builds are currently failing.  It looks like Pandas moved the furniture around.