### PR TITLE
MNT: account for changes in setuptools-scm

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -227,7 +227,7 @@ def _get_version():
             return setuptools_scm.get_version(
                 root=root,
                 dist_name="matplotlib",
-                version_scheme="release-branch-semver",
+                version_scheme="semver-pep440-release-branch",
                 local_scheme="node-and-date",
                 fallback_version=_version.version,
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ requires = [
 install = ['--tags=data,python-runtime,runtime']
 
 [tool.setuptools_scm]
-version_scheme = "release-branch-semver"
+version_scheme = "semver-pep440-release-branch"
 local_scheme = "node-and-date"
 parentdir_prefix_version = "matplotlib-"
 fallback_version = "0.0+UNKNOWN"


### PR DESCRIPTION
Names changed in https://github.com/pypa/setuptools-scm/pull/1276

This fixes a warning, however may require us to push our min setuptools-scm up or put a hard cap on it until it has been out long enough that we are willing to push the min version up.

We can version-gate the call in `__init__.py`, but I don't know of anyway to version gate the usage in pyproject.toml.