### PR TITLE
Remove unnecessary ruff lint exceptions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,7 +45,7 @@ repos:
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.11.5
+    rev: v0.15.11
     hooks:
       # Run the linter.
       - id: ruff

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,19 +198,13 @@ ignore = [
     "D107",
     "D200",
     "D202",
-    "D203",
     "D204",
     "D205",
-    "D212",
     "D301",
     "D400",
     "D401",
-    "D402",
     "D403",
     "D404",
-    "D413",
-    "D415",
-    "D417",
     "E266",
     "E305",
     "E306",
@@ -279,7 +273,6 @@ convention = "numpy"
 "lib/matplotlib/_mathtext_data.py" = ["E203"]
 "lib/matplotlib/backends/backend_template.py" = ["F401"]
 "lib/matplotlib/pylab.py" = ["F401", "F403"]
-"lib/matplotlib/pyplot.py" = ["F811"]
 "lib/matplotlib/tests/test_mathtext.py" = ["E501"]
 "lib/matplotlib/transforms.py" = ["E201"]
 "lib/matplotlib/tri/_triinterpolate.py" = ["E201", "E221"]


### PR DESCRIPTION
## PR summary

The numpy convention disables D203, D212, D402, D413, D415, and D417, so there's no need to list them ourselves.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines