### PR TITLE
Fix: Optimize Cursor clearing on mouse exit to prevent lag

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1845,17 +1845,30 @@ def test_parent_axes_removal():
     checks._clear(evt)
 
 
-def test_cursor_overlapping_axes_blitting_warning():
-    """Test that a warning is raised and useblit is disabled for overlapping axes."""
-    fig = plt.figure()
-    ax1 = fig.add_axes([0.1, 0.1, 0.8, 0.8])
-    ax2 = fig.add_axes([0.2, 0.2, 0.6, 0.6])  # Explicitly overlaps ax1
+def test_cursor_clear_on_move_outside():
+    """Test that moving the mouse outside the axes clears the cursor safely."""
+    import matplotlib.pyplot as plt
+    from matplotlib.widgets import Cursor
 
-    match_text = (
-        "Cursor blitting is currently not supported on "
-        "overlapping axes"
-    )
-    with pytest.warns(UserWarning, match=match_text):
-        cursor = widgets.Cursor(ax1, useblit=True)
+    fig, ax = plt.subplots()
+    cursor = Cursor(ax, useblit=True)
 
-    assert cursor.useblit is False
+    # Simulate the cursor lines being visible
+    cursor.linev.set_visible(True)
+    cursor.lineh.set_visible(True)
+    cursor.needclear = True
+
+    # Create a mock mouse event where 'inaxes' is None (meaning outside)
+    class MockEvent:
+        inaxes = None
+        x = 0
+        y = 0
+
+    # Trigger the movement cleanup
+    cursor.onmove(MockEvent())
+
+    # Verify the lines were hidden and the flag reset
+    assert not cursor.linev.get_visible()
+    assert not cursor.lineh.get_visible()
+    assert not cursor.needclear
+    

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1796,32 +1796,6 @@ def test_MultiCursor(horizOn, vertOn, with_deprecated_canvas):
         assert l.get_ydata() == (.25, .25)
 
 
-def test_cursor_clear_on_move_outside():
-    """Test that moving the mouse outside the axes clears the cursor safely."""
-    import matplotlib.pyplot as plt
-    from matplotlib.widgets import Cursor
-    
-    fig, ax = plt.subplots()
-    cursor = Cursor(ax, useblit=True)
-    
-    # Simulate the cursor lines being visible
-    cursor.linev.set_visible(True)
-    cursor.lineh.set_visible(True)
-    cursor.needclear = True
-    
-    # Create a mock mouse event where 'inaxes' is None (meaning outside)
-    class MockEvent:
-        inaxes = None
-    
-    # Trigger the movement cleanup
-    cursor.onmove(MockEvent())
-    
-    # Verify the lines were hidden and the flag reset
-    assert not cursor.linev.get_visible()
-    assert not cursor.lineh.get_visible()
-    assert not cursor.needclear
-
-
 def test_parent_axes_removal():
 
     fig, (ax_radio, ax_checks) = plt.subplots(1, 2)
@@ -1871,4 +1845,3 @@ def test_cursor_clear_on_move_outside():
     assert not cursor.linev.get_visible()
     assert not cursor.lineh.get_visible()
     assert not cursor.needclear
-    

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1796,6 +1796,32 @@ def test_MultiCursor(horizOn, vertOn, with_deprecated_canvas):
         assert l.get_ydata() == (.25, .25)
 
 
+def test_cursor_clear_on_move_outside():
+    """Test that moving the mouse outside the axes clears the cursor safely."""
+    import matplotlib.pyplot as plt
+    from matplotlib.widgets import Cursor
+    
+    fig, ax = plt.subplots()
+    cursor = Cursor(ax, useblit=True)
+    
+    # Simulate the cursor lines being visible
+    cursor.linev.set_visible(True)
+    cursor.lineh.set_visible(True)
+    cursor.needclear = True
+    
+    # Create a mock mouse event where 'inaxes' is None (meaning outside)
+    class MockEvent:
+        inaxes = None
+    
+    # Trigger the movement cleanup
+    cursor.onmove(MockEvent())
+    
+    # Verify the lines were hidden and the flag reset
+    assert not cursor.linev.get_visible()
+    assert not cursor.lineh.get_visible()
+    assert not cursor.needclear
+
+
 def test_parent_axes_removal():
 
     fig, (ax_radio, ax_checks) = plt.subplots(1, 2)

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1819,29 +1819,16 @@ def test_parent_axes_removal():
     checks._clear(evt)
 
 
-def test_cursor_clear_on_move_outside():
-    """Test that moving the mouse outside the axes clears the cursor safely."""
-    import matplotlib.pyplot as plt
-    from matplotlib.widgets import Cursor
+def test_cursor_overlapping_axes_blitting_warning():
+    """Test that a warning is raised and useblit is disabled for overlapping axes."""
+    fig = plt.figure()
+    ax1 = fig.add_axes([0.1, 0.1, 0.8, 0.8])
+    ax2 = fig.add_axes([0.2, 0.2, 0.6, 0.6])
+    match_text = (
+        "Cursor blitting is currently not supported on "
+        "overlapping axes"
+    )
+    with pytest.warns(UserWarning, match=match_text):
+        cursor = widgets.Cursor(ax1, useblit=True)
 
-    fig, ax = plt.subplots()
-    cursor = Cursor(ax, useblit=True)
-
-    # Simulate the cursor lines being visible
-    cursor.linev.set_visible(True)
-    cursor.lineh.set_visible(True)
-    cursor.needclear = True
-
-    # Create a mock mouse event where 'inaxes' is None (meaning outside)
-    class MockEvent:
-        inaxes = None
-        x = 0
-        y = 0
-
-    # Trigger the movement cleanup
-    cursor.onmove(MockEvent())
-
-    # Verify the lines were hidden and the flag reset
-    assert not cursor.linev.get_visible()
-    assert not cursor.lineh.get_visible()
-    assert not cursor.needclear
+    assert cursor.useblit is False

--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1823,7 +1823,8 @@ def test_cursor_overlapping_axes_blitting_warning():
     """Test that a warning is raised and useblit is disabled for overlapping axes."""
     fig = plt.figure()
     ax1 = fig.add_axes([0.1, 0.1, 0.8, 0.8])
-    ax2 = fig.add_axes([0.2, 0.2, 0.6, 0.6])
+    ax2 = fig.add_axes([0.2, 0.2, 0.6, 0.6])  # Explicitly overlaps ax1
+
     match_text = (
         "Cursor blitting is currently not supported on "
         "overlapping axes"

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2125,7 +2125,7 @@ class Cursor(AxesWidget):
                         self.canvas.restore_region(background)
                     self.canvas.blit(self.ax.bbox)
                 else:
-                    self.canvas.draw_idle()
+                    self.canvas.draw()
                 self.needclear = False
             return
         self.needclear = True
@@ -2144,7 +2144,7 @@ class Cursor(AxesWidget):
             self.ax.draw_artist(self.lineh)
             self.canvas.blit(self.ax.bbox)
         else:
-            self.canvas.draw_idle()
+            self.canvas.draw()
 
 
 class MultiCursor(Widget):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2123,6 +2123,9 @@ class Cursor(AxesWidget):
                     background = self._load_blit_background()
                     if background is not None:
                         self.canvas.restore_region(background)
+                background = self._load_blit_background()
+                if self.useblit and background is not None:
+                    self.canvas.restore_region(background)
                     self.canvas.blit(self.ax.bbox)
                 else:
                     self.canvas.draw()

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2119,7 +2119,13 @@ class Cursor(AxesWidget):
             self.linev.set_visible(False)
             self.lineh.set_visible(False)
             if self.needclear:
-                self.canvas.draw()
+                if self.useblit:
+                    background = self._load_blit_background()
+                    if background is not None:
+                        self.canvas.restore_region(background)
+                    self.canvas.blit(self.ax.bbox)
+                else:
+                    self.canvas.draw()
                 self.needclear = False
             return
         self.needclear = True

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2119,10 +2119,6 @@ class Cursor(AxesWidget):
             self.linev.set_visible(False)
             self.lineh.set_visible(False)
             if self.needclear:
-                if self.useblit:
-                    background = self._load_blit_background()
-                    if background is not None:
-                        self.canvas.restore_region(background)
                 background = self._load_blit_background()
                 if self.useblit and background is not None:
                     self.canvas.restore_region(background)
@@ -2147,7 +2143,7 @@ class Cursor(AxesWidget):
             self.ax.draw_artist(self.lineh)
             self.canvas.blit(self.ax.bbox)
         else:
-            self.canvas.draw()
+            self.canvas.draw_idle()
 
 
 class MultiCursor(Widget):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2125,7 +2125,7 @@ class Cursor(AxesWidget):
                         self.canvas.restore_region(background)
                     self.canvas.blit(self.ax.bbox)
                 else:
-                    self.canvas.draw()
+                    self.canvas.draw_idle()
                 self.needclear = False
             return
         self.needclear = True


### PR DESCRIPTION
## PR summary
closes #26901

**Why is this change necessary & what problem does it solve?**
Currently, `widgets.Cursor.onmove` calls a blocking `self.canvas.draw()` when the mouse leaves the axes and the cursor needs to be cleared. For large or complex figures (e.g., high-res images), this forces a full synchronous re-render, causing massive lag/stuttering (a busy icon that lasts 1-2 seconds per movement).

**What is the reasoning for this implementation?**
This PR optimizes the clear step by:
1. Checking if `useblit` is enabled. If it is, it cleanly restores the saved background and blits only the specific bounding box (`self.ax.bbox`).
2. Falling back to the non-blocking `self.canvas.draw_idle()` instead of `draw()` if blitting is disabled, preventing the heavy synchronous render lock.

## AI Disclosure
I used an AI assistant to help review the Git workflow, structure the blitting fallback logic, and format this Pull Request.

## PR checklist
- [x] "closes #0000" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines