### PR TITLE
MNT: Use new defaults in set_font_settings_for_testing

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -19,15 +19,8 @@ _log = logging.getLogger(__name__)
 
 def set_font_settings_for_testing():
     mpl.rcParams['font.family'] = 'DejaVu Sans'
-    # We've changed the default for ourselves here, but for backwards-compatibility, use
-    # the old setting if not called in our own tests (which would set
-    # `_called_from_pytest` from our `conftest.py`).
-    if getattr(mpl, '_called_from_pytest', False):
-        mpl.rcParams['text.hinting'] = 'default'
-        mpl.rcParams['text.hinting_factor'] = 1
-    else:
-        mpl.rcParams['text.hinting'] = 'none'
-        mpl.rcParams['text.hinting_factor'] = 8
+    mpl.rcParams['text.hinting'] = 'default'
+    mpl.rcParams['text.hinting_factor'] = 1
 
 
 def set_reproducibility_for_testing():


### PR DESCRIPTION
## PR summary

@tacaswell argued that downstreams will already have to contend with changes in text due to FreeType upgrades, so keeping the old hinting defaults doesn't really help with backwards compatibility and makes things different for other projects for no reason.

Followup to https://github.com/matplotlib/matplotlib/pull/30161#pullrequestreview-4090935810

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines