### PR TITLE
Make Animation._repr_html_ more useful by default

### DIFF
--- a/doc/release/next_whats_new/animation_default.rst
+++ b/doc/release/next_whats_new/animation_default.rst
@@ -1,0 +1,7 @@
+Animations now default to video rich display in Jupyter notebooks
+-----------------------------------------------------------------
+
+When rich display of an Animation object is requested (i.e., by placing the variable as
+the last line in a notebook cell), it will now default to the best available video
+output. That is, if FFmpeg is available, a video file will be output, otherwise a
+JavaScript animation will be output.

--- a/galleries/users_explain/animations/animations.py
+++ b/galleries/users_explain/animations/animations.py
@@ -64,6 +64,9 @@ import matplotlib.animation as animation
 #    - `.Animation.to_jshtml` to create HTML code with interactive JavaScript animation
 #      controls
 #    - `.Animation.save` to save the animation to a file
+#    - Place the animation as the last statement in a Jupyter Notebook cell; this will
+#      automatically render the animation as video and display it as the cell output,
+#      unless :rc:`animation.html` is set to ``'none'``.
 #
 # The following table shows a few plotting methods, the artists they return and some
 # commonly used ``set_*`` methods that update the underlying data. While updating data

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1274,7 +1274,7 @@ class Animation:
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
                                                        self._on_resize)
 
-    def to_html5_video(self, embed_limit=None):
+    def to_html5_video(self, embed_limit=None, _writer_cls=None):
         """
         Convert the animation to an HTML5 ``<video>`` tag.
 
@@ -1317,10 +1317,11 @@ class Animation:
                 path = Path(tmpdir, "temp.m4v")
                 # We create a writer manually so that we can get the
                 # appropriate size for the tag
-                Writer = writers[mpl.rcParams['animation.writer']]
-                writer = Writer(codec='h264',
-                                bitrate=mpl.rcParams['animation.bitrate'],
-                                fps=1000. / self._interval)
+                if _writer_cls is None:
+                    _writer_cls = writers[mpl.rcParams['animation.writer']]
+                writer = _writer_cls(codec='h264',
+                                     bitrate=mpl.rcParams['animation.bitrate'],
+                                     fps=1000. / self._interval)
                 self.save(str(path), writer=writer)
                 # Now open and base64 encode.
                 vid64 = base64.encodebytes(path.read_bytes())
@@ -1399,10 +1400,19 @@ class Animation:
     def _repr_html_(self):
         """IPython display hook for rendering."""
         fmt = mpl.rcParams['animation.html']
+        if fmt == 'none':
+            return
+        kwargs = {}
+        if fmt == 'auto':
+            if writers.is_available('ffmpeg'):
+                fmt = 'html5'
+                kwargs['_writer_cls'] = writers['ffmpeg']
+            else:
+                fmt = 'jshtml'
         if fmt == 'html5':
-            return self.to_html5_video()
+            return self.to_html5_video(**kwargs)
         elif fmt == 'jshtml':
-            return self.to_jshtml()
+            return self.to_jshtml(**kwargs)
 
     def pause(self):
         """Pause the animation."""

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -1272,7 +1272,7 @@ class Animation:
         self._resize_id = self._fig.canvas.mpl_connect('resize_event',
                                                        self._on_resize)
 
-    def to_html5_video(self, embed_limit=None):
+    def to_html5_video(self, embed_limit=None, _writer_cls=None):
         """
         Convert the animation to an HTML5 ``<video>`` tag.
 
@@ -1315,10 +1315,11 @@ class Animation:
                 path = Path(tmpdir, "temp.m4v")
                 # We create a writer manually so that we can get the
                 # appropriate size for the tag
-                Writer = writers[mpl.rcParams['animation.writer']]
-                writer = Writer(codec='h264',
-                                bitrate=mpl.rcParams['animation.bitrate'],
-                                fps=1000. / self._interval)
+                if _writer_cls is None:
+                    _writer_cls = writers[mpl.rcParams['animation.writer']]
+                writer = _writer_cls(codec='h264',
+                                     bitrate=mpl.rcParams['animation.bitrate'],
+                                     fps=1000 / self._interval)
                 self.save(str(path), writer=writer)
                 # Now open and base64 encode.
                 vid64 = base64.encodebytes(path.read_bytes())
@@ -1397,10 +1398,19 @@ class Animation:
     def _repr_html_(self):
         """IPython display hook for rendering."""
         fmt = mpl.rcParams['animation.html']
+        if fmt == 'none':
+            return
+        kwargs = {}
+        if fmt == 'auto':
+            if writers.is_available('ffmpeg'):
+                fmt = 'html5'
+                kwargs['_writer_cls'] = writers['ffmpeg']
+            else:
+                fmt = 'jshtml'
         if fmt == 'html5':
-            return self.to_html5_video()
+            return self.to_html5_video(**kwargs)
         elif fmt == 'jshtml':
-            return self.to_jshtml()
+            return self.to_jshtml(**kwargs)
 
     def pause(self):
         """Pause the animation."""

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -825,10 +825,11 @@
 ## ***************************************************************************
 ## * ANIMATION                                                               *
 ## ***************************************************************************
-#animation.html: none  # How to display the animation as HTML in
-                       # the IPython notebook:
-                       #     - 'html5' uses HTML5 video tag
-                       #     - 'jshtml' creates a JavaScript animation
+#animation.html: auto  # How to display the animation as HTML in the IPython notebook:
+                       #   - 'none' displays nothing
+                       #   - 'html5' uses HTML5 video tag
+                       #   - 'jshtml' creates a JavaScript animation
+                       #   - 'auto' picks the best available option
 #animation.writer:  ffmpeg        # MovieWriter 'backend' to use
 #animation.codec:   h264          # Codec to use for writing movie
 #animation.bitrate: -1            # Controls size/quality trade-off for movie.

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -823,10 +823,11 @@
 ## ***************************************************************************
 ## * ANIMATION                                                               *
 ## ***************************************************************************
-#animation.html: none  # How to display the animation as HTML in
-                       # the IPython notebook:
-                       #     - 'html5' uses HTML5 video tag
-                       #     - 'jshtml' creates a JavaScript animation
+#animation.html: auto  # How to display the animation as HTML in the IPython notebook:
+                       #   - 'none' displays nothing
+                       #   - 'html5' uses HTML5 video tag
+                       #   - 'jshtml' creates a JavaScript animation
+                       #   - 'auto' picks the best available option
 #animation.writer:  ffmpeg        # MovieWriter 'backend' to use
 #animation.codec:   h264          # Codec to use for writing movie
 #animation.bitrate: -1            # Controls size/quality trade-off for movie.

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1448,7 +1448,7 @@ _validators = {
     "keymap.copy":       validate_stringlist,
 
     # Animation settings
-    "animation.html":         ["html5", "jshtml", "none"],
+    "animation.html":         ["auto", "html5", "jshtml", "none"],
     # Limit, in MB, of size of base64 encoded animation in HTML
     # (i.e. IPython notebook)
     "animation.embed_limit":  validate_float,
@@ -3354,11 +3354,13 @@ _DEFINITION = [
     _Section("Animation"),
     _Param(
         "animation.html",
-        default="none",
-        validator=["html5", "jshtml", "none"],
-        description="How to display the animation as HTML in the IPython notebook: "
-                    "- 'html5' uses HTML5 video tag "
-                    "- 'jshtml' creates a JavaScript animation"
+        default="auto",
+        validator=["auto", "html5", "jshtml", "none"],
+        description="How to display the animation as HTML in the IPython notebook:\n"
+                    "- 'auto' picks the best available option\n"
+                    "- 'html5' uses HTML5 video tag\n"
+                    "- 'jshtml' creates a JavaScript animation\n"
+                    "- 'none' displays nothing"
     ),
     _Param(
         "animation.writer",

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -1448,7 +1448,7 @@ _validators = {
     "keymap.copy":       validate_stringlist,
 
     # Animation settings
-    "animation.html":         ["html5", "jshtml", "none"],
+    "animation.html":         ["auto", "html5", "jshtml", "none"],
     # Limit, in MB, of size of base64 encoded animation in HTML
     # (i.e. IPython notebook)
     "animation.embed_limit":  validate_float,
@@ -3687,12 +3687,14 @@ _DEFINITION = [
     _Section("Animation"),
     _Param(
         "animation.html",
-        default="none",
-        type=Literal["html5", "jshtml", "none"],
-        validator=["html5", "jshtml", "none"],
-        description="How to display the animation as HTML in the IPython notebook: "
-                    "- 'html5' uses HTML5 video tag "
-                    "- 'jshtml' creates a JavaScript animation"
+        default="auto",
+        type=Literal["auto", "html5", "jshtml", "none"],
+        validator=["auto", "html5", "jshtml", "none"],
+        description="How to display the animation as HTML in the IPython notebook:\n"
+                    "- 'auto' picks the best available option\n"
+                    "- 'html5' uses HTML5 video tag\n"
+                    "- 'jshtml' creates a JavaScript animation\n"
+                    "- 'none' displays nothing"
     ),
     _Param(
         "animation.writer",

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -270,6 +270,22 @@ def test_animation_repr_html(writer, html, want, anim):
         assert want in html
 
 
+@pytest.mark.parametrize('writer, want', [
+    pytest.param(
+        'ffmpeg', '<video width',
+        marks=pytest.mark.skipif(not animation.FFMpegWriter.isAvailable(),
+                                 reason='Requires FFMpeg')),
+    pytest.param('jshtml', '<script '),
+])
+@pytest.mark.parametrize('anim', [{}], indirect=['anim'])
+def test_animation_repr_html_auto(writer, want, anim, monkeypatch):
+    monkeypatch.setattr('matplotlib.animation.writers.is_available',
+                        lambda name: name == writer)
+    with plt.rc_context({'animation.html': 'auto'}):
+        html = anim._repr_html_()
+    assert want in html
+
+
 @pytest.mark.parametrize(
     'anim',
     [{'save_count': 10, 'frames': iter(range(5))}],


### PR DESCRIPTION
## PR summary

While `Animation` does define `_repr_html_`, it does nothing by default since `animation.html` is 'none'. The 'html5' option is the best, but it requires FFmpeg to be installed. So introduce a new 'auto' option that picks either one depending on what's available, and make it the default.

This still needs some docs/tests, if we are okay with this approach.

## AI Disclosure
None

## PR checklist
- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines