### PR TITLE
Add thumbnail number for packed_bubbles example

### DIFF
--- a/galleries/examples/misc/packed_bubbles.py
+++ b/galleries/examples/misc/packed_bubbles.py
@@ -13,6 +13,7 @@ browsers.
 
 import matplotlib.pyplot as plt
 import numpy as np
+# sphinx_gallery_thumbnail_number = 1
 
 browser_market_share = {
     'browsers': ['firefox', 'chrome', 'safari', 'edge', 'ie', 'opera'],


### PR DESCRIPTION
This PR adds a sphinx_gallery_thumbnail_number directive to the packed_bubbles example to ensure a proper thumbnail is displayed in the gallery.

Fixes missing thumbnail for this example.