### PR TITLE
Fix axisartist label not updating after draw_without_rendering

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -1005,6 +1005,10 @@ class AxisArtist(martist.Artist):
     def _update_label(self, renderer):
         if not self.label.get_visible():
             return
+        if self.label._text == "__from_axes__":
+            self.label.stale = True
+            if self.axes is not None:
+                self.axes.stale = True
 
         if self._ticklabel_add_angle != self._axislabel_add_angle:
             if ((self.major_ticks.get_visible()

--- a/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
+import mpl_toolkits.axisartist as axisartist
 
 from mpl_toolkits.axisartist import AxisArtistHelperRectlinear
 from mpl_toolkits.axisartist.axis_artist import (AxisArtist, AxisLabel,
@@ -100,3 +101,17 @@ def test_axis_artist():
     axisline.label.set_pad(5)
 
     ax.set_ylabel("Test")
+
+
+def test_axisartist_xlabel_update_after_draw_without_rendering():
+
+    fig = plt.figure()
+    ax = fig.add_subplot(axes_class=axisartist.Axes)
+
+    ax.set_xlabel("first label")
+    fig.draw_without_rendering()
+
+    ax.set_xlabel("second label")
+    fig.canvas.draw()
+
+    assert ax.get_xlabel() == "second label"


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x ] "closes #31288" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

**Description**
This PR solving the  bug occurs when we are setting xlabel of axisartist.Axes to some non-empty string, and draw the figure, but when when we are setting the xlabel to another string, the figure does not change.
So, this PR marks the label and axes as stale when using _from_axes_, ensuring the updated label is rendered.
Test file is added with the following changes.
