### PR TITLE
DOC: Use FuncAnimation in 3D animations

### DIFF
--- a/galleries/examples/mplot3d/rotate_axes3d_sgskip.py
+++ b/galleries/examples/mplot3d/rotate_axes3d_sgskip.py
@@ -5,7 +5,7 @@ Rotating a 3D plot
 
 A very simple animation of a rotating 3D plot about all three axes.
 
-See :doc:`wire3d_animation_sgskip` for another example of animating a 3D plot.
+See :doc:`wire3d_animation` for another example of animating a 3D plot.
 
 (This example is skipped when building the documentation gallery because it
 intentionally takes a long time to run)
@@ -13,6 +13,7 @@ intentionally takes a long time to run)
 
 import matplotlib.pyplot as plt
 
+from matplotlib import animation
 from mpl_toolkits.mplot3d import axes3d
 
 fig = plt.figure()
@@ -27,8 +28,9 @@ ax.set_xlabel('x')
 ax.set_ylabel('y')
 ax.set_zlabel('z')
 
+
 # Rotate the axes and update
-for angle in range(0, 360*4 + 1):
+def animate(angle):
     # Normalize the angle to the range [-180, 180] for display
     angle_norm = (angle + 180) % 360 - 180
 
@@ -45,10 +47,12 @@ for angle in range(0, 360*4 + 1):
 
     # Update the axis view and title
     ax.view_init(elev, azim, roll)
-    plt.title('Elevation: %d°, Azimuth: %d°, Roll: %d°' % (elev, azim, roll))
+    ax.set_title(f'Elevation: {elev}°, Azimuth: {azim}°, Roll: {roll}°')
 
-    plt.draw()
-    plt.pause(.001)
+
+ani = animation.FuncAnimation(fig, animate, interval=25, frames=360*4)
+
+plt.show()
 
 # %%
 # .. tags::

--- a/galleries/examples/mplot3d/wire3d_animation.py
+++ b/galleries/examples/mplot3d/wire3d_animation.py
@@ -4,15 +4,17 @@ Animate a 3D wireframe plot
 ===========================
 
 A very simple "animation" of a 3D plot.  See also :doc:`rotate_axes3d_sgskip`.
-
-(This example is skipped when building the documentation gallery because it
-intentionally takes a long time to run.)
 """
 
 import time
 
 import matplotlib.pyplot as plt
 import numpy as np
+
+from matplotlib import animation
+
+FRAMES = 25
+FPS = 25
 
 fig = plt.figure()
 ax = fig.add_subplot(projection='3d')
@@ -28,17 +30,28 @@ ax.set_zlim(-1, 1)
 # Begin plotting.
 wframe = None
 tstart = time.time()
-for phi in np.linspace(0, 180. / np.pi, 100):
-    # If a line collection is already remove it before drawing.
+
+
+def animate(i):
+    global wframe
+    # If a line collection is already there, remove it before drawing.
     if wframe:
         wframe.remove()
     # Generate data.
+    phi = i / FRAMES * 2 * np.pi
     Z = np.cos(2 * np.pi * X + phi) * (1 - np.hypot(X, Y))
-    # Plot the new wireframe and pause briefly before continuing.
+    # Plot the new wireframe.
     wframe = ax.plot_wireframe(X, Y, Z, rstride=2, cstride=2)
-    plt.pause(.001)
+    if i == FRAMES - 1:  # Print FPS at the end of the loop.
+        global tstart
+        fps = FRAMES / (time.time() - tstart)
+        print(f'Expected FPS: {FPS}; Average FPS: {fps}')
+        tstart = time.time()
 
-print('Average FPS: %f' % (100 / (time.time() - tstart)))
+
+ani = animation.FuncAnimation(fig, animate, interval=1000 / FPS, frames=FRAMES)
+
+plt.show()
 
 # %%
 # .. tags::


### PR DESCRIPTION
## PR summary

These examples were disabled because the manual pausing caused the example to take very long while the docs were being built. Using the animation framework works if run by itself and also in Sphinx-Gallery, which can then have the frames generated as quickly as possible.

That being said, I have only enabled the wire3d animation. The axes3d rotation example goes through so many frames that it takes 3 minutes, which is by far longer than any other example, so it remains skipped. If we wanted to enable that example, we could have it skip angles (by 5 or 10 degrees), but that does make it a bit choppy.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines