### PR TITLE
Fix outdated freetype URL causing intermittent 502 error

### DIFF
--- a/subprojects/freetype-2.6.1.wrap
+++ b/subprojects/freetype-2.6.1.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-source_url = https://download.savannah.nongnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
+source_url = https://download-mirror.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
 source_fallback_url = https://downloads.sourceforge.net/project/freetype/freetype2/2.6.1/freetype-2.6.1.tar.gz
 source_filename = freetype-2.6.1.tar.gz
 source_hash = 0a3c7dfbda6da1e8fce29232e8e96d987ababbbf71ebc8c75659e4132c367014


### PR DESCRIPTION
## PR summary

### Why is this change necessary?
The existing FreeType download URL is outdated and returns a 502 error, which breaks the build/setup process.

### What problem does it solve?
This fix ensures that the FreeType dependency can be downloaded successfully, preventing setup failures for contributors and CI pipelines.

### What is the reasoning for this implementation?
The outdated URL was replaced with a valid and accessible source to restore the expected behavior without altering any existing logic.

Fixes build failure caused by outdated FreeType URL.

---

## AI Disclosure

This PR description was improved with the assistance of an AI tool for clarity. The code changes were implemented and verified manually.

---

## PR checklist

- [ ] "closes #31340 " is in the body of the PR description
- [N/A] new and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines