### PR TITLE
MNT: Minor cleanup of label formatting in PathCollection.legend_elements

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -1271,7 +1271,15 @@ class PathCollection(_CollectionWithSizes):
               "alpha": self.get_alpha(),
               **kwargs}
 
-        for val, lab in zip(values, label_values):
+        # Pre-format all labels
+        # TODO: check whether we can switch to
+        #       formatted_labels = fmt.format_ticks(label_values)
+        #       There are subtle differences for some formatters as that passes the
+        #       indices to __call__ as well.
+        fmt.set_locs(label_values)
+        formatted_labels = [fmt(lab) for lab in label_values]
+
+        for val, formatted in zip(values, formatted_labels):
             if prop == "colors":
                 color = self.cmap(self.norm(val))
             elif prop == "sizes":
@@ -1281,10 +1289,7 @@ class PathCollection(_CollectionWithSizes):
             h = mlines.Line2D([0], [0], ls="", color=color, ms=size,
                               marker=self.get_paths()[0], **kw)
             handles.append(h)
-            if hasattr(fmt, "set_locs"):
-                fmt.set_locs(label_values)
-            l = fmt(lab)
-            labels.append(l)
+            labels.append(formatted)
 
         return handles, labels
 


### PR DESCRIPTION
This pulls the label formatting out of the loop, so that we don't have to do set_locs() for every label.

Note that `fmt` is a `Formatter` and thus always has `set_locs()`.

As written in the note, I would like to simplify to `fmt.format_ticks(label_values)`, but that has subtly different semantics, e.g. in possibly considering an offsetText. Such a change would require a deeper understanding of the formatter logic.
