### PR TITLE
Fix incorrect fontweight option in text_props gallery

### DIFF
--- a/galleries/users_explain/text/text_props.py
+++ b/galleries/users_explain/text/text_props.py
@@ -41,7 +41,7 @@ transform                   `~matplotlib.transforms.Transform` subclass
 variant                     [ ``'normal'`` | ``'small-caps'`` ]
 verticalalignment or va     [ ``'center'`` | ``'top'`` | ``'bottom'`` | ``'baseline'`` ]
 visible                     bool
-weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultrabold'`` | ``'ultralight'``]
+weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultralight'``]
 x                           `float`
 y                           `float`
 zorder                      any number


### PR DESCRIPTION
Fixes #31506

Removed invalid fontweight value "ultrabold" from the text_props gallery documentation to match actual supported values in the API.