### PR TITLE
DOC: Remove pyplot vs. OO interface discussion from lifecycle example

### DIFF
--- a/galleries/tutorials/lifecycle.py
+++ b/galleries/tutorials/lifecycle.py
@@ -19,35 +19,6 @@ to highlight some neat features and best-practices using Matplotlib.
     <https://pbpython.com/effective-matplotlib.html>`_
     by Chris Moffitt. It was transformed into this tutorial by Chris Holdgraf.
 
-A note on the explicit vs. implicit interfaces
-==============================================
-
-Matplotlib has two interfaces. For an explanation of the trade-offs between the
-explicit and implicit interfaces see :ref:`api_interfaces`.
-
-In the explicit object-oriented (OO) interface we directly utilize instances of
-:class:`axes.Axes` to build up the visualization in an instance of
-:class:`figure.Figure`.  In the implicit interface, inspired by and modeled on
-MATLAB, we use a global state-based interface which is encapsulated in the
-:mod:`.pyplot` module to plot to the "current Axes".  See the :ref:`pyplot
-tutorials <pyplot_tutorial>` for a more in-depth look at the
-pyplot interface.
-
-Most of the terms are straightforward but the main thing to remember
-is that:
-
-* The `.Figure` is the final image, and may contain one or more `~.axes.Axes`.
-* The `~.axes.Axes` represents an individual plot (not to be confused with
-   `~.axis.Axis`, which refers to the x-, y-, or z-axis of a plot).
-
-We call methods that do the plotting directly from the Axes, which gives
-us much more flexibility and power in customizing our plot.
-
-.. note::
-
-   In general, use the explicit interface over the implicit pyplot interface
-   for plotting.
-
 Our data
 ========
 


### PR DESCRIPTION
That discussion is out of scope here, and we generally use OO nowadays.

Likewise, we do not need to explain the terms figure/Axes.