### PR TITLE
Improve legend loc and bbox_to_anchor documentation (#26620)

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -121,9 +121,6 @@ bbox_to_anchor : `.BboxBase`, 2-tuple, or 4-tuple of floats
 
         loc='upper right', bbox_to_anchor=(0.5, 0.5)
 
-    For placing the legend outside the Axes, see
-    `.Figure.legend`, which supports ``'outside right upper'``
-    and similar location strings.
     For more details on legend positioning, see the
     :ref:`legend_guide`.
 

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -98,9 +98,12 @@ class DraggableLegend(DraggableOffsetBox):
 _legend_kw_doc_base = """
 bbox_to_anchor : `.BboxBase`, 2-tuple, or 4-tuple of floats
     Box that is used to position the legend in conjunction with *loc*.
+    This is an advanced option for free placement of the legend and is
+    typically used when placing the legend outside of the Axes or at a
+    custom position. For most use cases, *loc* alone is sufficient.
+
     Defaults to ``axes.bbox`` (if called as a method to `.Axes.legend`) or
-    ``figure.bbox`` (if ``figure.legend``).  This argument allows arbitrary
-    placement of the legend.
+    ``figure.bbox`` (if ``figure.legend``).
 
     Bbox coordinates are interpreted in the coordinate system given by
     *bbox_transform*, with the default transform
@@ -118,6 +121,12 @@ bbox_to_anchor : `.BboxBase`, 2-tuple, or 4-tuple of floats
     center of the Axes (or figure) the following keywords can be used::
 
         loc='upper right', bbox_to_anchor=(0.5, 0.5)
+
+    For placing the legend outside the Axes, see
+    `.Figure.legend`, which supports ``'outside right upper'``
+    and similar location strings.
+    For more details on legend positioning, see the
+    :ref:`legend_guide`.
 
 ncols : int, default: 1
     The number of columns that the legend has.
@@ -265,15 +274,19 @@ _loc_doc_base = """
 loc : str or pair of floats, default: {default}
     The location of the legend.
 
-    The strings ``'upper left'``, ``'upper right'``, ``'lower left'``,
-    ``'lower right'`` place the legend at the corresponding corner of the
-    {parent}.
+    The string locations place the legend at the corresponding position
+    within the bounding box, which by default is the full {parent} area.
+    The bounding box can be changed via *bbox_to_anchor*.
 
-    The strings ``'upper center'``, ``'lower center'``, ``'center left'``,
-    ``'center right'`` place the legend at the center of the corresponding edge
-    of the {parent}.
+    The positions are visualized below::
 
-    The string ``'center'`` places the legend at the center of the {parent}.
+        +--------------+--------------+---------------+
+        | 'upper left' |'upper center'| 'upper right' |
+        +--------------+--------------+---------------+
+        |'center left' |   'center'   |'center right' |
+        +--------------+--------------+---------------+
+        | 'lower left' |'lower center'| 'lower right' |
+        +--------------+--------------+---------------+
 {best}
     The location can also be a 2-tuple giving the coordinates of the lower-left
     corner of the legend in {parent} coordinates (in which case *bbox_to_anchor*

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -98,9 +98,8 @@ class DraggableLegend(DraggableOffsetBox):
 _legend_kw_doc_base = """
 bbox_to_anchor : `.BboxBase`, 2-tuple, or 4-tuple of floats
     Box that is used to position the legend in conjunction with *loc*.
-    This is an advanced option for free placement of the legend and is
-    typically used when placing the legend outside of the Axes or at a
-    custom position. For most use cases, *loc* alone is sufficient.
+    This is an advanced option for free placement of the legend. For
+    most use cases, *loc* alone is sufficient.
 
     Defaults to ``axes.bbox`` (if called as a method to `.Axes.legend`) or
     ``figure.bbox`` (if ``figure.legend``).


### PR DESCRIPTION
## PR summary

Fixes #26620 — Improves the `loc` and `bbox_to_anchor` parameter documentation in the legend module.

- **Why is this change necessary?** The current `loc` documentation uses three separate paragraphs to describe legend positions, which is verbose and harder to scan. The `bbox_to_anchor` docs don't clearly state it's an advanced option or link to relevant guides.

- **What problem does it solve?** Makes legend positioning easier to understand at a glance by adding a visual ASCII grid of all 9 positions, and clarifies the relationship between `loc` and `bbox_to_anchor`.

- **What is the reasoning for this implementation?** Follows the suggestions in #26620 by maintainer @timhoffm.

## Changes

- **Parameter `loc`**: Replaced three text paragraphs with a concise explanation and an ASCII visual grid showing all 9 legend positions. Clarified that positions are within a bounding box configurable via `bbox_to_anchor`.
- **Parameter `bbox_to_anchor`**: Clarified this is an advanced option for free placement. Added cross-references to `Figure.legend` for outside placement and to the `:ref:`legend_guide``.

## AI Disclosure

I used Claude (Anthropic) for researching the issue and drafting the documentation text. The changes were reviewed and verified by me.

## PR checklist

- [x] "closes #26620" is in the body of the PR description
- [N/A] new and changed code is tested
- [N/A] "Plotting related" features are demonstrated in an example
- [N/A] "New Features" and "API Changes" are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines