### PR TITLE
DOC: Minor style improvement of radio buttons examples

### DIFF
--- a/galleries/examples/widgets/radio_buttons.py
+++ b/galleries/examples/widgets/radio_buttons.py
@@ -40,8 +40,10 @@ fig, axd = plt.subplot_mosaic(
 axd['main'].set(xlabel="Time (s)", ylabel="Amplitude", title="Sine Wave")
 
 background_color = '0.95'
+edge_color = '0.8'
 
 axd['freq'].set_facecolor(background_color)
+axd['freq'].spines[:].set_color(edge_color)
 axd['freq'].set_title('Frequency')
 radio = RadioButtons(axd['freq'], labels=list(FREQUENCIES.keys()),
                      label_props={'fontsize': [12, 14, 16]},
@@ -56,6 +58,7 @@ radio.on_clicked(update_frequency)
 
 
 axd['color'].set_facecolor(background_color)
+axd['color'].spines[:].set_color(edge_color)
 axd['color'].set_title('Color')
 radio2 = RadioButtons(
     axd['color'], ('red', 'blue', 'green'),
@@ -73,6 +76,7 @@ radio2.on_clicked(update_color)
 
 
 axd['linestyle'].set_facecolor(background_color)
+axd['linestyle'].spines[:].set_color(edge_color)
 axd['linestyle'].set_title('Linestyle')
 radio3 = RadioButtons(axd['linestyle'], ('solid', 'dashed', 'dashdot', 'dotted'))
 

--- a/galleries/examples/widgets/radio_buttons_grid.py
+++ b/galleries/examples/widgets/radio_buttons_grid.py
@@ -36,6 +36,7 @@ ax.set(xlabel="Time (s)", ylabel="Amplitude", title="Sine Wave - Click a color!"
 
 # Configure the radio buttons axes
 ax_buttons.set_facecolor("0.95")
+ax_buttons.spines[:].set_color("0.8")
 ax_buttons.set_title("Line Color")
 # Create a 2D grid of color options (3 rows x 2 columns)
 colors = ["red", "yellow", "green", "purple", "brown", "gray"]


### PR DESCRIPTION
Lighten the edges of the Axes serving as a container for the buttons. The black line has too much contrast and made the panels look "old".

## AI Disclosure
<!-- If you used AI in writing this PR, please briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#restrictions-on-generative-ai-usage
-->
No AI
