### PR TITLE
Fix outdated savannah URL in freetype-2.6.1.wrap

### DIFF
--- a/subprojects/freetype-2.6.1.wrap
+++ b/subprojects/freetype-2.6.1.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
+source_url = https://download.savannah.nongnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
 source_fallback_url = https://downloads.sourceforge.net/project/freetype/freetype2/2.6.1/freetype-2.6.1.tar.gz
 source_filename = freetype-2.6.1.tar.gz
 source_hash = 0a3c7dfbda6da1e8fce29232e8e96d987ababbbf71ebc8c75659e4132c367014


### PR DESCRIPTION
## Fix: Update outdated savannah URL

### Bug
The URL  returns HTTP 502 Bad Gateway, causing matplotlib builds from source to fail.

### Fix
Changed  to  which resolves correctly.

### Testing
Verified the new URL works with wget and returns HTTP 200.

Fixes #31340