### PR TITLE
Fix outdated Savannah URL for freetype download

### DIFF
--- a/subprojects/freetype-2.6.1.wrap
+++ b/subprojects/freetype-2.6.1.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-source_url = https://download.savannah.gnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
+source_url = https://download.savannah.nongnu.org/releases/freetype/freetype-old/freetype-2.6.1.tar.gz
 source_fallback_url = https://downloads.sourceforge.net/project/freetype/freetype2/2.6.1/freetype-2.6.1.tar.gz
 source_filename = freetype-2.6.1.tar.gz
 source_hash = 0a3c7dfbda6da1e8fce29232e8e96d987ababbbf71ebc8c75659e4132c367014


### PR DESCRIPTION
Fixes an outdated Savannah URL in subprojects/freetype-2.6.1.wrap.

The previous URL returned a 502 error. Updated it to use the working
savannah.nongnu.org mirror.

Closes #31340.
