### PR TITLE
DOC: More concise page title: Development setup

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -14,9 +14,9 @@
 
 .. _installing_for_devs:
 
-=====================================
-Setting up Matplotlib for development
-=====================================
+=================
+Development setup
+=================
 
 To set up Matplotlib for development follow these steps:
 


### PR DESCRIPTION
Minor improvement.

Almost all pages under development use a nominal-style title, and also "Development setup" rhymes nicely with the subsequent "Development workflow"

<img width="306" height="567" alt="grafik" src="https://github.com/user-attachments/assets/8865ead3-9b18-4292-8629-b709f1d3e2d1" />
