### PR TITLE
Improve clarity in getting started documentation

### DIFF
--- a/doc/users/getting_started/index.rst
+++ b/doc/users/getting_started/index.rst
@@ -9,7 +9,7 @@ Installation quick-start
 Draw a first plot
 -----------------
 
-Here is a minimal example plot:
+Here is a minimal example of a plot:
 
 .. plot::
    :include-source:


### PR DESCRIPTION
## PR Summary

This PR improves the clarity of wording in the getting started documentation.

The sentence "Here is a minimal example plot:" was updated to "Here is a minimal example of a plot:" for better readability and natural phrasing.

## Reason for change

This change improves documentation clarity for beginners and enhances readability without altering functionality.

## AI Disclosure

I used AI assistance to guide me through the contribution workflow and improve the wording.