### PR TITLE
TST: account for flakiness with Numpy v1 (part 2)

### DIFF
--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -631,7 +631,9 @@ def test_colorbar_format(fmt):
     assert cbar.ax.yaxis.get_ticklabels()[4].get_text() == '2.00e+02'
 
     # but if we change the norm:
-    im.set_norm(LogNorm(vmin=0.1, vmax=10))
+    # when we require numpy >= 2, vmin can be 0.1, but at numpy 1.x this is
+    # sensitive to floating point errors
+    im.set_norm(LogNorm(vmin=0.09999, vmax=10))
     fig.canvas.draw()
     assert (cbar.ax.yaxis.get_ticklabels()[0].get_text() ==
             '$\\mathdefault{10^{-2}}$')


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Following #30950, fix the flaky colorbar test in minver in the same way we fixed the flaky pcolor test before.  In my local dev environment with Numpy v2.3, I verified that setting _vmin_ slightly higher (`vmin=0.100001`) reproduces the failure.

I also ran minver multiple times in parallel on my fork and found
* With no code changes, the colorbar test fails in six runs out of 60. [logs](https://github.com/rcomer/matplotlib/actions/runs/23941314530/job/69837835696)
* If I move the Numpy pin to v2.0.0 (and the contourpy pin to v1.2.1 as that's the [first version to support numpy v2](https://contourpy.readthedocs.io/en/v1.3.3/changelog.html#v1-2-1-2024-04-02)), I see no failures in 60 runs. [logs](https://github.com/rcomer/matplotlib/actions/runs/23944995635)
* If I revert the pins and include the change in this PR, I see no failures in 60 runs. [logs](https://github.com/rcomer/matplotlib/actions/runs/23946621934)

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
None
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
