### PR TITLE
Add thumbnail directive to zorder_demo example

### DIFF
--- a/galleries/examples/misc/zorder_demo.py
+++ b/galleries/examples/misc/zorder_demo.py
@@ -34,6 +34,7 @@ their relative zorder.
 
 import matplotlib.pyplot as plt
 import numpy as np
+# sphinx_gallery_thumbnail_number = 1
 
 r = np.linspace(0.3, 1, 30)
 theta = np.linspace(0, 4*np.pi, 30)


### PR DESCRIPTION
This PR adds a sphinx_gallery_thumbnail_number directive to the zorder_demo example to ensure a representative thumbnail is displayed correctly in the gallery.