### PR TITLE
TST: Replace pywin32 with ctypes wrapper

### DIFF
--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -702,8 +702,11 @@ def _test_sigint_impl(backend, target_name, kwargs):
 
     def interrupter():
         if sys.platform == 'win32':
-            import win32api
-            win32api.GenerateConsoleCtrlEvent(0, 0)
+            from ctypes import windll, wintypes
+            GenerateConsoleCtrlEvent = windll.kernel32.GenerateConsoleCtrlEvent
+            GenerateConsoleCtrlEvent.argtypes = [wintypes.DWORD, wintypes.DWORD]
+            GenerateConsoleCtrlEvent.restype = wintypes.BOOL
+            GenerateConsoleCtrlEvent(0, 0)
         else:
             import signal
             os.kill(os.getpid(), signal.SIGINT)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,6 @@ test-extra = [
     "pandas!=0.25.0",
     "pikepdf",
     "pytz",
-    "pywin32; sys_platform == 'win32'",
     "xarray",
 ]
 


### PR DESCRIPTION
## PR summary

We only use `pywin32` for one function, and while taking care of all the wrapping is nice, it's easy to just take the information from the MSDN docs [1] and pass it through `ctypes` instead.

This avoids the dependency entirely, helping to fix package conflicts with pixi [2].

[1] https://learn.microsoft.com/en-us/windows/console/generateconsolectrlevent
[2] https://github.com/matplotlib/matplotlib/issues/30877#issuecomment-4114264540

## AI Disclosure
None

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines