### PR TITLE
ENH: Extend gouraud shading to support data at quadrilateral centers

### DIFF
--- a/doc/release/next_whats_new/pcolormesh_gouraud.rst
+++ b/doc/release/next_whats_new/pcolormesh_gouraud.rst
@@ -1,0 +1,52 @@
+``gouraud`` shading supports data at quadrilaterals centers
+-----------------------------------------------------------
+
+`~.Axes.pcolormesh` previously required data at the corners of
+quadrilaterals for ``gouraud`` shading. It now also supports data
+defined at the centers of quadrilaterals.
+
+This now allows `~.Axes.pcolormesh` to provide both constant and
+linearly interpolated shading for each data location.
+
+=============== ======== =====================
+..              constant linearly interpolated
+=============== ======== =====================
+data at corners nearest  gouraud
+data at centers flat     gouraud
+=============== ======== =====================
+
+Shading can be switched for the same data location, allowing
+switches between ``nearest`` and ``gouraud``, and now also
+between ``flat`` and ``gouraud``.
+
+For example:
+
+.. plot::
+    :include-source: true
+    :alt: Switching between constant and linearly interpolated shading for data at corners and centers.
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    nrows, ncols = 3, 5
+    Z = np.arange(nrows * ncols).reshape(nrows, ncols)
+    x = np.arange(ncols + 1)
+    y = np.arange(nrows + 1)
+
+    fig, axs = plt.subplots(2, 2, layout='constrained')
+
+    # Data at corners, requires X and Y the same shape as Z.
+    axs[0, 0].pcolormesh(x[:-1], y[:-1], Z, shading='nearest')
+    axs[0, 0].set_title('nearest: X, Y, Z same shape')
+
+    axs[0, 1].pcolormesh(x[:-1], y[:-1], Z, shading='gouraud')
+    axs[0, 1].set_title('gouraud: X, Y, Z same shape')
+
+    # Data at centers, requires X and Y one larger than Z.
+    axs[1, 0].pcolormesh(x, y, Z, shading='flat')
+    axs[1, 0].set_title('flat: X, Y one larger than Z')
+
+    axs[1, 1].pcolormesh(x, y, Z, shading='gouraud')
+    axs[1, 1].set_title('gouraud: X, Y one larger than Z')
+
+    plt.show()

--- a/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -108,13 +108,28 @@ _annotate(ax, x, y, "shading='auto'; X, Y one larger than Z (flat)")
 #
 # `Gouraud shading <https://en.wikipedia.org/wiki/Gouraud_shading>`_ can also
 # be specified, where the color in the quadrilaterals is linearly interpolated
-# between the grid points.  The shapes of *X*, *Y*, *Z* must be the same.
+# between the grid points. The data is specified at the corners of the
+# quadrilaterals, in which case *X*, *Y* and *Z* are all the same shape.
 
 fig, ax = plt.subplots(layout='constrained')
 x = np.arange(ncols)
 y = np.arange(nrows)
 ax.pcolormesh(x, y, Z, shading='gouraud', vmin=Z.min(), vmax=Z.max())
 _annotate(ax, x, y, "shading='gouraud'; X, Y same shape as Z")
+
+# %%
+# Gouraud Shading, one larger grid
+# --------------------------------
+# In some cases, the user has data defined at the centers of the quadrilaterals
+# with *X* and *Y* one larger than *Z*. ``shading='gouraud'`` also supports
+# this, and automatically converts the grid to match the shape of *Z*
+# by replacing each quadrilateral with a single point at its center.
+
+fig, ax = plt.subplots(layout='constrained')
+x = np.arange(ncols + 1)
+y = np.arange(nrows + 1)
+ax.pcolormesh(x, y, Z, shading='gouraud', vmin=Z.min(), vmax=Z.max())
+_annotate(ax, x, y, "shading='gouraud'; X, Y one larger than Z")
 
 plt.show()
 # %%

--- a/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -120,10 +120,11 @@ _annotate(ax, x, y, "shading='gouraud'; X, Y same shape as Z")
 # %%
 # Gouraud Shading, one larger grid
 # --------------------------------
+#
 # In some cases, the user has data defined at the centers of the quadrilaterals
 # with *X* and *Y* one larger than *Z*. ``shading='gouraud'`` also supports
-# this, and automatically converts the grid to match the shape of *Z*
-# by replacing each quadrilateral with a single point at its center.
+# this by using the grid quadrilateral centers as the corners of each colored
+# quadrilateral.
 
 fig, ax = plt.subplots(layout='constrained')
 x = np.arange(ncols + 1)

--- a/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
+++ b/galleries/examples/images_contours_and_fields/pcolormesh_grids.py
@@ -124,7 +124,7 @@ _annotate(ax, x, y, "shading='gouraud'; X, Y same shape as Z")
 # In some cases, the user has data defined at the centers of the quadrilaterals
 # with *X* and *Y* one larger than *Z*. ``shading='gouraud'`` also supports
 # this by using the grid quadrilateral centers as the corners of each colored
-# quadrilateral.
+# quadrilateral. This contracts the pseudocolor plot by half a grid cell.
 
 fig, ax = plt.subplots(layout='constrained')
 x = np.arange(ncols + 1)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6829,7 +6829,7 @@ or pandas.DataFrame
             If ``shading='gouraud'`` the dimensions of *X* and *Y* should be
             the same as those of *C* or be one greater than those of *C*,
             otherwise a TypeError is raised. If the dimensions of *X* and *Y*
-            are one greater, they are automatically converted to match the shape
+            are one greater, they are internally converted to match the shape
             of *C* by replacing each quadrilateral with a point at its center,
             computed as the average of their four corners. In both cases a
             smooth interpolation is carried out between the quadrilateral corners.
@@ -6871,11 +6871,15 @@ or pandas.DataFrame
             - 'nearest': Each grid point will have a color centered on it,
               extending halfway between the adjacent grid centers.  The
               dimensions of *X* and *Y* must be the same as *C*.
-            - 'gouraud': Each quad will be Gouraud shaded: The color of the
-              corners (i', j') are given by ``C[i', j']``. The color values of
-              the area in between is interpolated from the corner values.
-              If the dimensions of *X* and *Y* are one greater, the grid is
-              automatically converted to match the shape of *C*.
+            - 'gouraud': If the mesh data is defined at the corners of grid
+              quadrilaterals, with *X*, *Y* and *C* having the same dimensions,
+              each grid quad will be Gouraud shaded. If the color values
+              are specified at the centers of grid quadrilaterals, *X* and *Y*
+              have dimensions one greater than those of *C*, and each colored
+              quadrilateral will use the grid quad centers as its corners, so
+              that it can be Gouraud shaded: The color of the corners (i', j')
+              are given by ``C[i', j']``, and the color values of the area
+              in between are interpolated from the corner values.
               When Gouraud shading is used, *edgecolors* is ignored.
             - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
               larger than *C*.  Choose 'nearest' if dimensions are the same.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6523,9 +6523,13 @@ or pandas.DataFrame
                                 f" see help({funcname})")
         else:    # ['nearest', 'gouraud']:
             if (Nx, Ny) != (ncols, nrows):
-                raise TypeError('Dimensions of C %s are incompatible with'
-                                ' X (%d) and/or Y (%d); see help(%s)' % (
-                                    C.shape, Nx, Ny, funcname))
+                if shading == 'gouraud' and (Nx, Ny) == (ncols + 1, nrows + 1):
+                    # the center of each quad is the average of its four corners
+                    X = 0.25 * (X[:-1, :-1] + X[:-1, 1:] + X[1:, 1:] + X[1:, :-1])
+                    Y = 0.25 * (Y[:-1, :-1] + Y[:-1, 1:] + Y[1:, 1:] + Y[1:, :-1])
+                else:
+                    raise TypeError(f"Dimensions of C {C.shape} are incompatible with"
+                                    f" X ({Nx}) and/or Y ({Ny}); see help({funcname})")
             if shading == 'nearest':
                 # grid is specified at the center, so define corners
                 # at the midpoints between the grid centers and then use the
@@ -6818,11 +6822,17 @@ or pandas.DataFrame
             greater than those of *C*, otherwise a TypeError is raised. The
             quadrilateral is colored due to the value at ``C[i, j]``.
 
-            If ``shading='nearest'`` or ``'gouraud'``, the dimensions of *X*
-            and *Y* should be the same as those of *C* (if not, a TypeError
-            will be raised).  For ``'nearest'`` the color ``C[i, j]`` is
-            centered on ``(X[i, j], Y[i, j])``.  For ``'gouraud'``, a smooth
-            interpolation is carried out between the quadrilateral corners.
+            If ``shading='nearest'`` the dimensions of *X* and *Y* should be
+            the same as those of *C*, otherwise a TypeError is raised. The
+            color ``C[i, j]`` is centered on ``(X[i, j], Y[i, j])``.
+
+            If ``shading='gouraud'`` the dimensions of *X* and *Y* should be
+            the same as those of *C* or be one greater than those of *C*,
+            otherwise a TypeError is raised. If the dimensions of *X* and *Y*
+            are one greater, they are automatically converted to match the shape
+            of *C* by replacing each quadrilateral with a point at its center,
+            computed as the average of their four corners. In both cases a
+            smooth interpolation is carried out between the quadrilateral corners.
 
             If *X* and/or *Y* are 1-D arrays or column vectors they will be
             expanded as needed into the appropriate 2D arrays, making a
@@ -6864,8 +6874,9 @@ or pandas.DataFrame
             - 'gouraud': Each quad will be Gouraud shaded: The color of the
               corners (i', j') are given by ``C[i', j']``. The color values of
               the area in between is interpolated from the corner values.
-              The dimensions of *X* and *Y* must be the same as *C*. When
-              Gouraud shading is used, *edgecolors* is ignored.
+              If the dimensions of *X* and *Y* are one greater, the grid is
+              automatically converted to match the shape of *C*.
+              When Gouraud shading is used, *edgecolors* is ignored.
             - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
               larger than *C*.  Choose 'nearest' if dimensions are the same.
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1644,13 +1644,17 @@ def test_pcolormesh_switching_shadings():
 
 @check_figures_equal()
 def test_pcolormesh_gouraud_grid_conversion(fig_test, fig_ref):
+    # For X and Y one dimension greater than Z, gouraud converts the
+    # grid representation to match the data shape, by using quad centers.
     Z = np.arange(6).reshape(2, 3)
 
+    # One larger than Z in each dimension.
     x_test = np.array([0, 2, 8, 12])
     y_test = np.array([0, 2, 6])
     ax_test = fig_test.subplots()
     ax_test.pcolormesh(x_test, y_test, Z, shading='gouraud')
 
+    # Same shape as Z.
     x_ref = np.array([1, 5, 10])
     y_ref = np.array([1, 4])
     ax_ref = fig_ref.subplots()

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1623,6 +1623,40 @@ def test_pcolor_log_scale(fig_test, fig_ref):
     ax.set_xscale('log')
 
 
+def test_pcolormesh_switching_shadings():
+    nrows, ncols = 3, 4
+    Z = np.arange(nrows * ncols).reshape(nrows, ncols)
+    x = np.arange(ncols + 1)
+    y = np.arange(nrows + 1)
+
+    _, ax = plt.subplots()
+
+    ax.pcolormesh(x, y, Z, shading='flat')
+    ax.pcolormesh(x, y, Z, shading='gouraud')
+    with pytest.raises(TypeError):
+        ax.pcolormesh(x, y, Z, shading='nearest')
+
+    ax.pcolormesh(x[:-1], y[:-1], Z, shading='nearest')
+    ax.pcolormesh(x[:-1], y[:-1], Z, shading='gouraud')
+    with pytest.raises(TypeError):
+        ax.pcolormesh(x[:-1], y[:-1], Z, shading='flat')
+
+
+@check_figures_equal()
+def test_pcolormesh_gouraud_grid_conversion(fig_test, fig_ref):
+    Z = np.arange(6).reshape(2, 3)
+
+    x_test = np.array([0, 2, 8, 12])
+    y_test = np.array([0, 2, 6])
+    ax_test = fig_test.subplots()
+    ax_test.pcolormesh(x_test, y_test, Z, shading='gouraud')
+
+    x_ref = np.array([1, 5, 10])
+    y_ref = np.array([1, 4])
+    ax_ref = fig_ref.subplots()
+    ax_ref.pcolormesh(x_ref, y_ref, Z, shading='gouraud')
+
+
 def test_pcolorargs():
     n = 12
     x = np.linspace(-1.5, 1.5, n)
@@ -1636,9 +1670,9 @@ def test_pcolorargs():
     with pytest.raises(TypeError):
         ax.pcolormesh(X, Y, Z.T)
     with pytest.raises(TypeError):
-        ax.pcolormesh(x, y, Z[:-1, :-1], shading="gouraud")
+        ax.pcolormesh(x, y, Z[:-2, :-2], shading='gouraud')
     with pytest.raises(TypeError):
-        ax.pcolormesh(X, Y, Z[:-1, :-1], shading="gouraud")
+        ax.pcolormesh(X, Y, Z[:-2, :-2], shading='gouraud')
     x[0] = np.nan
     with pytest.raises(ValueError):
         ax.pcolormesh(x, y, Z[:-1, :-1])


### PR DESCRIPTION
## PR summary

This PR extends the `gouraud` shading in `Axes.pcolormesh` to support data defined at the centers of quadrilaterals, where X and Y are one larger than Z in each dimension. In this situation, `gouraud` automatically converts the grid internally to match the data's shape by replacing each quadrilateral with a point at its center, computed as the average of its four corners, and then applies Gouraud shading.

- Why is this change necessary / what problem does it solve?

    `pcolormesh` with `shading='gouraud'` requires the data to be defined at the corners of quadrilaterals, meaning X, Y and Z must have the same shape. If the user is working with data defined at the centers, so that X and Y are one larger in each dimension, and tries to use `shading='gouraud'` for a smooth color interpolation, a TypeError is raised.

    This now allows `pcolormesh` to provide both constant and linearly interpolated shading for each data/grid configuration. Shading can be switched for the same data location, allowing switches between nearest and gouraud, and now also between flat and gouraud.
    |                 | constant  | linearly interpolated         |
    |-----------------|-----------|--------------------|
    | data at grid quad corners (*X*, *Y*, *Z* same shape) | `nearest` | `gouraud` |
    | data at grid quad centers (*X*, *Y* one larger than *Z*) | `flat` | `gouraud` |

- What is the reasoning for this implementation?

    Following discussion on the [issue](https://github.com/matplotlib/matplotlib/issues/8422) and in this PR, the approach taken is to extend the existing `gouraud` shading.

    **Edit**: The initial version of this PR introduced a new shading, called `centered-gouraud`, in `pcolormesh`. This shading was a variant of `gouraud` dedicated to handle the case of data defined at quadrilateral centers (with X and Y one larger than Z), by performing the same grid conversion described above. Following discussion in this PR, the approach was revised to extend the existing `gouraud` shading instead.

### Example

```py
nrows, ncols = 3, 5
Z = np.arange(nrows * ncols).reshape(nrows, ncols)
x = np.arange(ncols + 1)
y = np.arange(nrows + 1)

_, axs = plt.subplots(2, 2, layout='constrained')

# Data at corners, requires X and Y the same shape as Z.
axs[0, 0].pcolormesh(x[:-1], y[:-1], Z, shading='nearest')
axs[0, 1].pcolormesh(x[:-1], y[:-1], Z, shading='gouraud')

# Data at centers, requires X and Y one larger than Z.
axs[1, 0].pcolormesh(x, y, Z, shading='flat')
axs[1, 1].pcolormesh(x, y, Z, shading='gouraud') # works now
```

<img width="640" height="480" alt="pcolormesh_shadings" src="https://github.com/user-attachments/assets/5ed1d3e6-97de-44a6-905a-6aad7e37d3ee" />

<br>

Closes #8422

## AI Disclosure

I used AI tools to help proofread and improve the grammar of this PR description. The code logic and implementation are my own.

## PR checklist

- [X] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [X] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [X] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines