### PR TITLE
Fix: Prevent clabel() from modifying filled contour geometry

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -464,8 +464,8 @@ class ContourLabeler:
             path, idx_vtx_min, proj, label_width, inline_spacing)
         self.add_label(*proj, rotation, self.labelLevelList[idx_level_min],
                        self.labelCValueList[idx_level_min])
-
-        if inline:
+# 🔧 FIX: Do NOT modify paths for filled contours
+        if inline and not self.filled:
             self._paths[idx_level_min] = path
 
     def pop_label(self, index=-1):


### PR DESCRIPTION
## Summary

Fixes an issue where adding contour labels using `clabel()` on filled contour plots (`contourf`) alters the geometry of the filled regions.

When inline labeling is enabled, the labeling logic modifies internal path data. This behavior is appropriate for line contours but unintentionally affects filled contours, resulting in distorted shapes.

## Root Cause

The inline labeling code updates the internal `_paths` of the contour set regardless of whether the contour is filled or not. For filled contours, these paths define the filled regions themselves, so modifying them changes the visual output.

## Fix

Restrict path modification to non-filled contours only. Inline labeling now avoids mutating `_paths` when `self.filled` is True.

## Reproduction

Example demonstrating the issue:

```python
import matplotlib.pyplot as plt
import numpy as np

delta = 0.025
x = np.arange(-3.0, 3.0, delta)
y = np.arange(-2.0, 2.0, delta)
X, Y = np.meshgrid(x, y)

Z1 = np.exp(-X**2 - Y**2)
Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
Z = (Z1 - Z2) * 2

fig, axs = plt.subplots(2, 1)

axs[0].contourf(X, Y, Z)

CS = axs[1].contourf(X, Y, Z)
axs[1].clabel(CS)

plt.show()