### PR TITLE
MAINT: Add PR triage board action

### DIFF
--- a/.github/workflows/triage_board.yml
+++ b/.github/workflows/triage_board.yml
@@ -1,0 +1,20 @@
+---
+name: 'Update PR Triage Board'
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # Run every hour
+  workflow_dispatch:
+
+jobs:
+  pr-triage:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update PR Triage Board
+        uses: yuvipanda/pr-triage-board-bot@main
+        with:
+          organization: 'matplotlib'
+          project-number: '11'
+          gh-app-id: '3339145'
+          gh-app-installation-id: '122963236'
+          gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}

--- a/.github/workflows/triage_board.yml
+++ b/.github/workflows/triage_board.yml
@@ -6,15 +6,18 @@ on:
     - cron: '0 * * * *'  # Run every hour
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   pr-triage:
     runs-on: ubuntu-latest
     steps:
       - name: Update PR Triage Board
-        uses: yuvipanda/pr-triage-board-bot@main
+        uses: jupyter/pr-triage-board-bot@dae1209c73e70224b2f2955590d0698832a5a076  # main @ Oct 26, 2025
         with:
           organization: 'matplotlib'
           project-number: '11'
           gh-app-id: '3339145'
           gh-app-installation-id: '122963236'
           gh-app-private-key: ${{ secrets.GH_APP_PRIVATE_KEY }}
+          repositories: 'matplotlib'


### PR DESCRIPTION
## PR summary
Adds a github action to manage the PR Triage Board set up at https://github.com/orgs/matplotlib/projects/11, following the instructions on https://github.com/jupyter/pr-triage-board-bot#using-as-a-github-action

This was discussed in our weekly meeting a couple of times. Thanks @ksunden for the help setting this up!

## AI Disclosure
No AI tooling was used.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

