### PR TITLE
MAINT: Set "skip internal contributors" to False on PR welcome bot

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: plbstl/first-contribution@5e84b16ee0cef8f8a87cb7a2cf247b187c228879  # v4.3.1
         with:
           labels: first-contribution
-          skip-internal-contributors: true
+          skip-internal-contributors: false
           pr-opened-msg: >+
             Thank you for opening your first PR into Matplotlib!
 

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -16,7 +16,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: plbstl/first-contribution@5e84b16ee0cef8f8a87cb7a2cf247b187c228879  # v4.3.1
+      - uses: plbstl/first-contribution@fa732d1b5586da1a72ba34290a32e87467a59b78  # v4.3.2
         with:
           labels: first-contribution
           skip-internal-contributors: false

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -16,9 +16,10 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: plbstl/first-contribution@4fb1541ce2706255850d56c5684552607be1ae9b  # v4.2.0
+      - uses: plbstl/first-contribution@5e84b16ee0cef8f8a87cb7a2cf247b187c228879  # v4.3.1
         with:
           labels: first-contribution
+          skip-internal-contributors: true
           pr-opened-msg: >+
             Thank you for opening your first PR into Matplotlib!
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
This first-contribution github action had a recent new release that breaks our usage. For example:

https://github.com/matplotlib/matplotlib/actions/runs/24148295131?pr=31478

In this case, the action fails with `Error: GH_PAT_READ_ORG env variable is not set.`. The new release of the action includes [a new option "skip-internal-contributors" that should only require a PAT when set to true](https://github.com/plbstl/first-contribution#skip-internal-contributors), but it is requiring the env var in all cases. This is a bug in first-contributions and I'll report upstream, but in the meantime (and frankly I think this is a good idea regardless) we can set this option to true, as long as we set the `GH_PAT_READ_ORG`. This means the first-contribution action will not run for all PRs but only for external contributors.

## AI Disclosure
No AI was used.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
