### PR TITLE
ci: Force AppVeyor to build/test in parallel

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -24,7 +24,7 @@ environment:
   global:
     PYTHONFAULTHANDLER: 1
     PYTHONIOENCODING: UTF-8
-    PYTEST_ARGS: -rfEsXR --numprocesses=auto --timeout=300 --durations=25
+    PYTEST_ARGS: -rfEsXR --numprocesses=2 --timeout=300 --durations=25
                  --cov-report= --cov=lib --log-level=DEBUG
 
   matrix:
@@ -63,7 +63,7 @@ install:
 test_script:
   # Now build the thing..
   - set LINK=/LIBPATH:%cd%\lib
-  - pip install -v --no-build-isolation --editable .
+  - pip install -v --no-build-isolation -Ccompile-args=-j2 --editable .
   # this should show no freetype dll...
   - set "DUMPBIN=%VS140COMNTOOLS%\..\..\VC\bin\dumpbin.exe"
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'


### PR DESCRIPTION
## PR summary
According to [AppVeyor docs](https://www.appveyor.com/docs/build-environment/#build-vm-configurations), there should be at least 2 cores, but this doesn't seem to be triggering automatically.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines