### PR TITLE
MNT: Update bundled font libraries

### DIFF
--- a/extern/meson.build
+++ b/extern/meson.build
@@ -42,17 +42,24 @@ else
       'gdi=disabled',
       'glib=disabled',
       'gobject=disabled',
+      'gpu=disabled',
+      'gpu_demo=disabled',
       'harfrust=disabled',
       'icu=disabled',
       'introspection=disabled',
       'kbts=disabled',
+      'png=disabled',
+      'raster=disabled',
+      'subset=disabled',
       'tests=disabled',
       'utilities=disabled',
+      'vector=disabled',
       'wasm=disabled',
+      'zlib=disabled',
     ]
   )
   subproject('sheenbidi', default_options: ['default_library=static'])
-  libraqm_proj = subproject('libraqm-0.10.4',
+  libraqm_proj = subproject('libraqm',
     default_options: [
       'default_library=static',
       'sheenbidi=true',

--- a/subprojects/harfbuzz.wrap
+++ b/subprojects/harfbuzz.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = harfbuzz-12.3.0
-source_url = https://github.com/harfbuzz/harfbuzz/releases/download/12.3.0/harfbuzz-12.3.0.tar.xz
-source_filename = harfbuzz-12.3.0.tar.xz
-source_hash = 8660ebd3c27d9407fc8433b5d172bafba5f0317cb0bb4339f28e5370c93d42b7
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/harfbuzz_12.3.0-1/harfbuzz-12.3.0.tar.xz
-wrapdb_version = 12.3.0-1
+directory = harfbuzz-14.1.0
+source_url = https://github.com/harfbuzz/harfbuzz/releases/download/14.1.0/harfbuzz-14.1.0.tar.xz
+source_filename = harfbuzz-14.1.0.tar.xz
+source_hash = ee0eb3a1da2c5a28147f12dff55f6c7d60aeeeb29ac7ef334eabe84c8476c105
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/harfbuzz_14.1.0-1/harfbuzz-14.1.0.tar.xz
+wrapdb_version = 14.1.0-1
 
 [provide]
-dependency_names = harfbuzz, harfbuzz-cairo, harfbuzz-gobject, harfbuzz-icu, harfbuzz-subset
+dependency_names = harfbuzz, harfbuzz-cairo, harfbuzz-gobject, harfbuzz-gpu, harfbuzz-icu, harfbuzz-raster, harfbuzz-subset, harfbuzz-vector

--- a/subprojects/libraqm-0.10.4.wrap
+++ b/subprojects/libraqm-0.10.4.wrap
@@ -1,7 +1,0 @@
-[wrap-file]
-source_url = https://github.com/HOST-Oman/libraqm/archive/v0.10.4/libraqm-0.10.4.tar.gz
-source_filename = libraqm-0.10.4.tar.gz
-source_hash = 6b583fb0eb159a3727a1e8c653bb0294173a14af8eb60195a775879de72320a3
-
-# First patch allows using our bundled FreeType.
-diff_files = libraqm-0.10.2-bundle-freetype.patch

--- a/subprojects/libraqm.wrap
+++ b/subprojects/libraqm.wrap
@@ -1,0 +1,8 @@
+[wrap-file]
+directory = libraqm-0.10.5
+source_url = https://github.com/HOST-Oman/libraqm/archive/v0.10.5/libraqm-0.10.5.tar.gz
+source_filename = libraqm-0.10.5.tar.gz
+source_hash = 7f3dd21b4b3bd28a36f2c911d31d91a9d69341697713923ef1aac65d56ebcafd
+
+# First patch allows using our bundled FreeType.
+diff_files = libraqm-0.10.2-bundle-freetype.patch

--- a/subprojects/sheenbidi.wrap
+++ b/subprojects/sheenbidi.wrap
@@ -1,5 +1,5 @@
 [wrap-file]
-directory = SheenBidi-2.9.0
-source_url = https://github.com/Tehreer/SheenBidi/archive/refs/tags/v2.9.0/sheenbidi-2.9.0.tar.gz
-source_filename = sheenbidi-2.9.0.tar.gz
-source_hash = e90ae142c6fc8b94366f3526f84b349a2c10137f87093db402fe51f6eace6d13
+directory = SheenBidi-3.0.0
+source_url = https://github.com/Tehreer/SheenBidi/archive/refs/tags/v3.0.0/sheenbidi-3.0.0.tar.gz
+source_filename = sheenbidi-3.0.0.tar.gz
+source_hash = 86c56014034739ba39a24c23eb00323b0bf6f737354f665786015fca842af786


### PR DESCRIPTION
## PR summary

SheenBidi 3.0.0 adds new text editing and analysis API, but that does not directly affect us as it is used by libraqm only.

HarfBuzz 12.3.1 and 12.3.2 fix several bugs and vulnerabilities.

HarfBuzz 13 adds experimental raster and vector rendering libraries. These may be useful for implementing colour emoji, but we remain using FreeType right now.

HarfBuzz 14 adds a GPU text rasterization library. This is again not useful for us right now, unless we start making a GPU backend.

As we have disabled these new features, there should be no size change in the resulting Python extensions, or increased compile time.

Note, the Meson wrapdb hasn't been updated: https://github.com/mesonbuild/wrapdb/pull/2695 but I updated the fallback URL anyway.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines