### PR TITLE
Tweak Formatter method docstrings.

### DIFF
--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -206,13 +206,18 @@ class Formatter(TickHelper):
 
     def __call__(self, x, pos=None):
         """
-        Return the format for tick value *x* at position pos.
+        Return the format for tick value *x* at index *pos*.
         ``pos=None`` indicates an unspecified location.
         """
         raise NotImplementedError('Derived must override')
 
     def format_ticks(self, values):
-        """Return the tick labels for all the ticks at once."""
+        """
+        Return the tick labels strings for all *values*.
+
+        This method is the public API to generate a meaningful format for a set
+        of values, e.g. by ensuring an appropriate precision.
+        """
         self.set_locs(values)
         return [self(value, i) for i, value in enumerate(values)]
 
@@ -225,9 +230,13 @@ class Formatter(TickHelper):
 
     def format_data_short(self, value):
         """
-        Return a short string version of the tick value.
+        Return the mouseover-text representation of a value.
 
-        Defaults to the position-independent long value.
+        This defaults to the representation returned by `.Formatter.format_data`,
+        but subclasses may override this.
+
+        Note: The mouseover text can be customized by setting the
+        ``Axes.fmt_xdata`` and ``Axes.fmt_ydata`` attributes.
         """
         return self.format_data(value)
 


### PR DESCRIPTION
In particular, make it explicit which methods are used for what purpose.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
