### PR TITLE
Document that `TimedAnimation` should not be used

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -853,10 +853,7 @@ class HTMLWriter(FileMovieWriter):
 
 class Animation:
     """
-    A base class for Animations.
-
-    This class is not usable as is, and should be subclassed to provide needed
-    behavior.
+    Abstract base class for Animations.
 
     .. note::
 
@@ -1421,7 +1418,7 @@ class Animation:
 
 class TimedAnimation(Animation):
     """
-    `Animation` subclass for time-based animation.
+    Abstract `Animation` subclass for time-based animation.
 
     A new frame is drawn every *interval* milliseconds.
 


### PR DESCRIPTION
## PR summary

This copies the text from `Animation`.

Fixes #30831

## AI Disclosure
None

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines