### PR TITLE
BLD: Update bundled FreeType to 2.14.3

### DIFF
--- a/subprojects/freetype2.wrap
+++ b/subprojects/freetype2.wrap
@@ -3,7 +3,7 @@
 # in `.circleci/config.yml` when changing requirements.
 [wrap-file]
 directory = freetype-2.14.3
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-2.14.3.tar.xz
+source_url = https://download.savannah.nongnu.org/releases/freetype/freetype-2.14.3.tar.xz
 source_fallback_url = https://downloads.sourceforge.net/project/freetype/freetype2/2.14.3/freetype-2.14.3.tar.xz
 source_filename = freetype-2.14.3.tar.xz
 source_hash = 36bc4f1cc413335368ee656c42afca65c5a3987e8768cc28cf11ba775e785a5f


### PR DESCRIPTION
## PR summary

These releases mostly consist of security fixes.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines