### PR TITLE
Fix errorbar autoscaling inconsistency on log axes

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1183,19 +1183,13 @@ class Axes(_AxesBase):
             # e.g. by errorbar()), which would make nanmin/nanmax stumble.
             updatex = True
             updatey = True
+            minx = np.nanmin(masked_verts[..., 0])
+            maxx = np.nanmax(masked_verts[..., 0])
+            miny = np.nanmin(masked_verts[..., 1])
+            maxy = np.nanmax(masked_verts[..., 1])
             if self.name == "rectilinear":
-                datalim = lines.get_datalim(self.transData)
                 t = lines.get_transform()
                 updatex, updatey = t.contains_branch_separately(self.transData)
-                minx = np.nanmin(datalim.xmin)
-                maxx = np.nanmax(datalim.xmax)
-                miny = np.nanmin(datalim.ymin)
-                maxy = np.nanmax(datalim.ymax)
-            else:
-                minx = np.nanmin(masked_verts[..., 0])
-                maxx = np.nanmax(masked_verts[..., 0])
-                miny = np.nanmin(masked_verts[..., 1])
-                maxy = np.nanmax(masked_verts[..., 1])
 
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners, updatex, updatey)
@@ -1275,19 +1269,13 @@ class Axes(_AxesBase):
             # e.g. by errorbar()), which would make nanmin/nanmax stumble.
             updatex = True
             updatey = True
+            minx = np.nanmin(masked_verts[..., 0])
+            maxx = np.nanmax(masked_verts[..., 0])
+            miny = np.nanmin(masked_verts[..., 1])
+            maxy = np.nanmax(masked_verts[..., 1])
             if self.name == "rectilinear":
-                datalim = lines.get_datalim(self.transData)
                 t = lines.get_transform()
                 updatex, updatey = t.contains_branch_separately(self.transData)
-                minx = np.nanmin(datalim.xmin)
-                maxx = np.nanmax(datalim.xmax)
-                miny = np.nanmin(datalim.ymin)
-                maxy = np.nanmax(datalim.ymax)
-            else:
-                minx = np.nanmin(masked_verts[..., 0])
-                maxx = np.nanmax(masked_verts[..., 0])
-                miny = np.nanmin(masked_verts[..., 1])
-                maxy = np.nanmax(masked_verts[..., 1])
 
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners, updatex, updatey)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1183,13 +1183,19 @@ class Axes(_AxesBase):
             # e.g. by errorbar()), which would make nanmin/nanmax stumble.
             updatex = True
             updatey = True
-            minx = np.nanmin(masked_verts[..., 0])
-            maxx = np.nanmax(masked_verts[..., 0])
-            miny = np.nanmin(masked_verts[..., 1])
-            maxy = np.nanmax(masked_verts[..., 1])
             if self.name == "rectilinear":
+                datalim = lines.get_datalim(self.transData)
                 t = lines.get_transform()
                 updatex, updatey = t.contains_branch_separately(self.transData)
+                minx = np.nanmin(datalim.xmin)
+                maxx = np.nanmax(datalim.xmax)
+                miny = np.nanmin(datalim.ymin)
+                maxy = np.nanmax(datalim.ymax)
+            else:
+                minx = np.nanmin(masked_verts[..., 0])
+                maxx = np.nanmax(masked_verts[..., 0])
+                miny = np.nanmin(masked_verts[..., 1])
+                maxy = np.nanmax(masked_verts[..., 1])
 
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners, updatex, updatey)
@@ -1269,13 +1275,19 @@ class Axes(_AxesBase):
             # e.g. by errorbar()), which would make nanmin/nanmax stumble.
             updatex = True
             updatey = True
-            minx = np.nanmin(masked_verts[..., 0])
-            maxx = np.nanmax(masked_verts[..., 0])
-            miny = np.nanmin(masked_verts[..., 1])
-            maxy = np.nanmax(masked_verts[..., 1])
             if self.name == "rectilinear":
+                datalim = lines.get_datalim(self.transData)
                 t = lines.get_transform()
                 updatex, updatey = t.contains_branch_separately(self.transData)
+                minx = np.nanmin(datalim.xmin)
+                maxx = np.nanmax(datalim.xmax)
+                miny = np.nanmin(datalim.ymin)
+                maxy = np.nanmax(datalim.ymax)
+            else:
+                minx = np.nanmin(masked_verts[..., 0])
+                maxx = np.nanmax(masked_verts[..., 0])
+                miny = np.nanmin(masked_verts[..., 1])
+                maxy = np.nanmax(masked_verts[..., 1])
 
             corners = (minx, miny), (maxx, maxy)
             self.update_datalim(corners, updatex, updatey)

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -291,8 +291,11 @@ class Collection(mcolorizer.ColorizingArtist):
             if isinstance(offsets, np.ma.MaskedArray):
                 offsets = offsets.filled(np.nan)
                 # get_path_collection_extents handles nan but not masked arrays
+            data_trf = transform.get_affine() - transData
+            if not data_trf.is_affine:
+                paths = [data_trf.transform_path_non_affine(p) for p in paths]
             return mpath.get_path_collection_extents(
-                transform.get_affine() - transData, paths,
+                data_trf.get_affine(), paths,
                 self.get_transforms(),
                 offset_trf.transform_non_affine(offsets),
                 offset_trf.get_affine().frozen())

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4660,7 +4660,7 @@ def test_errorbar_log_autoscale_order_independent():
     yerr = np.ones_like(y) * 10
 
     fig, (ax1, ax2) = plt.subplots(2)
-    
+
     ax1.set_xscale("log")
     ax1.set_yscale("log")
     ax1.errorbar(x, y, yerr=yerr)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4659,12 +4659,12 @@ def test_errorbar_log_autoscale_order_independent():
     y = np.array([100, 80, 60, 30])
     yerr = np.ones_like(y) * 10
 
-    fig1, ax1 = plt.subplots()
+    fig, (ax1, ax2) = plt.subplots(2)
+    
     ax1.set_xscale("log")
     ax1.set_yscale("log")
     ax1.errorbar(x, y, yerr=yerr)
 
-    fig2, ax2 = plt.subplots()
     ax2.errorbar(x, y, yerr=yerr)
     ax2.set_xscale("log")
     ax2.set_yscale("log")

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -4654,6 +4654,25 @@ def test_errorbar_limits():
     ax.set_title('Errorbar upper and lower limits')
 
 
+def test_errorbar_log_autoscale_order_independent():
+    x = 10 ** np.array([18, 18.1, 18.2, 18.3])
+    y = np.array([100, 80, 60, 30])
+    yerr = np.ones_like(y) * 10
+
+    fig1, ax1 = plt.subplots()
+    ax1.set_xscale("log")
+    ax1.set_yscale("log")
+    ax1.errorbar(x, y, yerr=yerr)
+
+    fig2, ax2 = plt.subplots()
+    ax2.errorbar(x, y, yerr=yerr)
+    ax2.set_xscale("log")
+    ax2.set_yscale("log")
+
+    assert_allclose(ax1.get_xlim(), ax2.get_xlim())
+    assert_allclose(ax1.get_ylim(), ax2.get_ylim())
+
+
 def test_errorbar_nonefmt():
     # Check that passing 'none' as a format still plots errorbars
     x = np.arange(5)


### PR DESCRIPTION
## PR summary

closes #31462

This PR fixes an autoscaling inconsistency for `errorbar` on log-scaled axes by addressing a root-cause bug in `Collection.get_datalim`.

### Why this change is necessary

When log scale is set before calling `errorbar`, autoscaling can produce incorrect lower limits (often collapsing near 1).
If `errorbar` is called first and log scale is applied afterward, the limits are correct.

This order-dependent behavior is unexpected and inconsistent.

---

### What this PR changes

As suggested by maintainers in the review, the root cause was traced to `Collection.get_datalim`. 

When calculating limits on log axes, `transform.get_affine() - transData` yields an inverse non-affine (inverse log) component. However, this was being passed to the C wrapper (`_path_wrapper.cpp`), which only accepts affine matrices. The non-affine part was completely discarded at the C boundary, causing extents to be computed in log-transformed coordinates instead of original data coordinates.

To fix this:
* This PR pre-applies the non-affine component to the paths in Python *before* passing the remaining affine transform to the C extents call.
* Adds a regression test to ensure both call orders now produce consistent limits.
---

### Before fix (incorrect behavior)

<img width="1287" height="1069" alt="Screenshot 2026-04-08 201640" src="https://github.com/user-attachments/assets/2d44ea52-a43b-4c5b-ad3c-d656a05573eb" />

* Lower limits collapse near ~1 when using `scale → errorbar`

---

### After fix (correct behavior)

<img width="1266" height="1067" alt="image" src="https://github.com/user-attachments/assets/6a3d9c83-dc35-4a94-b5ff-db3330a0eead" />


* Both orders now produce consistent and reasonable limits

---

### Minimum self-contained example

```python
import numpy as np
import matplotlib.pyplot as plt

x = 10 ** np.array([18, 18.1, 18.2, 18.3])
y = np.array([100, 80, 60, 30])
yerr = np.ones_like(y) * 10

# Order 1: scale -> errorbar
fig1, ax1 = plt.subplots()
ax1.set_xscale("log")
ax1.set_yscale("log")
ax1.errorbar(x, y, yerr=yerr)

# Order 2: errorbar -> scale
fig2, ax2 = plt.subplots()
ax2.errorbar(x, y, yerr=yerr)
ax2.set_xscale("log")
ax2.set_yscale("log")

print(ax1.get_xlim(), ax1.get_ylim())
print(ax2.get_xlim(), ax2.get_ylim())
```

---

### Expected after this PR

* Both orders produce consistent, reasonable limits

---

## AI Disclosure

AI tools were used to assist in drafting text and suggesting validation scenarios.
All code changes, final implementation decisions, and verification were done manually.

---

## PR checklist

* [x] closes #31462
* [x] new and changed code is tested
* [N/A] Plotting related features are demonstrated in an example
* [N/A] New Features and API Changes are noted
* [N/A] Documentation changes
