### PR TITLE
DOC: document xlim_changed / ylim_changed / zlim_changed axes callbacks

### DIFF
--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -208,6 +208,41 @@ Event name             Class            Description
 Matplotlib attaches some keypress callbacks by default for interactivity; they
 are documented in the :ref:`key-event-handling` section.
 
+.. _axes-limit-events:
+
+Axes limit change events
+========================
+
+In addition to the canvas events listed above, :class:`~matplotlib.axes.Axes`
+instances expose their own callback registry for axes-specific events.  Connect
+to these events with ``ax.callbacks.connect()`` rather than
+``fig.canvas.mpl_connect()``:
+
+``'xlim_changed'``
+    Fired when the x-axis view limits change. The callback receives the
+    :class:`~matplotlib.axes.Axes` instance as its sole argument.
+
+``'ylim_changed'``
+    Fired when the y-axis view limits change. The callback receives the
+    :class:`~matplotlib.axes.Axes` instance as its sole argument.
+
+``'zlim_changed'``
+    *(3D axes only)* Fired when the z-axis view limits change. The callback
+    receives the :class:`~mpl_toolkits.mplot3d.axes3d.Axes3D` instance as its
+    sole argument.
+
+For example::
+
+    fig, ax = plt.subplots()
+
+    def on_xlim_change(ax):
+        print(f"x limits changed to {ax.get_xlim()}")
+
+    ax.callbacks.connect('xlim_changed', on_xlim_change)
+
+These callbacks are disconnected via ``ax.callbacks.disconnect(cid)`` where
+*cid* is the integer connection id returned by ``ax.callbacks.connect()``.
+
 .. _event-attributes:
 
 Event attributes


### PR DESCRIPTION
## Summary

Closes #30647.

`xlim_changed` and `ylim_changed` (and `zlim_changed` for 3-D axes) are
Matplotlib events that users can subscribe to via `ax.callbacks.connect()`,
but they were absent from the "Event connections" reference table and had
no dedicated section in the event-handling guide.  They were mentioned only
in scattered docstrings and examples, making them hard to discover.

## Changes

Adds a new **"Axes limit change events"** section to
`galleries/users_explain/figure/event_handling.rst` that:

* lists and describes `xlim_changed`, `ylim_changed`, and `zlim_changed`
* shows the correct API (`ax.callbacks.connect()` / `ax.callbacks.disconnect()`)
* includes a minimal usage example

## Test plan

- [x] Docs build correctly (RST syntax verified)
- [x] New section renders in the right place in the guide

🤖 Generated with [Claude Code](https://claude.com/claude-code)