### PR TITLE
Fix crash when removing a subfigure with subplots

### DIFF
--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -255,10 +255,13 @@ Supported properties are
             # clear stale callback
             self.stale_callback = None
             _ax_flag = False
-            if hasattr(self, 'axes') and self.axes:
+            axes = getattr(self, 'axes', None)
+            if axes is not None:
+                from matplotlib.axes import Axes
+            if isinstance(axes, Axes):
                 # remove from the mouse hit list
-                self.axes._mouseover_set.discard(self)
-                self.axes.stale = True
+                axes._mouseover_set.discard(self)
+                axes.stale = True
                 self.axes = None  # decouple the artist from the Axes
                 _ax_flag = True
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1575,6 +1575,7 @@ def test_subfigures_wspace_hspace():
 def test_subfigure_remove():
     fig = plt.figure()
     sfs = fig.subfigures(2, 2)
+    sfs[1, 1].subplots()
     sfs[1, 1].remove()
     assert len(fig.subfigs) == 3
 


### PR DESCRIPTION
## Summary

Fix a crash in `Artist.remove()` when removing a `SubFigure` that already contains subplots.

`SubFigure.axes` returns a list of axes, but `Artist.remove()` assumed that a truthy `self.axes` was always a single `Axes` instance and tried to access `_mouseover_set` on it.

This change only performs the `_mouseover_set` cleanup when `self.axes` is actually an `Axes` instance, and extends the existing subfigure removal test to cover the non-empty case.

Closes #31319
