### PR TITLE
ps/pdf: Override font height metrics to support AFM files

### DIFF
--- a/lib/matplotlib/_afm.py
+++ b/lib/matplotlib/_afm.py
@@ -478,9 +478,17 @@ class AFM:
         """Return the fontangle as float."""
         return self._header['ItalicAngle']
 
+    def get_ascender(self) -> float:
+        """Return the ascent as float."""
+        return self._header['Ascender']
+
     def get_capheight(self) -> float:
         """Return the cap height as float."""
         return self._header['CapHeight']
+
+    def get_descender(self) -> float:
+        """Return the descent as float."""
+        return self._header['Descender']
 
     def get_xheight(self) -> float:
         """Return the xheight as float."""

--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -348,6 +348,32 @@ class RendererPDFPSBase(RendererBase):
         # docstring inherited
         return self.width * 72.0, self.height * 72.0
 
+    def _get_font_height_metrics(self, prop):
+        """
+        Return the ascent, descent, and line gap for font described by *prop*.
+
+        TODO: This is a temporary method until we design a proper API for the backends.
+
+        Parameters
+        ----------
+        prop : `.font_manager.FontProperties`
+            The properties describing the font to measure.
+
+        Returns
+        -------
+        ascent, descent, line_gap : float or None
+            The ascent, descent and line gap of the determined font, or None to fall
+            back to normal measurements.
+        """
+        if not mpl.rcParams[self._use_afm_rc_name]:
+            return None, None, None
+        font = self._get_font_afm(prop)
+        scale = prop.get_size_in_points() / 1000
+        a = font.get_ascender() * scale
+        d = -font.get_descender() * scale
+        g = (a + d) * 0.2  # Preserve previous line spacing of 1.2.
+        return a, d, g
+
     def get_text_width_height_descent(self, s, prop, ismath):
         # docstring inherited
         if ismath == "TeX":

--- a/lib/matplotlib/tests/baseline_images/test_backend_pdf/pdf_use14corefonts.pdf
+++ b/lib/matplotlib/tests/baseline_images/test_backend_pdf/pdf_use14corefonts.pdf
@@ -1,23 +1,23 @@
 %PDF-1.4
 %¬Ü «º
 1 0 obj
-<< /Pages 2 0 R /Type /Catalog >>
+<< /Type /Catalog /Pages 2 0 R >>
 endobj
 8 0 obj
-<< /ExtGState 4 0 R /Font 3 0 R /Pattern 5 0 R
-/ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] /Shading 6 0 R
-/XObject 7 0 R >>
+<< /Font 3 0 R /XObject 7 0 R /ExtGState 4 0 R /Pattern 5 0 R
+/Shading 6 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ] >>
 endobj
-10 0 obj
-<< /Annots [ ] /Contents 9 0 R
-/Group << /CS /DeviceRGB /S /Transparency /Type /Group >>
-/MediaBox [ 0 0 576 432 ] /Parent 2 0 R /Resources 8 0 R /Type /Page >>
+11 0 obj
+<< /Type /Page /Parent 2 0 R /Resources 8 0 R /MediaBox [ 0 0 576 432 ]
+/Contents 9 0 R /Annots 10 0 R >>
 endobj
 9 0 obj
-<< /Length 11 0 R >>
+<< /Length 12 0 R >>
 stream
+/DeviceRGB CS
+/DeviceRGB cs
 1 j
-1 g 0 j 0 w [ ] 0 d 1 G 1 g
+1 g 0 j 0 w 1 G 1 g
 0 0 m
 576 0 l
 576 432 l
@@ -33,8 +33,7 @@ f
 h
 
 f
-q 72 43.2 446.4 345.6 re W n /A2 gs 2 J 1 j 0.5 w [ ] 0 d 0 0 1 RG
-/DeviceRGB cs
+q 72 43.2 446.4 345.6 re W n /A2 gs 2 J 1 j 0.5 w 0 0 1 RG /DeviceRGB cs
 72 216 m
 518.4 216 l
 
@@ -56,7 +55,7 @@ S
 518.4 388.8 l
 
 S
-/A2 gs 0 J 0 g 1 j 0.5 w [ ] 0 d 0 g
+0 J 0 g 1 j 0.5 w 0 g
 72 43.2 m
 72 47.2 l
 
@@ -65,11 +64,11 @@ B
 72 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 66.44 33.456 Td
 (0.0) Tj ET
-/A2 gs 0.5 w
+0.5 w
 161.28 43.2 m
 161.28 47.2 l
 
@@ -78,11 +77,11 @@ B
 161.28 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 155.72 33.456 Td
 (0.2) Tj ET
-/A2 gs 0.5 w
+0.5 w
 250.56 43.2 m
 250.56 47.2 l
 
@@ -91,11 +90,11 @@ B
 250.56 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 245 33.456 Td
 (0.4) Tj ET
-/A2 gs 0.5 w
+0.5 w
 339.84 43.2 m
 339.84 47.2 l
 
@@ -104,11 +103,11 @@ B
 339.84 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 334.28 33.456 Td
 (0.6) Tj ET
-/A2 gs 0.5 w
+0.5 w
 429.12 43.2 m
 429.12 47.2 l
 
@@ -117,11 +116,11 @@ B
 429.12 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 423.56 33.456 Td
 (0.8) Tj ET
-/A2 gs 0.5 w
+0.5 w
 518.4 43.2 m
 518.4 47.2 l
 
@@ -130,11 +129,11 @@ B
 518.4 384.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 512.84 33.456 Td
 (1.0) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 43.2 m
 76 43.2 l
 
@@ -143,11 +142,11 @@ B
 514.4 43.2 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 40.328 Td
 (0.0) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 112.32 m
 76 112.32 l
 
@@ -156,11 +155,11 @@ B
 514.4 112.32 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 109.448 Td
 (0.2) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 181.44 m
 76 181.44 l
 
@@ -169,11 +168,11 @@ B
 514.4 181.44 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 178.568 Td
 (0.4) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 250.56 m
 76 250.56 l
 
@@ -182,11 +181,11 @@ B
 514.4 250.56 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 247.688 Td
 (0.6) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 319.68 m
 76 319.68 l
 
@@ -195,11 +194,11 @@ B
 514.4 319.68 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 316.808 Td
 (0.8) Tj ET
-/A2 gs 0.5 w
+0.5 w
 72 388.8 m
 76 388.8 l
 
@@ -208,18 +207,18 @@ B
 514.4 388.8 l
 
 B
-/A2 gs 1 w
+1 w
 BT /F1 8 Tf
 56.88 385.928 Td
 (1.0) Tj ET
 BT /F1 14 Tf
-145.253 256.8212 Td
+145.253 257.979 Td
 (A three-line text positioned just above a blue line) Tj ET
 BT /F1 14 Tf
-105.332 241.8188 Td
+105.332 242.397 Td
 (and containing some French characters and the euro symbol:) Tj ET
 BT /F1 14 Tf
-213.195 218.898 Td
+213.195 220.193 Td
 ("Merci pépé pour les 10 €") Tj ET
 BT /F1 9.6 Tf
 185.7648 393.8 Td
@@ -228,19 +227,22 @@ Q
 
 endstream
 endobj
-11 0 obj
-2245
-endobj
 12 0 obj
-<< /BaseFont /Helvetica /Encoding /WinAnsiEncoding /Subtype /Type1
-/Type /Font >>
+2079
+endobj
+10 0 obj
+[ ]
+endobj
+13 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica
+/Encoding /WinAnsiEncoding >>
 endobj
 3 0 obj
-<< /F1 12 0 R >>
+<< /F1 13 0 R >>
 endobj
 4 0 obj
-<< /A1 << /CA 0 /Type /ExtGState /ca 1 >>
-/A2 << /CA 1 /Type /ExtGState /ca 1 >> >>
+<< /A1 << /Type /ExtGState /CA 0 /ca 1 >>
+/A2 << /Type /ExtGState /CA 1 /ca 1 >> >>
 endobj
 5 0 obj
 << >>
@@ -252,31 +254,30 @@ endobj
 << >>
 endobj
 2 0 obj
-<< /Count 1 /Kids [ 10 0 R ] /Type /Pages >>
+<< /Type /Pages /Kids [ 11 0 R ] /Count 1 >>
 endobj
-13 0 obj
-<< /CreationDate (D:20160912125131+03'00')
-/Creator (matplotlib 2.0.0b4.post2053.dev0+g440adff, http://matplotlib.org)
-/Producer (matplotlib pdf backend) >>
+14 0 obj
+<< >>
 endobj
 xref
-0 14
+0 15
 0000000000 65535 f 
 0000000016 00000 n 
-0000002997 00000 n 
-0000002803 00000 n 
-0000002835 00000 n 
-0000002934 00000 n 
-0000002955 00000 n 
-0000002976 00000 n 
+0000002796 00000 n 
+0000002602 00000 n 
+0000002634 00000 n 
+0000002733 00000 n 
+0000002754 00000 n 
+0000002775 00000 n 
 0000000065 00000 n 
-0000000385 00000 n 
+0000000330 00000 n 
+0000002484 00000 n 
 0000000208 00000 n 
-0000002684 00000 n 
-0000002705 00000 n 
-0000003057 00000 n 
+0000002463 00000 n 
+0000002504 00000 n 
+0000002856 00000 n 
 trailer
-<< /Info 13 0 R /Root 1 0 R /Size 14 >>
+<< /Size 15 /Root 1 0 R /Info 14 0 R >>
 startxref
-3230
+2878
 %%EOF

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -437,22 +437,29 @@ class Text(Artist):
         dpi = self.get_figure(root=True).dpi
         # Determine full vertical extent of font, including ascenders and descenders:
         if not self.get_usetex():
-            font = get_font(fontManager._find_fonts_by_props(self._fontproperties))
-            possible_metrics = [
-                ('OS/2', 'sTypoLineGap', 'sTypoAscender', 'sTypoDescender'),
-                ('hhea', 'lineGap', 'ascent', 'descent')
-            ]
-            for table_name, linegap_key, ascent_key, descent_key in possible_metrics:
-                table = font.get_sfnt_table(table_name)
-                if table is None:
-                    continue
-                # Rescale to font size/DPI if the metrics were available.
-                fontsize = self._fontproperties.get_size_in_points()
-                units_per_em = font.get_sfnt_table('head')['unitsPerEm']
-                line_gap = table[linegap_key] / units_per_em * fontsize * dpi / 72
-                min_ascent = table[ascent_key] / units_per_em * fontsize * dpi / 72
-                min_descent = -table[descent_key] / units_per_em * fontsize * dpi / 72
-                break
+            if hasattr(renderer, '_get_font_height_metrics'):
+                # TODO: This is a temporary internal method call (for _backend_pdf_ps to
+                # support AFM files) until we design a proper API for the backends.
+                min_ascent, min_descent, line_gap = renderer._get_font_height_metrics(
+                    self._fontproperties)
+            if min_ascent is None:
+                font = get_font(fontManager._find_fonts_by_props(self._fontproperties))
+                possible = [
+                    ('OS/2', 'sTypoLineGap', 'sTypoAscender', 'sTypoDescender'),
+                    ('hhea', 'lineGap', 'ascent', 'descent')
+                ]
+                for table_name, linegap_key, ascent_key, descent_key in possible:
+                    table = font.get_sfnt_table(table_name)
+                    if table is None:
+                        continue
+                    # Rescale to font size/DPI if the metrics were available.
+                    fontsize = self._fontproperties.get_size_in_points()
+                    units_per_em = font.get_sfnt_table('head')['unitsPerEm']
+                    scale = 1 / units_per_em * fontsize * dpi / 72
+                    line_gap = table[linegap_key] * scale
+                    min_ascent = table[ascent_key] * scale
+                    min_descent = -table[descent_key] * scale
+                    break
         if None in (min_ascent, min_descent):
             # Fallback to font measurement.
             _, h, min_descent = _get_text_metrics_with_cache(


### PR DESCRIPTION
## PR summary

When outputting files using the "core 14 fonts" (e.g., `rcParams['pdf.use14corefonts'] = True`), text will be measured using our internal AFM files instead of any external files.

While we don't have a full API decided for how to pass full `Text` objects through backends, add in a small internal helper to allow the PS/PDF backends to override font height metrics with the AFM files.

Note, because there is still some small difference in how we calculated line spacing, there is some small difference in the result from before. But it no longer changes results depending on whether Helvetica is installed globally.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines