### PR TITLE
BLD: Temporarily pin setuptools-scm<10

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,7 +28,7 @@ dependencies:
   - pyqt
   - python>=3.11
   - python-dateutil>=2.1
-  - setuptools_scm
+  - setuptools_scm<10
   - wxpython
   # building documentation
   - colorspacious

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ requires = [
     # you really need it and aren't using an sdist.
     "meson-python>=0.13.1,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
-    "setuptools_scm>=7",
+    "setuptools_scm>=7,<10",
 ]
 
 [dependency-groups]
@@ -80,7 +80,7 @@ build = [
     # Should be the same as `[build-system] requires` above.
     "meson-python>=0.13.1,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
-    "setuptools_scm>=7",
+    "setuptools_scm>=7,<10",
     # Not required by us but setuptools_scm without a version, so _if_
     # installed, then setuptools_scm 8 requires at least this version.
     # Unfortunately, we can't do a sort of minimum-if-installed dependency, so


### PR DESCRIPTION
## PR summary

This is currently causing warnings at runtime in the editable install, which breaks almost all tests.

We'll need this until at least pypa/setuptools-scm#1314 is fixed, or we come up with a better fix.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines