### PR TITLE
Fix ContourSet.set_color messing up unfilled contours (#31335)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -1115,6 +1115,28 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         if self.extend in ('both', 'max', 'min'):
             self.norm.clip = False
 
+    def set_color(self, c):
+        """
+        Set the edgecolor(s) of the contour.
+
+        For unfilled contours (the default), this is the same as
+        `LineCollection.set_color` -- only the edge color is set,
+        because an unfilled contour has no face/area to fill.
+
+        For filled contours, both the edge and face colors are set.
+
+        Parameters
+        ----------
+        c : :mpltype:`color` or list of RGBA tuples
+        """
+        if self.filled:
+            self.set_edgecolor(c)
+            self.set_facecolor(c)
+        else:
+            self.set_edgecolor(c)
+
+    set_colors = set_color
+
     def _process_linewidths(self, linewidths):
         Nlev = len(self.levels)
         if linewidths is None:

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -872,3 +872,63 @@ def test_contour_aliases(fig_test, fig_ref):
 def test_contour_singular_color():
     with pytest.raises(TypeError):
         plt.figure().add_subplot().contour([[0, 1], [2, 3]], color="r")
+
+
+def test_contour_set_color_unfilled():
+    """Test that set_color on unfilled contours only changes edgecolor, not facecolor."""
+    fig, ax = plt.subplots()
+    x = np.arange(-3.0, 3.0, 0.025)
+    y = np.arange(-2.0, 2.0, 0.025)
+    X, Y = np.meshgrid(x, y)
+    Z1 = np.exp(-X**2 - Y**2)
+    Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
+    Z = (Z1 - Z2) * 2
+
+    CS = ax.contour(X, Y, Z)
+    # Unfilled contours should have empty facecolor initially
+    assert_array_almost_equal(CS.get_facecolor(),
+                               np.array([[0., 0., 0., 0.]]))
+
+    CS.set_color('k')
+    # After set_color, edgecolor should be black
+    ec = CS.get_edgecolor()
+    assert len(ec) == 1
+    assert_array_almost_equal(ec[0], [0., 0., 0., 1.])
+    # But facecolor should STILL be empty for unfilled contours
+    assert_array_almost_equal(CS.get_facecolor(),
+                               np.array([[0., 0., 0., 0.]]))
+
+
+def test_contour_set_color_filled():
+    """Test that set_color on filled contours changes both edge and face color."""
+    fig, ax = plt.subplots()
+    x = np.arange(-3.0, 3.0, 0.025)
+    y = np.arange(-2.0, 2.0, 0.025)
+    X, Y = np.meshgrid(x, y)
+    Z1 = np.exp(-X**2 - Y**2)
+    Z2 = np.exp(-(X - 1)**2 - (Y - 1)**2)
+    Z = (Z1 - Z2) * 2
+
+    CS = ax.contourf(X, Y, Z)
+    # Filled contours should have non-empty facecolor initially
+    assert not np.allclose(CS.get_facecolor(), 0)
+
+    orig_facecolors = CS.get_facecolor().copy()
+    CS.set_color('red')
+    # After set_color, edgecolor should be red
+    ec = CS.get_edgecolor()
+    assert len(ec) == 1
+    assert_array_almost_equal(ec[0], [1., 0., 0., 1.])
+    # And facecolor should also be red
+    fc = CS.get_facecolor()
+    assert len(fc) == 1
+    assert_array_almost_equal(fc[0], [1., 0., 0., 1.])
+
+
+def test_contour_set_colors_alias():
+    """Test that set_colors is an alias for set_color."""
+    fig, ax = plt.subplots()
+    CS = ax.contour([[0, 1], [2, 3]])
+    CS.set_colors('r')
+    ec = CS.get_edgecolor()
+    assert_array_almost_equal(ec[0], [1., 0., 0., 1.])


### PR DESCRIPTION
## Fixes matplotlib/matplotlib#31335

### Bug summary
Calling `CS.set_color('k')` on an unfilled contour incorrectly changed both the edgecolor AND facecolor, causing the interior of contour lines to be filled. For unfilled contours (the default), there is no face/area to fill — only the edge (contour line) color should change.

### Root cause
`ContourSet` inherits `Collection.set_color()`, which sets both `edgecolor` and `facecolor`. For unfilled contours, the facecolor should remain empty (no fill), but this inherited method was overwriting it with the same color.

### Fix
Override `set_color` in `ContourSet` to follow the `LineCollection` precedent:
- **Unfilled contours**: only set `edgecolor` (the contour lines)
- **Filled contours**: set both `edgecolor` and `facecolor`

This is consistent with the semantic meaning of "color of a contour" — for unfilled contours, the contour IS just lines, so only the line (edge) color should change.

### Changes
- `lib/matplotlib/contour.py`: Added `ContourSet.set_color()` override with filled/unfilled branching logic. Added `set_colors` alias for consistency.
- `lib/matplotlib/tests/test_contour.py`: Added `test_contour_set_color_unfilled`, `test_contour_set_color_filled`, and `test_contour_set_colors_alias`.

### Test
`pytest lib/matplotlib/tests/test_contour.py::test_contour_set_color_unfilled -v`