### PR TITLE
lib/matplotlib/tests/test_inset.py: Fix tolerance on aarch64

### DIFF
--- a/lib/matplotlib/tests/test_inset.py
+++ b/lib/matplotlib/tests/test_inset.py
@@ -94,7 +94,7 @@ def test_inset_indicator_zorder():
 
 
 @image_comparison(['zoom_inset_connector_styles.png'], remove_text=True, style='mpl20',
-                  tol=0.024 if platform.machine() == 'arm64' else 0)
+                  tol=0.024 if platform.machine() in ['aarch64', 'arm64'] else 0)
 def test_zoom_inset_connector_styles():
     fig, axs = plt.subplots(2)
     for ax in axs:


### PR DESCRIPTION
I tried to run the test suite on a aarch64 linux system and it failed due to test_zoom_inset_connector_styles exceeding the tolerance. The test is already checking the platform to increase the tolerance on aarch64 but the check is failing as on this system, ``platform.machine()`` is returning ``aarch64`` not ``arm64``.

I've checked on several distributions and it seems consistent.

So, update the check to match both ``arm64`` and ``aarch64``.