### PR TITLE
Re-order variants to prioritize narrower types

### DIFF
--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -58,8 +58,8 @@ PyRendererAgg_draw_path(RendererAgg *self,
 static void
 PyRendererAgg_draw_text_image(RendererAgg *self,
                               py::array_t<agg::int8u, py::array::c_style | py::array::forcecast> image_obj,
-                              std::variant<double, int> vx,
-                              std::variant<double, int> vy,
+                              std::variant<int, double> vx,
+                              std::variant<int, double> vy,
                               double angle,
                               GCAgg &gc)
 {

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -14,7 +14,7 @@ namespace py = pybind11;
 using namespace pybind11::literals;
 
 template <typename T>
-using double_or_ = std::variant<double, T>;
+using double_or_ = std::variant<T, double>;
 
 template <typename T>
 static T


### PR DESCRIPTION
## PR summary

As of https://github.com/pybind/pybind11/pull/5879, pybind11 will convert Python `int` to C `float`/`double`. For `std::variant`, pybind11 will attempt to convert arguments in the order of the type.

So if `double` occurs earlier in the variant, then `int`/`long` will never be produced. By putting `int`/`long` before `double`, pybind11 will attempt that conversion first and we'll continue to produce our deprecation warning correctly.

Fixes #31495

## AI Disclosure
None

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines