### PR TITLE
doc: add thumbnails for skipped gallery and tutorial examples (fixes #17479)

### DIFF
--- a/doc/_static/frame_grabbing_sgskip_thumbnail.svg
+++ b/doc/_static/frame_grabbing_sgskip_thumbnail.svg
@@ -1,0 +1,34 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Film strip -->
+  <rect x="20" y="20" width="280" height="184" rx="8" fill="#222222"/>
+  <!-- Sprocket holes top -->
+  <rect x="30" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="58" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="86" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="114" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="142" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="170" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="198" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="226" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="254" y="26" width="18" height="14" rx="3" fill="#555555"/>
+  <!-- Sprocket holes bottom -->
+  <rect x="30" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="58" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="86" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="114" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="142" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="170" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="198" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="226" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <rect x="254" y="184" width="18" height="14" rx="3" fill="#555555"/>
+  <!-- Frame 1 -->
+  <rect x="28" y="48" width="76" height="128" fill="white"/>
+  <polyline points="28,176 56,120 70,140 90,96 104,176" fill="none" stroke="#1f77b4" stroke-width="2.5"/>
+  <!-- Frame 2 -->
+  <rect x="122" y="48" width="76" height="128" fill="white"/>
+  <polyline points="122,176 150,108 164,128 184,84 198,176" fill="none" stroke="#1f77b4" stroke-width="2.5"/>
+  <!-- Frame 3 -->
+  <rect x="216" y="48" width="76" height="128" fill="white"/>
+  <polyline points="216,176 244,96 258,116 278,72 292,176" fill="none" stroke="#1f77b4" stroke-width="2.5"/>
+</svg>

--- a/doc/_static/ginput_manual_clabel_sgskip_thumbnail.svg
+++ b/doc/_static/ginput_manual_clabel_sgskip_thumbnail.svg
@@ -1,0 +1,20 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Axes box -->
+  <rect x="40" y="20" width="260" height="184" fill="#f8f8f8" stroke="#cccccc" stroke-width="1"/>
+  <!-- Contour lines (ellipses representing a 2D Gaussian) -->
+  <ellipse cx="170" cy="112" rx="120" ry="84" fill="none" stroke="#2166ac" stroke-width="1.5" opacity="0.5"/>
+  <ellipse cx="170" cy="112" rx="90" ry="62" fill="none" stroke="#4393c3" stroke-width="1.5" opacity="0.6"/>
+  <ellipse cx="170" cy="112" rx="62" ry="42" fill="none" stroke="#92c5de" stroke-width="1.5" opacity="0.7"/>
+  <ellipse cx="170" cy="112" rx="36" ry="24" fill="none" stroke="#d6604d" stroke-width="1.5" opacity="0.8"/>
+  <ellipse cx="170" cy="112" rx="14" ry="9" fill="none" stroke="#b2182b" stroke-width="1.5" opacity="0.9"/>
+  <!-- Contour labels -->
+  <rect x="148" y="151" width="26" height="14" rx="2" fill="white"/>
+  <text x="161" y="162" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#2166ac">-1.0</text>
+  <rect x="124" y="135" width="26" height="14" rx="2" fill="white"/>
+  <text x="137" y="146" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#4393c3">-0.5</text>
+  <rect x="200" y="107" width="22" height="14" rx="2" fill="white"/>
+  <text x="211" y="118" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#d6604d">0.5</text>
+  <!-- Mouse cursor -->
+  <polygon points="210,78 210,100 216,95 220,104 223,103 219,94 226,94" fill="#333333"/>
+</svg>

--- a/doc/_static/hyperlinks_sgskip_thumbnail.svg
+++ b/doc/_static/hyperlinks_sgskip_thumbnail.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Axes box -->
+  <rect x="44" y="16" width="256" height="176" fill="#f8f8f8" stroke="#cccccc" stroke-width="1"/>
+  <!-- Scatter points with different colors (representing clickable links) -->
+  <circle cx="110" cy="108" r="14" fill="#1f77b4" opacity="0.8"/>
+  <circle cx="170" cy="76" r="14" fill="#ff7f0e" opacity="0.8"/>
+  <circle cx="230" cy="132" r="14" fill="#2ca02c" opacity="0.8"/>
+  <!-- Underline / hyperlink visual cue -->
+  <line x1="96" y1="122" x2="124" y2="122" stroke="#1f77b4" stroke-width="2"/>
+  <line x1="156" y1="90" x2="184" y2="90" stroke="#ff7f0e" stroke-width="2"/>
+  <line x1="216" y1="146" x2="244" y2="146" stroke="#2ca02c" stroke-width="2"/>
+  <!-- Link icon top right -->
+  <text x="270" y="42" font-family="sans-serif" font-size="20" fill="#555555">🔗</text>
+  <!-- Axis labels -->
+  <text x="172" y="208" font-family="sans-serif" font-size="11" text-anchor="middle" fill="#555555">SVG Hyperlinks</text>
+</svg>

--- a/doc/_static/lasso_selector_sgskip_thumbnail.svg
+++ b/doc/_static/lasso_selector_sgskip_thumbnail.svg
@@ -1,0 +1,21 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Axes box -->
+  <rect x="40" y="16" width="260" height="192" fill="#f8f8f8" stroke="#cccccc" stroke-width="1"/>
+  <!-- Deselected scatter points (faded) -->
+  <circle cx="80" cy="80" r="7" fill="#1f77b4" opacity="0.3"/>
+  <circle cx="130" cy="50" r="7" fill="#1f77b4" opacity="0.3"/>
+  <circle cx="260" cy="60" r="7" fill="#1f77b4" opacity="0.3"/>
+  <circle cx="280" cy="140" r="7" fill="#1f77b4" opacity="0.3"/>
+  <circle cx="240" cy="170" r="7" fill="#1f77b4" opacity="0.3"/>
+  <circle cx="72" cy="170" r="7" fill="#1f77b4" opacity="0.3"/>
+  <!-- Selected scatter points (bright) -->
+  <circle cx="160" cy="100" r="7" fill="#1f77b4" opacity="1.0"/>
+  <circle cx="190" cy="140" r="7" fill="#1f77b4" opacity="1.0"/>
+  <circle cx="148" cy="158" r="7" fill="#1f77b4" opacity="1.0"/>
+  <circle cx="210" cy="110" r="7" fill="#1f77b4" opacity="1.0"/>
+  <circle cx="175" cy="170" r="7" fill="#1f77b4" opacity="1.0"/>
+  <!-- Lasso selection path -->
+  <path d="M 136,82 Q 250,68 236,190 Q 120,200 128,168 Q 110,130 136,82 Z"
+        fill="none" stroke="#ff7f0e" stroke-width="2" stroke-dasharray="6,3"/>
+</svg>

--- a/doc/_static/multiprocess_sgskip_thumbnail.svg
+++ b/doc/_static/multiprocess_sgskip_thumbnail.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Axes box -->
+  <rect x="44" y="16" width="252" height="172" fill="#f8f8f8" stroke="#cccccc" stroke-width="1"/>
+  <!-- Live data line (jagged, like real-time data) -->
+  <polyline
+    points="44,138 68,120 90,130 112,98 134,112 156,82 178,96 200,68 222,84 244,58 264,72 286,52 296,44"
+    fill="none" stroke="#1f77b4" stroke-width="2.5" stroke-linejoin="round"/>
+  <!-- Process A label -->
+  <rect x="52" y="24" width="82" height="18" rx="3" fill="#1f77b4" opacity="0.15"/>
+  <text x="93" y="37" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#1f77b4">Process A (data)</text>
+  <!-- Process B label -->
+  <rect x="52" y="48" width="82" height="18" rx="3" fill="#ff7f0e" opacity="0.15"/>
+  <text x="93" y="61" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#ff7f0e">Process B (plot)</text>
+  <!-- Arrow between processes -->
+  <line x1="180" y1="33" x2="200" y2="33" stroke="#888888" stroke-width="1.5" marker-end="url(#arr)"/>
+  <!-- Two process boxes at bottom -->
+  <rect x="52" y="198" width="84" height="20" rx="4" fill="#1f77b4" opacity="0.3"/>
+  <text x="94" y="212" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#333333">Producer</text>
+  <rect x="184" y="198" width="84" height="20" rx="4" fill="#ff7f0e" opacity="0.3"/>
+  <text x="226" y="212" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#333333">Plotter</text>
+</svg>

--- a/doc/_static/pong_sgskip_thumbnail.svg
+++ b/doc/_static/pong_sgskip_thumbnail.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="#1a1a2e"/>
+  <!-- Court boundary -->
+  <rect x="10" y="10" width="300" height="204" fill="none" stroke="#4a4a6a" stroke-width="2"/>
+  <!-- Center line (dashed) -->
+  <line x1="160" y1="10" x2="160" y2="214" stroke="#4a4a6a" stroke-width="2" stroke-dasharray="8,8"/>
+  <!-- Left paddle -->
+  <rect x="24" y="78" width="14" height="68" rx="4" fill="#1f77b4"/>
+  <!-- Right paddle -->
+  <rect x="282" y="88" width="14" height="68" rx="4" fill="#ff7f0e"/>
+  <!-- Ball -->
+  <circle cx="134" cy="118" r="9" fill="white"/>
+  <!-- Score -->
+  <text x="100" y="50" font-family="monospace" font-size="32" font-weight="bold" text-anchor="middle" fill="#aaaacc">3</text>
+  <text x="220" y="50" font-family="monospace" font-size="32" font-weight="bold" text-anchor="middle" fill="#aaaacc">5</text>
+</svg>

--- a/doc/_static/print_stdout_sgskip_thumbnail.svg
+++ b/doc/_static/print_stdout_sgskip_thumbnail.svg
@@ -1,0 +1,19 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 320 224">
+  <rect width="320" height="224" fill="white"/>
+  <!-- Terminal / stdout box -->
+  <rect x="20" y="16" width="280" height="100" rx="6" fill="#1e1e1e"/>
+  <!-- Terminal dots -->
+  <circle cx="38" cy="32" r="6" fill="#ff5f57"/>
+  <circle cx="58" cy="32" r="6" fill="#febc2e"/>
+  <circle cx="78" cy="32" r="6" fill="#28c840"/>
+  <!-- Terminal text: binary data -->
+  <text x="32" y="58" font-family="monospace" font-size="10" fill="#888888">$ python print_stdout.py &gt; out.png</text>
+  <text x="32" y="74" font-family="monospace" font-size="10" fill="#4ec9b0">PNG</text>
+  <text x="60" y="74" font-family="monospace" font-size="10" fill="#9cdcfe">&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;&#x2588;</text>
+  <text x="32" y="90" font-family="monospace" font-size="10" fill="#4ec9b0">IHDR</text>
+  <text x="60" y="90" font-family="monospace" font-size="10" fill="#9cdcfe">&#x2588;&#x2588;&#x2588;&#x2588;</text>
+  <!-- Simple line plot below -->
+  <rect x="44" y="130" width="232" height="78" fill="#f8f8f8" stroke="#cccccc" stroke-width="1"/>
+  <polyline points="44,208 120,170 196,155 276,140" fill="none" stroke="#1f77b4" stroke-width="2.5"/>
+  <text x="160" y="220" font-family="sans-serif" font-size="10" text-anchor="middle" fill="#555555">plot saved to stdout</text>
+</svg>

--- a/galleries/examples/animation/frame_grabbing_sgskip.py
+++ b/galleries/examples/animation/frame_grabbing_sgskip.py
@@ -7,6 +7,7 @@ Use a MovieWriter directly to grab individual frames and write them to a
 file.  This avoids any event loop integration, and thus works even with the Agg
 backend.  This is not recommended for use in an interactive setting.
 """
+# sphinx_gallery_thumbnail_path = '_static/frame_grabbing_sgskip_thumbnail.svg'
 
 import numpy as np
 

--- a/galleries/examples/event_handling/ginput_manual_clabel_sgskip.py
+++ b/galleries/examples/event_handling/ginput_manual_clabel_sgskip.py
@@ -14,6 +14,7 @@ waitforbuttonpress and manual clabel placement.
     You can copy and paste individual parts, or download the entire example
     using the link at the bottom of the page.
 """
+# sphinx_gallery_thumbnail_path = '_static/ginput_manual_clabel_sgskip_thumbnail.svg'
 
 import time
 

--- a/galleries/examples/event_handling/pong_sgskip.py
+++ b/galleries/examples/event_handling/pong_sgskip.py
@@ -14,6 +14,7 @@ animations that are easily ported to multiple backends.
     You can copy and paste individual parts, or download the entire example
     using the link at the bottom of the page.
 """
+# sphinx_gallery_thumbnail_path = '_static/pong_sgskip_thumbnail.svg'
 
 import time
 

--- a/galleries/examples/misc/hyperlinks_sgskip.py
+++ b/galleries/examples/misc/hyperlinks_sgskip.py
@@ -8,6 +8,7 @@ This example demonstrates how to set a hyperlinks on various kinds of elements.
 This currently only works with the SVG backend.
 
 """
+# sphinx_gallery_thumbnail_path = '_static/hyperlinks_sgskip_thumbnail.svg'
 
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/misc/image_thumbnail_sgskip.py
+++ b/galleries/examples/misc/image_thumbnail_sgskip.py
@@ -9,6 +9,7 @@ supported by Pillow.
 
 .. _Pillow: https://python-pillow.github.io
 """
+# sphinx_gallery_thumbnail_path = '_static/stinkbug.png'
 
 from argparse import ArgumentParser
 from pathlib import Path

--- a/galleries/examples/misc/multiprocess_sgskip.py
+++ b/galleries/examples/misc/multiprocess_sgskip.py
@@ -8,6 +8,7 @@ plotting in another.
 
 Written by Robert Cimrman
 """
+# sphinx_gallery_thumbnail_path = '_static/multiprocess_sgskip_thumbnail.svg'
 
 import multiprocessing as mp
 import time

--- a/galleries/examples/misc/print_stdout_sgskip.py
+++ b/galleries/examples/misc/print_stdout_sgskip.py
@@ -8,6 +8,7 @@ print png to standard out
 usage: python print_stdout.py > somefile.png
 
 """
+# sphinx_gallery_thumbnail_path = '_static/print_stdout_sgskip_thumbnail.svg'
 
 import sys
 

--- a/galleries/examples/mplot3d/wire3d_animation_sgskip.py
+++ b/galleries/examples/mplot3d/wire3d_animation_sgskip.py
@@ -8,6 +8,7 @@ A very simple "animation" of a 3D plot.  See also :doc:`rotate_axes3d_sgskip`.
 (This example is skipped when building the documentation gallery because it
 intentionally takes a long time to run.)
 """
+# sphinx_gallery_thumbnail_path = '_static/demo_mplot3d.png'
 
 import time
 

--- a/galleries/examples/widgets/lasso_selector_demo_sgskip.py
+++ b/galleries/examples/widgets/lasso_selector_demo_sgskip.py
@@ -9,6 +9,7 @@ This examples plots a scatter plot. You can then select a few points by drawing
 a lasso loop around the points on the graph. To draw, just click
 on the graph, hold, and drag it around the points you need to select.
 """
+# sphinx_gallery_thumbnail_path = '_static/lasso_selector_sgskip_thumbnail.svg'
 
 
 import numpy as np


### PR DESCRIPTION
## What Does This PR Do

Adds missing gallery thumbnails for examples that use the `_sgskip` suffix and are therefore excluded from documentation build execution. These examples were showing placeholder grey boxes in the gallery index page, which could confuse users into thinking the examples were broken.

## Root Cause

Examples with `_sgskip` in their filename are intentionally skipped during the Sphinx Gallery build (because they require interactive input, external programs like FFmpeg, or intentionally take too long). Since sphinx-gallery never executes them, it cannot auto-generate a thumbnail image. Without a `sphinx_gallery_thumbnail_path` directive, these examples display an empty placeholder thumbnail.

## Changes

- Added `# sphinx_gallery_thumbnail_path = '...'` directive to 9 skipped examples
- Created 6 new descriptive SVG thumbnails in `doc/_static/`, each designed to visually represent what the example demonstrates
- Two examples reuse already-present images in `_static/` (no new file needed):
  - `image_thumbnail_sgskip` uses `stinkbug.png` (an image being thumbnailed — fitting)
  - `wire3d_animation_sgskip` uses `demo_mplot3d.png` (existing 3D plot image)

## Expected Impact

| Gallery Section | Before | After |
|----------------|--------|-------|
| Animation / frame_grabbing | Grey placeholder | Film-strip animation thumbnail |
| Event Handling / ginput | Grey placeholder | Contour plot with cursor thumbnail |
| Event Handling / pong | Grey placeholder | Pong game court thumbnail |
| Misc / hyperlinks | Grey placeholder | Scatter with SVG link indicators |
| Misc / image_thumbnail | Grey placeholder | Real stinkbug image thumbnail |
| Misc / multiprocess | Grey placeholder | Producer/plotter process diagram |
| Misc / print_stdout | Grey placeholder | Terminal + line plot thumbnail |
| Mplot3d / wire3d_animation | Grey placeholder | 3D surface plot thumbnail |
| Widgets / lasso_selector | Grey placeholder | Scatter with lasso selection loop |

## Type of Change

- [x] Documentation / gallery improvement
- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change

## Checklist

- [x] All new SVG thumbnails are original works with no licensing issues
- [x] SVG thumbnails visually represent what each example demonstrates
- [x] Follows the existing pattern set by `multipage_pdf.py` (`sphinx_gallery_thumbnail_path`)
- [x] No changes to example logic — only thumbnail directives added
- [x] Two examples reuse already-present `_static/` images (no unnecessary new files)
- [x] Addresses the open items listed in #17479

Fixes #17479