### PR TITLE
mplot3d: refresh projected axis positions before tightbbox

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axis3d.py
+++ b/lib/mpl_toolkits/mplot3d/axis3d.py
@@ -684,6 +684,20 @@ class Axis(maxis.XAxis):
         # docstring inherited
         if not self.get_visible():
             return
+        if renderer is None:
+            renderer = self.get_figure(root=True)._get_renderer()
+
+        locator = self.axes.get_axes_locator()
+        self.axes.apply_aspect(locator(self.axes, renderer) if locator else None)
+
+        # The 2D positions of 3D ticks and labels are updated during draw()
+        # based on the current projection. Refresh that state without
+        # rendering so the bbox query sees the same geometry as the real draw.
+        self.axes.M = self.axes.get_proj()
+        self.axes.invM = np.linalg.inv(self.axes.M)
+        with renderer._draw_disabled():
+            self.draw(renderer)
+
         # We have to directly access the internal data structures
         # (and hope they are up to date) because at draw time we
         # shift the ticks and their labels around in (x, y) space

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -2738,6 +2738,38 @@ def test_axes3d_set_aspect_deperecated_params():
         ax.set_aspect('equal', adjustable='invalid_value')
 
 
+def test_axis_get_tightbbox_before_draw_matches_after_draw():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+
+    axes = [ax.xaxis, ax.yaxis, ax.zaxis]
+    renderer = fig.canvas.get_renderer()
+    bboxes_before = {
+        axis.axis_name: axis.get_tightbbox(renderer).extents.copy()
+        for axis in axes
+    }
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    for axis in axes:
+        np.testing.assert_allclose(
+            bboxes_before[axis.axis_name],
+            axis.get_tightbbox(renderer).extents)
+
+
+def test_constrained_layout_3d_axis_tightbbox_prevents_overlap():
+    fig = plt.figure(constrained_layout=True)
+    ax1 = fig.add_subplot(2, 1, 1, projection='3d')
+    ax1.set_title('3D Plot')
+    ax2 = fig.add_subplot(2, 1, 2)
+    ax2.set_title('2D Plot')
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+
+    assert ax1.get_tightbbox(renderer).y0 >= ax2.title.get_window_extent(renderer).y1
+
+
 def test_axis_get_tightbbox_includes_offset_text():
     # Test that axis.get_tightbbox includes the offset_text
     # Regression test for issue #30744


### PR DESCRIPTION
Fixes #31277

The issue comes from `Axis3D.get_tightbbox()` using stale artist extents before
the projected 3D axis positions have been refreshed. In constrained layout, this
can make the computed bbox too small and lead to overlaps between 3D tick labels
and the title of the following subplot.

This patch refreshes the projected axis geometry before computing the tightbbox,
so layout uses updated extents.

It also adds regression tests covering:
- consistency of `Axis3D.get_tightbbox()` before and after draw
- the constrained-layout overlap case reported in #31277