### PR TITLE
Preserve custom linestyles in Qt figure options

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -10,6 +10,7 @@ from matplotlib import cbook, cm, colors as mcolors, markers, image as mimage
 from matplotlib.backends.qt_compat import QtGui
 from matplotlib.backends.qt_editor import _formlayout
 from matplotlib.dates import DateConverter, num2date
+from matplotlib.lines import _get_dash_pattern
 
 LINESTYLES = {'-': 'Solid',
               '--': 'Dashed',
@@ -120,11 +121,21 @@ def figure_edit(axes, parent=None):
         fc = mcolors.to_hex(
             mcolors.to_rgba(line.get_markerfacecolor(), line.get_alpha()),
             keep_alpha=True)
+
+        linestyle = line.get_linestyle()
+        dash_pattern = line._unscaled_dash_pattern
+        try:
+            implied_pattern = _get_dash_pattern(linestyle)
+        except ValueError:
+            implied_pattern = dash_pattern
+        if dash_pattern != implied_pattern:
+            linestyle = dash_pattern
+
         curvedata = [
             ('Label', label),
             sep,
             (None, '<b>Line</b>'),
-            ('Line style', prepare_data(LINESTYLES, line.get_linestyle())),
+            ('Line style', prepare_data(LINESTYLES, linestyle)),
             ('Draw style', prepare_data(DRAWSTYLES, line.get_drawstyle())),
             ('Width', line.get_linewidth()),
             ('Color (RGBA)', color),

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -246,6 +246,46 @@ def test_figureoptions_with_datetime_axes():
 
 
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)
+def test_figureoptions_preserves_custom_dash_tuple(monkeypatch):
+    from matplotlib.backends.qt_editor import figureoptions
+
+    fig, ax = plt.subplots()
+    line, = ax.plot([1, 2], [1, 2], label="line", linestyle=(5, (10, 3)))
+    before = line._unscaled_dash_pattern
+
+    def fake_fedit(datalist, apply, **kwargs):
+        general = [ax.get_title()]
+        for name, axis in ax._axis_map.items():
+            axis_min, axis_max = getattr(ax, f"get_{name}lim")()
+            general.extend([axis_min, axis_max, axis.label.get_text(),
+                            axis.get_scale()])
+        general.append(False)
+
+        curves = []
+        for curve, _, _ in datalist[1][0]:
+            fields = dict(curve)
+            curves.append([
+                fields['Label'],
+                fields['Line style'][0],
+                fields['Draw style'][0],
+                fields['Width'],
+                fields['Color (RGBA)'],
+                fields['Style'][0],
+                fields['Size'],
+                fields['Face color (RGBA)'],
+                fields['Edge color (RGBA)'],
+            ])
+
+        apply([general, curves])
+        return None
+
+    monkeypatch.setattr(figureoptions._formlayout, "fedit", fake_fedit)
+    figureoptions.figure_edit(ax, parent=None)
+
+    assert line._unscaled_dash_pattern == before
+
+
+@pytest.mark.backend('QtAgg', skip_on_importerror=True)
 def test_double_resize():
     # Check that resizing a figure twice keeps the same window size
     fig, ax = plt.subplots()


### PR DESCRIPTION
Fixed an issue where custom tuple dash patterns change to the unscaled dash pattern when trying to navigate off of "Edit axis, curve and image parameters" 

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
--> 

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
PR request fixes bug #31289 
Currently, when a line uses any custom dash style, if one opens the qt bar option "Edit axis, curve, and image parameters", it automatically would switch the line style to a default "style token", which in this bug case was a "--"

This happened because `Line2D.get_linestyle()` reports a the default style token, which was tripped by the "edit axis... and image parameters" tripping set_linestyle(...) , replacing the custom tuple token. :(

PR edits figureoptions.py to where if the custom pattern and the default pattern differ, it defaults to the custom pattern specified. 

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
AI was used to generate the test case inside test_backend_qt, labeled "test_figureoptions_preserves_custom_dash_tuple" to test if the bug was still present. All code / behavior manually reviewed by me 


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ yes] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [yes ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
