### PR TITLE
Backport PR #31401: BLD: Temporarily pin setuptools-scm<10

### DIFF
--- a/.github/workflows/cygwin.yml
+++ b/.github/workflows/cygwin.yml
@@ -181,7 +181,7 @@ jobs:
           export PATH="/usr/local/bin:$PATH"
           python -m pip install --no-build-isolation 'contourpy>=1.0.1'
           python -m pip install --upgrade cycler fonttools \
-              packaging pyparsing python-dateutil setuptools-scm \
+              packaging pyparsing python-dateutil 'setuptools-scm<10' \
               -r requirements_test.txt sphinx ipython
           python -m pip install --upgrade pycairo 'cairocffi>=0.8' PyGObject &&
              python -c 'import gi; gi.require_version("Gtk", "3.0"); from gi.repository import Gtk' &&

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,7 +243,7 @@ jobs:
           # Preinstall build requirements to enable no-build-isolation builds.
           python -m pip install --upgrade $PRE \
             'contourpy>=1.0.1' cycler fonttools kiwisolver importlib_resources \
-            packaging pillow 'pyparsing!=3.1.0' python-dateutil setuptools-scm \
+            packaging pillow 'pyparsing!=3.1.0' python-dateutil 'setuptools-scm<10' \
             'meson-python>=0.13.1' 'pybind11>=2.13.2' \
             -r requirements/testing/all.txt \
             ${{ matrix.extra-requirements }}

--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,7 @@ dependencies:
   - pyqt
   - python>=3.10
   - python-dateutil>=2.1
-  - setuptools_scm
+  - setuptools_scm<10
   - wxpython
   # building documentation
   - colorspacious

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ requires-python = ">=3.10"
 dev = [
     "meson-python>=0.13.1,<0.17.0",
     "pybind11>=2.13.2,!=2.13.3",
-    "setuptools_scm>=7",
+    "setuptools_scm>=7,<10",
     # Not required by us but setuptools_scm without a version, cso _if_
     # installed, then setuptools_scm 8 requires at least this version.
     # Unfortunately, we can't do a sort of minimum-if-instaled dependency, so
@@ -74,7 +74,7 @@ build-backend = "mesonpy"
 requires = [
     "meson-python>=0.13.1,<0.17.0",
     "pybind11>=2.13.2,!=2.13.3",
-    "setuptools_scm>=7",
+    "setuptools_scm>=7,<10",
 ]
 
 [tool.meson-python.args]

--- a/requirements/dev/build-requirements.txt
+++ b/requirements/dev/build-requirements.txt
@@ -1,3 +1,3 @@
 pybind11>=2.13.2,!=2.13.3
 meson-python
-setuptools-scm
+setuptools-scm<10

--- a/requirements/testing/mypy.txt
+++ b/requirements/testing/mypy.txt
@@ -22,5 +22,5 @@ packaging>=20.0
 pillow>=8
 pyparsing>=3
 python-dateutil>=2.7
-setuptools_scm>=7
+setuptools_scm>=7,<10
 setuptools>=64


### PR DESCRIPTION
Manual backport of #31401.  The conflict was because the bugfix branch does not have #29281, so we need to pin in slightly different places.