### PR TITLE
DOC: clarify Axes limit callbacks in event handling guide

### DIFF
--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -208,26 +208,14 @@ Event name             Class            Description
 Matplotlib attaches some keypress callbacks by default for interactivity; they
 are documented in the :ref:`key-event-handling` section.
 
-.. _axes-callbacks:
-
-Axes callbacks
-==============
-
-The events listed above are canvas events connected with
-``canvas.mpl_connect``. `~.axes.Axes` also has a ``callbacks`` registry for
-Axes-specific changes. For limit changes, connect with
-``ax.callbacks.connect``; the callback receives the `~.axes.Axes` rather than
-an event.
-
-``'xlim_changed'``
-    Called when the x-axis view limits change.
-
-``'ylim_changed'``
-    Called when the y-axis view limits change.
-
-See :doc:`/gallery/subplots_axes_and_figures/fahrenheit_celsius_scales`
-for a ``ylim_changed`` example and :doc:`/gallery/event_handling/resample`
-for a ``xlim_changed`` example.
+.. note::
+   ``'xlim_changed'`` and ``'ylim_changed'`` are Axes callbacks rather than
+   canvas events, so they do not appear in the table above. Connect to them
+   with ``ax.callbacks.connect``; the callback receives the `~.axes.Axes`
+   rather than an event. See
+   :doc:`/gallery/subplots_axes_and_figures/fahrenheit_celsius_scales` for a
+   ``ylim_changed`` example and :doc:`/gallery/event_handling/resample` for a
+   ``xlim_changed`` example.
 
 .. _event-attributes:
 

--- a/galleries/users_explain/figure/event_handling.rst
+++ b/galleries/users_explain/figure/event_handling.rst
@@ -208,6 +208,27 @@ Event name             Class            Description
 Matplotlib attaches some keypress callbacks by default for interactivity; they
 are documented in the :ref:`key-event-handling` section.
 
+.. _axes-callbacks:
+
+Axes callbacks
+==============
+
+The events listed above are canvas events connected with
+``canvas.mpl_connect``. `~.axes.Axes` also has a ``callbacks`` registry for
+Axes-specific changes. For limit changes, connect with
+``ax.callbacks.connect``; the callback receives the `~.axes.Axes` rather than
+an event.
+
+``'xlim_changed'``
+    Called when the x-axis view limits change.
+
+``'ylim_changed'``
+    Called when the y-axis view limits change.
+
+See :doc:`/gallery/subplots_axes_and_figures/fahrenheit_celsius_scales`
+for a ``ylim_changed`` example and :doc:`/gallery/event_handling/resample`
+for a ``xlim_changed`` example.
+
 .. _event-attributes:
 
 Event attributes


### PR DESCRIPTION
Closes #30647.

Add a short note to the event handling guide that Axes limit callbacks are
separate from canvas events. Document `xlim_changed` and `ylim_changed`
and point to the existing examples.

Thanks to @shiivangr and @DORI2001 for earlier work on this topic.
