### PR TITLE
DOC: clarify explanation of axline in infinite lines example

### DIFF
--- a/galleries/examples/lines_bars_and_markers/axline.py
+++ b/galleries/examples/lines_bars_and_markers/axline.py
@@ -8,7 +8,8 @@ horizontal lines, at given *x* / *y* positions. They are usually used to mark
 special data values, e.g. in this example the center and limit values of the
 sigmoid function.
 
-`~.axes.Axes.axline` draws infinite straight lines in arbitrary directions.
+`~.axes.Axes.axline` draws infinite straight lines defined either by two
+points or by a point and a slope.
 
 .. redirect-from:: /gallery/pyplot/axline
 """


### PR DESCRIPTION
Improves the explanation of axline in the Infinite Lines gallery example.
The previous description did not explain how the line is defined.
This update clarifies that axline can be defined by two points or by a point and a slope.