### PR TITLE
PERF: Defer tick materialization during Axes init/clear

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1435,18 +1435,10 @@ class _AxesBase(martist.Artist):
         self.xaxis.set_clip_path(self.patch)
         self.yaxis.set_clip_path(self.patch)
 
-        # Ensure spines have the correct transform before any subsequent
-        # layout or draw. Spine.__init__ installs self.axes.transData as
-        # a placeholder; the real blended transform is set by
-        # Spine.set_position via _ensure_position_is_set().  Historically
-        # the spine position was set as a side effect of tick materialization
-        # during clear; with lazy tick lists that cascade no longer runs, so
-        # nudge it here for spines that still carry the placeholder
-        # (projections like polar or secondary axes install custom
-        # transforms and are skipped).
+        # Lazy tick lists no longer trigger spine transform setup as a
+        # side effect, so nudge each spine explicitly.
         for spine in self.spines.values():
-            if spine._position is None and spine._transform is self.transData:
-                spine._ensure_position_is_set()
+            spine._ensure_transform_is_set()
 
         if self._sharex is not None:
             self.xaxis.set_visible(xaxis_visible)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1435,6 +1435,20 @@ class _AxesBase(martist.Artist):
         self.xaxis.set_clip_path(self.patch)
         self.yaxis.set_clip_path(self.patch)
 
+        # Ensure spines have the correct transform before any subsequent
+        # layout or draw. Spine.__init__ installs ``self.axes.transData`` as
+        # a placeholder; the real blended transform is set by
+        # Spine.set_position (via ``_ensure_position_is_set``).  Historically
+        # this fired as a side effect of tick materialization during clear;
+        # with lazy tick lists that cascade no longer runs, so nudge it here
+        # for spines that still carry the placeholder (projections like
+        # polar or secondary axes install custom transforms and are
+        # skipped).
+        for spine in self.spines.values():
+            if spine._position is None and spine._transform is self.transData:
+                spine._position = ('outward', 0.0)
+                spine.set_transform(spine.get_spine_transform())
+
         if self._sharex is not None:
             self.xaxis.set_visible(xaxis_visible)
             self.patch.set_visible(patch_visible)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1436,18 +1436,17 @@ class _AxesBase(martist.Artist):
         self.yaxis.set_clip_path(self.patch)
 
         # Ensure spines have the correct transform before any subsequent
-        # layout or draw. Spine.__init__ installs ``self.axes.transData`` as
+        # layout or draw. Spine.__init__ installs self.axes.transData as
         # a placeholder; the real blended transform is set by
-        # Spine.set_position (via ``_ensure_position_is_set``).  Historically
-        # this fired as a side effect of tick materialization during clear;
-        # with lazy tick lists that cascade no longer runs, so nudge it here
-        # for spines that still carry the placeholder (projections like
-        # polar or secondary axes install custom transforms and are
-        # skipped).
+        # Spine.set_position via _ensure_position_is_set().  Historically
+        # this fired as a side effect of tick materialization during
+        # clear; with lazy tick lists that cascade no longer runs, so
+        # nudge it here for spines that still carry the placeholder
+        # (projections like polar or secondary axes install custom
+        # transforms and are skipped).
         for spine in self.spines.values():
             if spine._position is None and spine._transform is self.transData:
-                spine._position = ('outward', 0.0)
-                spine.set_transform(spine.get_spine_transform())
+                spine._ensure_position_is_set()
 
         if self._sharex is not None:
             self.xaxis.set_visible(xaxis_visible)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1439,8 +1439,8 @@ class _AxesBase(martist.Artist):
         # layout or draw. Spine.__init__ installs self.axes.transData as
         # a placeholder; the real blended transform is set by
         # Spine.set_position via _ensure_position_is_set().  Historically
-        # this fired as a side effect of tick materialization during
-        # clear; with lazy tick lists that cascade no longer runs, so
+        # the spine position was set as a side effect of tick materialization
+        # during clear; with lazy tick lists that cascade no longer runs, so
         # nudge it here for spines that still carry the placeholder
         # (projections like polar or secondary axes install custom
         # transforms and are skipped).

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -244,6 +244,18 @@ class Tick(martist.Artist):
         self.gridline.set_clip_path(path, transform)
         self.stale = True
 
+    def _configure_for_axis(self, axis):
+        """
+        Copy the Axis clip state onto this Tick and its gridline.
+
+        Used by `_LazyTickList` to stamp clip state set via
+        `Axis.set_clip_path` onto a lazily-materialized Tick.
+        """
+        for artist in (self, self.gridline):
+            artist.clipbox = axis.clipbox
+            artist._clippath = axis._clippath
+            artist._clipon = axis._clipon
+
     def contains(self, mouseevent):
         """
         Test whether the mouse event occurred in the Tick marks.
@@ -598,7 +610,7 @@ class _LazyTickList:
                    else instance._minor_tick_kw)
         if tick_kw:
             tick._apply_params(**tick_kw)
-        instance._propagate_axis_state_to_tick(tick)
+        tick._configure_for_axis(instance)
         tick_list.append(tick)
         setattr(instance, attr, tick_list)
         return tick_list
@@ -713,7 +725,7 @@ class Axis(martist.Artist):
         # materialization would have seen. Kept separate from
         # _major_tick_kw/_minor_tick_kw, which hold user-provided
         # set_tick_params() overrides rather than ambient rcParams. See
-        # _propagate_axis_state_to_tick() for the clip-state counterpart.
+        # Tick._configure_for_axis() for the clip-state counterpart.
         self._tick_rcParams = None
 
         if clear:
@@ -888,22 +900,6 @@ class Axis(martist.Artist):
     def get_children(self):
         return [self.label, self.offsetText,
                 *self.get_major_ticks(), *self.get_minor_ticks()]
-
-    def _propagate_axis_state_to_tick(self, tick):
-        """
-        Copy Axis clip state onto a lazily-created Tick.
-
-        `Axis.set_clip_path` can run before any Tick exists, so the clip
-        stored on the Axis must be re-stamped onto the first Tick when
-        it materializes (only the Tick itself and its gridline are
-        clipped, matching `Tick.set_clip_path`). Per-Artist rcParams
-        like ``path.sketch`` / ``path.effects`` are handled by the
-        rcParams restore in `_LazyTickList.__get__`, not here.
-        """
-        for artist in (tick, tick.gridline):
-            artist.clipbox = self.clipbox
-            artist._clippath = self._clippath
-            artist._clipon = self._clipon
 
     def _reset_major_tick_kw(self):
         self._major_tick_kw.clear()

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -550,36 +550,36 @@ class _LazyTickList:
     def __get__(self, instance, owner):
         if instance is None:
             return self
+        # instance._get_tick() can itself try to access the majorTicks
+        # attribute (e.g. in certain projection classes which override
+        # e.g. get_xaxis_text1_transform).  In order to avoid infinite
+        # recursion, first set the majorTicks on the instance temporarily
+        # to an empty list. Then create the tick; note that _get_tick()
+        # may call reset_ticks(). Therefore, the final tick list is
+        # created and assigned afterwards.
+        attr = 'majorTicks' if self._major else 'minorTicks'
+        setattr(instance, attr, [])
+        # Build the Tick (and its sub-artists) under the rcParams snapshot
+        # taken at the last ``Axis.clear`` so that a lazily-materialized
+        # Tick matches the values an eager (pre-lazy) Tick would have had
+        # (see ``Axis._rc_snapshot``). Use ``_update_raw`` rather than
+        # ``rc_context`` to bypass validators that would otherwise fire
+        # spurious warnings when re-applying settings like
+        # ``rcParams['toolbar'] = 'toolmanager'``.
+        snapshot = instance._rc_snapshot
+        if snapshot is not None:
+            rc = mpl.rcParams
+            orig = dict(rc)
+            rc._update_raw(snapshot)
+            try:
+                tick = instance._get_tick(major=self._major)
+            finally:
+                rc._update_raw(orig)
         else:
-            # instance._get_tick() can itself try to access the majorTicks
-            # attribute (e.g. in certain projection classes which override
-            # e.g. get_xaxis_text1_transform).  In order to avoid infinite
-            # recursion, first set the majorTicks on the instance temporarily
-            # to an empty list. Then create the tick; note that _get_tick()
-            # may call reset_ticks(). Therefore, the final tick list is
-            # created and assigned afterwards.
-            if self._major:
-                instance.majorTicks = []
-                tick = instance._get_tick(major=True)
-                tick.clipbox = instance.clipbox
-                tick._clippath = instance._clippath
-                tick._clipon = instance._clipon
-                tick.gridline.clipbox = instance.clipbox
-                tick.gridline._clippath = instance._clippath
-                tick.gridline._clipon = instance._clipon
-                instance.majorTicks = [tick]
-                return instance.majorTicks
-            else:
-                instance.minorTicks = []
-                tick = instance._get_tick(major=False)
-                tick.clipbox = instance.clipbox
-                tick._clippath = instance._clippath
-                tick._clipon = instance._clipon
-                tick.gridline.clipbox = instance.clipbox
-                tick.gridline._clippath = instance._clippath
-                tick.gridline._clipon = instance._clipon
-                instance.minorTicks = [tick]
-                return instance.minorTicks
+            tick = instance._get_tick(major=self._major)
+        instance._propagate_axis_state_to_tick(tick)
+        setattr(instance, attr, [tick])
+        return getattr(instance, attr)
 
 
 class Axis(martist.Artist):
@@ -684,6 +684,13 @@ class Axis(martist.Artist):
         # Initialize here for testing; later add API
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
+        # Snapshot of rcParams at the time of the last ``Axis.clear`` (or
+        # ``set_tick_params(reset=True)``). ``_LazyTickList`` applies this
+        # via ``rc_context`` when it lazily creates a Tick so that the Tick
+        # and its sub-artists see the same rcParams an eager (pre-lazy)
+        # materialization would have seen. See ``_propagate_axis_state_to_tick``
+        # for the clip-state counterpart.
+        self._rc_snapshot = None
 
         if clear:
             self.clear()
@@ -858,17 +865,36 @@ class Axis(martist.Artist):
         return [self.label, self.offsetText,
                 *self.get_major_ticks(), *self.get_minor_ticks()]
 
+    def _propagate_axis_state_to_tick(self, tick):
+        """
+        Copy Axis clip state onto a lazily-created Tick.
+
+        `Axis.set_clip_path` runs during ``Axes.__clear`` before any Tick
+        exists under the lazy-init refactor, so the clip stored on the
+        Axis must be re-stamped onto the first Tick when it materializes
+        (only the Tick itself and its gridline are clipped, matching
+        `Tick.set_clip_path`). Per-Artist rcParams like ``path.sketch`` /
+        ``path.effects`` are handled by the ``rc_context`` wrapping in
+        `_LazyTickList.__get__`, not here.
+        """
+        for artist in (tick, tick.gridline):
+            artist.clipbox = self.clipbox
+            artist._clippath = self._clippath
+            artist._clipon = self._clipon
+
     def _reset_major_tick_kw(self):
         self._major_tick_kw.clear()
         self._major_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'major'))
+        self._rc_snapshot = dict(mpl.rcParams)
 
     def _reset_minor_tick_kw(self):
         self._minor_tick_kw.clear()
         self._minor_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
+        self._rc_snapshot = dict(mpl.rcParams)
 
     def clear(self):
         """
@@ -898,6 +924,11 @@ class Axis(martist.Artist):
 
         # Clear the callback registry for this axis, or it may "leak"
         self.callbacks = cbook.CallbackRegistry(signals=["units"])
+
+        # Snapshot current rcParams so that a Tick materialized later by
+        # ``_LazyTickList`` (possibly outside any ``rc_context`` active
+        # now) sees the same rcParams an eager pre-lazy tick would have.
+        self._rc_snapshot = dict(mpl.rcParams)
 
         # whether the grids are on
         self._major_tick_kw['gridOn'] = (
@@ -939,9 +970,7 @@ class Axis(martist.Artist):
         doing so would
 
         (a) create throwaway Tick objects during ``Axes.__init__`` and
-            ``Axes.__clear`` -- defeating the whole point of the lazy lists --
-            and
-
+            ``Axes.__clear``
         (b) risk re-entering the
             ``Spine.set_position -> Axis.reset_ticks -> Axis.set_clip_path
             -> _LazyTickList.__get__ -> Tick.__init__ -> Spine.set_position``

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -577,6 +577,17 @@ class _LazyTickList:
                 rc._update_raw(orig)
         else:
             tick = instance._get_tick(major=self._major)
+        # Re-apply any ``set_tick_params`` overrides to the fresh Tick.
+        # Subclasses of ``Axis`` (e.g. the ``SkewXAxis`` in the skewt
+        # gallery example) sometimes override ``_get_tick`` without
+        # forwarding ``_{major,minor}_tick_kw``; calling ``_apply_params``
+        # here guarantees those overrides still take effect, matching the
+        # pre-lazy behaviour where the first tick was materialized eagerly
+        # and updated in place by ``set_tick_params``.
+        tick_kw = (instance._major_tick_kw if self._major
+                   else instance._minor_tick_kw)
+        if tick_kw:
+            tick._apply_params(**tick_kw)
         instance._propagate_axis_state_to_tick(tick)
         setattr(instance, attr, [tick])
         return getattr(instance, attr)

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -248,18 +248,13 @@ class Tick(martist.Artist):
         """
         Apply axis-level configuration to a freshly-materialized Tick.
 
-        Used by `_LazyTickList` to:
-
-        - re-apply any ``set_tick_params()`` overrides held on the Axis.
-          Subclasses of Axis (e.g. the SkewXAxis in the skewt gallery
-          example) sometimes override ``_get_tick()`` without forwarding
-          ``_{major,minor}_tick_kw``; calling ``_apply_params()`` here
-          guarantees those overrides still take effect, matching the
-          pre-lazy behaviour where the first tick was materialized eagerly
-          and updated in place by ``set_tick_params()``.
-        - stamp the clip state set via ``Axis.set_clip_path`` onto this
-          Tick and its gridline.
+        Used by `_LazyTickList` to apply ``set_tick_params()`` overrides
+        held on the Axis and to stamp the clip state set via
+        ``Axis.set_clip_path`` onto the Tick and its gridline.
         """
+        # Subclasses of Axis (e.g. SkewXAxis in the skewt gallery example)
+        # may override _get_tick() without forwarding _{major,minor}_tick_kw,
+        # so apply them here.
         tick_kw = axis._major_tick_kw if major else axis._minor_tick_kw
         if tick_kw:
             self._apply_params(**tick_kw)
@@ -599,13 +594,12 @@ class _LazyTickList:
         # 1. Bind a placeholder so reentrant access via _get_tick() (e.g.
         #    projections overriding get_xaxis_text1_transform) does not
         #    recurse back into this descriptor.
-        # 2. Build the tick under the rcParams snapshot taken at the last
-        #    Axis.clear(), so it matches an eager (pre-lazy) Tick.
-        # 3. Apply set_tick_params() overrides and axis state via
-        #    Tick._configure_for_axis().
+        # 2. Build the tick under the rcParams snapshot from the last
+        #    Axis.clear() so its sub-artists pick up the right rcParams.
+        # 3. Apply set_tick_params() overrides and axis state.
         # 4. Re-bind the final list; _get_tick() may have called
-        #    reset_ticks(), which pops the attribute, so this assignment is
-        #    what makes future accesses skip the descriptor.
+        #    reset_ticks(), which pops the attribute, so this assignment
+        #    is what makes future accesses skip the descriptor.
         attr = 'majorTicks' if self._major else 'minorTicks'
         setattr(instance, attr, ())  # placeholder; not appended to
         with _rc_context_raw(instance._tick_rcParams):
@@ -718,14 +712,11 @@ class Axis(martist.Artist):
         # Initialize here for testing; later add API
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
-        # Snapshot of rcParams at the time of the last Axis.clear() (or
-        # set_tick_params(reset=True)). _LazyTickList re-applies these
-        # when it lazily creates a Tick so that the Tick and its
-        # sub-artists see the same rcParams an eager (pre-lazy)
-        # materialization would have seen. Kept separate from
+        # Snapshot of rcParams from the last Axis.clear() (or
+        # set_tick_params(reset=True)); re-applied by _LazyTickList when
+        # it lazily materializes a Tick. Kept separate from
         # _major_tick_kw/_minor_tick_kw, which hold user-provided
-        # set_tick_params() overrides rather than ambient rcParams. See
-        # Tick._configure_for_axis() for the clip-state counterpart.
+        # set_tick_params() overrides rather than ambient rcParams.
         self._tick_rcParams = None
 
         if clear:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -559,18 +559,19 @@ class _LazyTickList:
         # created and assigned afterwards.
         attr = 'majorTicks' if self._major else 'minorTicks'
         setattr(instance, attr, [])
-        # Build the Tick (and its sub-artists) under the rcParams snapshot
-        # taken at the last ``Axis.clear`` so that a lazily-materialized
-        # Tick matches the values an eager (pre-lazy) Tick would have had
-        # (see ``Axis._rc_snapshot``). Use ``_update_raw`` rather than
-        # ``rc_context`` to bypass validators that would otherwise fire
-        # spurious warnings when re-applying settings like
-        # ``rcParams['toolbar'] = 'toolmanager'``.
-        snapshot = instance._rc_snapshot
-        if snapshot is not None:
+        # Build the Tick (and its sub-artists) under the rcParams captured
+        # at the last ``Axis.clear`` so that a lazily-materialized Tick
+        # matches an eager (pre-lazy) Tick (see ``Axis._tick_rcParams``).
+        # We avoid ``rc_context`` here because it re-applies rcParams via
+        # ``RcParams.__setitem__``, whose validators emit warnings on every
+        # assignment for keys like ``toolbar='toolmanager'`` -- re-setting
+        # the snapshot to its own (identical) values would spuriously
+        # re-trigger those warnings. ``_update_raw`` bypasses the validators
+        # on both entry and exit.
+        if instance._tick_rcParams is not None:
             rc = mpl.rcParams
             orig = dict(rc)
-            rc._update_raw(snapshot)
+            rc._update_raw(instance._tick_rcParams)
             try:
                 tick = instance._get_tick(major=self._major)
             finally:
@@ -696,12 +697,14 @@ class Axis(martist.Artist):
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
         # Snapshot of rcParams at the time of the last ``Axis.clear`` (or
-        # ``set_tick_params(reset=True)``). ``_LazyTickList`` applies this
-        # via ``rc_context`` when it lazily creates a Tick so that the Tick
-        # and its sub-artists see the same rcParams an eager (pre-lazy)
-        # materialization would have seen. See ``_propagate_axis_state_to_tick``
-        # for the clip-state counterpart.
-        self._rc_snapshot = None
+        # ``set_tick_params(reset=True)``). ``_LazyTickList`` re-applies
+        # these when it lazily creates a Tick so that the Tick and its
+        # sub-artists see the same rcParams an eager (pre-lazy)
+        # materialization would have seen. Kept separate from
+        # ``_major_tick_kw``/``_minor_tick_kw``, which hold user-provided
+        # ``set_tick_params`` overrides rather than ambient rcParams. See
+        # ``_propagate_axis_state_to_tick`` for the clip-state counterpart.
+        self._tick_rcParams = None
 
         if clear:
             self.clear()
@@ -898,14 +901,14 @@ class Axis(martist.Artist):
         self._major_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'major'))
-        self._rc_snapshot = dict(mpl.rcParams)
+        self._tick_rcParams = dict(mpl.rcParams)
 
     def _reset_minor_tick_kw(self):
         self._minor_tick_kw.clear()
         self._minor_tick_kw['gridOn'] = (
                 mpl.rcParams['axes.grid'] and
                 mpl.rcParams['axes.grid.which'] in ('both', 'minor'))
-        self._rc_snapshot = dict(mpl.rcParams)
+        self._tick_rcParams = dict(mpl.rcParams)
 
     def clear(self):
         """
@@ -939,7 +942,7 @@ class Axis(martist.Artist):
         # Snapshot current rcParams so that a Tick materialized later by
         # ``_LazyTickList`` (possibly outside any ``rc_context`` active
         # now) sees the same rcParams an eager pre-lazy tick would have.
-        self._rc_snapshot = dict(mpl.rcParams)
+        self._tick_rcParams = dict(mpl.rcParams)
 
         # whether the grids are on
         self._major_tick_kw['gridOn'] = (
@@ -961,7 +964,9 @@ class Axis(martist.Artist):
 
         Each list starts with a single fresh Tick.
         """
-        # Restore the lazy tick lists.
+        # Drop any materialized tick lists so the _LazyTickList descriptor is
+        # reactivated on next access. If ticks were already materialized,
+        # re-apply the axes-patch clip path; otherwise skip.
         had_major = bool(self.__dict__.pop('majorTicks', None))
         had_minor = bool(self.__dict__.pop('minorTicks', None))
         if had_major or had_minor:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -548,6 +548,7 @@ class _LazyTickList:
         self._major = major
 
     def __get__(self, instance, owner):
+        """Materialize the descriptor to a list with one configured tick."""
         if instance is None:
             return self
         # instance._get_tick() can itself try to access the majorTicks
@@ -560,13 +561,13 @@ class _LazyTickList:
         attr = 'majorTicks' if self._major else 'minorTicks'
         setattr(instance, attr, [])
         # Build the Tick (and its sub-artists) under the rcParams captured
-        # at the last ``Axis.clear`` so that a lazily-materialized Tick
-        # matches an eager (pre-lazy) Tick (see ``Axis._tick_rcParams``).
-        # We avoid ``rc_context`` here because it re-applies rcParams via
-        # ``RcParams.__setitem__``, whose validators emit warnings on every
-        # assignment for keys like ``toolbar='toolmanager'`` -- re-setting
+        # at the last Axis.clear() so that a lazily-materialized Tick
+        # matches an eager (pre-lazy) Tick (see Axis._tick_rcParams).
+        # We avoid rc_context() here because it re-applies rcParams via
+        # RcParams.__setitem__, whose validators emit warnings on every
+        # assignment for keys like toolbar='toolmanager' -- re-setting
         # the snapshot to its own (identical) values would spuriously
-        # re-trigger those warnings. ``_update_raw`` bypasses the validators
+        # re-trigger those warnings. _update_raw() bypasses the validators
         # on both entry and exit.
         if instance._tick_rcParams is not None:
             rc = mpl.rcParams
@@ -578,13 +579,13 @@ class _LazyTickList:
                 rc._update_raw(orig)
         else:
             tick = instance._get_tick(major=self._major)
-        # Re-apply any ``set_tick_params`` overrides to the fresh Tick.
-        # Subclasses of ``Axis`` (e.g. the ``SkewXAxis`` in the skewt
-        # gallery example) sometimes override ``_get_tick`` without
-        # forwarding ``_{major,minor}_tick_kw``; calling ``_apply_params``
-        # here guarantees those overrides still take effect, matching the
-        # pre-lazy behaviour where the first tick was materialized eagerly
-        # and updated in place by ``set_tick_params``.
+        # Re-apply any set_tick_params() overrides to the fresh Tick.
+        # Subclasses of Axis (e.g. the SkewXAxis in the skewt gallery
+        # example) sometimes override _get_tick() without forwarding
+        # _{major,minor}_tick_kw; calling _apply_params() here guarantees
+        # those overrides still take effect, matching the pre-lazy
+        # behaviour where the first tick was materialized eagerly and
+        # updated in place by set_tick_params().
         tick_kw = (instance._major_tick_kw if self._major
                    else instance._minor_tick_kw)
         if tick_kw:
@@ -696,14 +697,14 @@ class Axis(martist.Artist):
         # Initialize here for testing; later add API
         self._major_tick_kw = dict()
         self._minor_tick_kw = dict()
-        # Snapshot of rcParams at the time of the last ``Axis.clear`` (or
-        # ``set_tick_params(reset=True)``). ``_LazyTickList`` re-applies
-        # these when it lazily creates a Tick so that the Tick and its
+        # Snapshot of rcParams at the time of the last Axis.clear() (or
+        # set_tick_params(reset=True)). _LazyTickList re-applies these
+        # when it lazily creates a Tick so that the Tick and its
         # sub-artists see the same rcParams an eager (pre-lazy)
         # materialization would have seen. Kept separate from
-        # ``_major_tick_kw``/``_minor_tick_kw``, which hold user-provided
-        # ``set_tick_params`` overrides rather than ambient rcParams. See
-        # ``_propagate_axis_state_to_tick`` for the clip-state counterpart.
+        # _major_tick_kw/_minor_tick_kw, which hold user-provided
+        # set_tick_params() overrides rather than ambient rcParams. See
+        # _propagate_axis_state_to_tick() for the clip-state counterpart.
         self._tick_rcParams = None
 
         if clear:
@@ -883,13 +884,12 @@ class Axis(martist.Artist):
         """
         Copy Axis clip state onto a lazily-created Tick.
 
-        `Axis.set_clip_path` runs during ``Axes.__clear`` before any Tick
-        exists under the lazy-init refactor, so the clip stored on the
-        Axis must be re-stamped onto the first Tick when it materializes
-        (only the Tick itself and its gridline are clipped, matching
-        `Tick.set_clip_path`). Per-Artist rcParams like ``path.sketch`` /
-        ``path.effects`` are handled by the ``rc_context`` wrapping in
-        `_LazyTickList.__get__`, not here.
+        `Axis.set_clip_path` can run before any Tick exists, so the clip
+        stored on the Axis must be re-stamped onto the first Tick when
+        it materializes (only the Tick itself and its gridline are
+        clipped, matching `Tick.set_clip_path`). Per-Artist rcParams
+        like ``path.sketch`` / ``path.effects`` are handled by the
+        rcParams restore in `_LazyTickList.__get__`, not here.
         """
         for artist in (tick, tick.gridline):
             artist.clipbox = self.clipbox
@@ -940,8 +940,8 @@ class Axis(martist.Artist):
         self.callbacks = cbook.CallbackRegistry(signals=["units"])
 
         # Snapshot current rcParams so that a Tick materialized later by
-        # ``_LazyTickList`` (possibly outside any ``rc_context`` active
-        # now) sees the same rcParams an eager pre-lazy tick would have.
+        # _LazyTickList (possibly outside any rc_context() active now)
+        # sees the same rcParams an eager pre-lazy tick would have.
         self._tick_rcParams = dict(mpl.rcParams)
 
         # whether the grids are on

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -561,11 +561,23 @@ class _LazyTickList:
             if self._major:
                 instance.majorTicks = []
                 tick = instance._get_tick(major=True)
+                tick.clipbox = instance.clipbox
+                tick._clippath = instance._clippath
+                tick._clipon = instance._clipon
+                tick.gridline.clipbox = instance.clipbox
+                tick.gridline._clippath = instance._clippath
+                tick.gridline._clipon = instance._clipon
                 instance.majorTicks = [tick]
                 return instance.majorTicks
             else:
                 instance.minorTicks = []
                 tick = instance._get_tick(major=False)
+                tick.clipbox = instance.clipbox
+                tick._clippath = instance._clippath
+                tick._clipon = instance._clipon
+                tick.gridline.clipbox = instance.clipbox
+                tick.gridline._clippath = instance._clippath
+                tick.gridline._clipon = instance._clipon
                 instance.minorTicks = [tick]
                 return instance.minorTicks
 
@@ -908,18 +920,45 @@ class Axis(martist.Artist):
         Each list starts with a single fresh Tick.
         """
         # Restore the lazy tick lists.
-        try:
-            del self.majorTicks
-        except AttributeError:
-            pass
-        try:
-            del self.minorTicks
-        except AttributeError:
-            pass
-        try:
-            self.set_clip_path(self.axes.patch)
-        except AttributeError:
-            pass
+        had_major = bool(self.__dict__.pop('majorTicks', None))
+        had_minor = bool(self.__dict__.pop('minorTicks', None))
+        if had_major or had_minor:
+            try:
+                self.set_clip_path(self.axes.patch)
+            except AttributeError:
+                pass
+
+    def _existing_ticks(self, major=None):
+        """
+        Yield already-materialized ticks without triggering the lazy descriptor.
+
+        `majorTicks` and `minorTicks` are `_LazyTickList` descriptors that
+        create a fresh `.Tick` on first access. Several internal methods
+        (`set_clip_path`, `set_tick_params`) need to touch every
+        *already-materialized* tick without forcing materialization, because
+        doing so would
+
+        (a) create throwaway Tick objects during ``Axes.__init__`` and
+            ``Axes.__clear`` -- defeating the whole point of the lazy lists --
+            and
+
+        (b) risk re-entering the
+            ``Spine.set_position -> Axis.reset_ticks -> Axis.set_clip_path
+            -> _LazyTickList.__get__ -> Tick.__init__ -> Spine.set_position``
+            cascade.
+
+        Reading the instance ``__dict__`` directly bypasses the descriptor.
+
+        Parameters
+        ----------
+        major : bool, optional
+            If True, yield only major ticks; if False, only minor ticks;
+            if None (default), yield major followed by minor.
+        """
+        if major is None or major:
+            yield from self.__dict__.get('majorTicks', ())
+        if major is None or not major:
+            yield from self.__dict__.get('minorTicks', ())
 
     def minorticks_on(self):
         """
@@ -988,11 +1027,11 @@ class Axis(martist.Artist):
         else:
             if which in ['major', 'both']:
                 self._major_tick_kw.update(kwtrans)
-                for tick in self.majorTicks:
+                for tick in self._existing_ticks(major=True):
                     tick._apply_params(**kwtrans)
             if which in ['minor', 'both']:
                 self._minor_tick_kw.update(kwtrans)
-                for tick in self.minorTicks:
+                for tick in self._existing_ticks(major=False):
                     tick._apply_params(**kwtrans)
             # labelOn and labelcolor also apply to the offset text.
             if 'label1On' in kwtrans or 'label2On' in kwtrans:
@@ -1131,7 +1170,7 @@ class Axis(martist.Artist):
 
     def set_clip_path(self, path, transform=None):
         super().set_clip_path(path, transform)
-        for child in self.majorTicks + self.minorTicks:
+        for child in self._existing_ticks():
             child.set_clip_path(path, transform)
         self.stale = True
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -244,13 +244,25 @@ class Tick(martist.Artist):
         self.gridline.set_clip_path(path, transform)
         self.stale = True
 
-    def _configure_for_axis(self, axis):
+    def _configure_for_axis(self, axis, major):
         """
-        Copy the Axis clip state onto this Tick and its gridline.
+        Apply axis-level configuration to a freshly-materialized Tick.
 
-        Used by `_LazyTickList` to stamp clip state set via
-        `Axis.set_clip_path` onto a lazily-materialized Tick.
+        Used by `_LazyTickList` to:
+
+        - re-apply any ``set_tick_params()`` overrides held on the Axis.
+          Subclasses of Axis (e.g. the SkewXAxis in the skewt gallery
+          example) sometimes override ``_get_tick()`` without forwarding
+          ``_{major,minor}_tick_kw``; calling ``_apply_params()`` here
+          guarantees those overrides still take effect, matching the
+          pre-lazy behaviour where the first tick was materialized eagerly
+          and updated in place by ``set_tick_params()``.
+        - stamp the clip state set via ``Axis.set_clip_path`` onto this
+          Tick and its gridline.
         """
+        tick_kw = axis._major_tick_kw if major else axis._minor_tick_kw
+        if tick_kw:
+            self._apply_params(**tick_kw)
         for artist in (self, self.gridline):
             artist.clipbox = axis.clipbox
             artist._clippath = axis._clippath
@@ -584,34 +596,22 @@ class _LazyTickList:
         """Materialize the descriptor to a list with one configured tick."""
         if instance is None:
             return self
-        # instance._get_tick() can itself try to access the majorTicks
-        # attribute (e.g. in certain projection classes which override
-        # e.g. get_xaxis_text1_transform).  To avoid infinite recursion,
-        # bind the attribute to an empty list before calling _get_tick().
-        # _get_tick() may also call reset_ticks(), which pops the attribute
-        # from the instance dict; the final setattr below re-binds the
-        # (now non-empty) list so subsequent accesses skip the descriptor.
+        # 1. Bind a placeholder so reentrant access via _get_tick() (e.g.
+        #    projections overriding get_xaxis_text1_transform) does not
+        #    recurse back into this descriptor.
+        # 2. Build the tick under the rcParams snapshot taken at the last
+        #    Axis.clear(), so it matches an eager (pre-lazy) Tick.
+        # 3. Apply set_tick_params() overrides and axis state via
+        #    Tick._configure_for_axis().
+        # 4. Re-bind the final list; _get_tick() may have called
+        #    reset_ticks(), which pops the attribute, so this assignment is
+        #    what makes future accesses skip the descriptor.
         attr = 'majorTicks' if self._major else 'minorTicks'
-        tick_list = []
-        setattr(instance, attr, tick_list)
-        # Build the Tick (and its sub-artists) under the rcParams captured
-        # at the last Axis.clear() so that a lazily-materialized Tick
-        # matches an eager (pre-lazy) Tick (see Axis._tick_rcParams).
+        setattr(instance, attr, ())  # placeholder; not appended to
         with _rc_context_raw(instance._tick_rcParams):
             tick = instance._get_tick(major=self._major)
-        # Re-apply any set_tick_params() overrides to the fresh Tick.
-        # Subclasses of Axis (e.g. the SkewXAxis in the skewt gallery
-        # example) sometimes override _get_tick() without forwarding
-        # _{major,minor}_tick_kw; calling _apply_params() here guarantees
-        # those overrides still take effect, matching the pre-lazy
-        # behaviour where the first tick was materialized eagerly and
-        # updated in place by set_tick_params().
-        tick_kw = (instance._major_tick_kw if self._major
-                   else instance._minor_tick_kw)
-        if tick_kw:
-            tick._apply_params(**tick_kw)
-        tick._configure_for_axis(instance)
-        tick_list.append(tick)
+        tick._configure_for_axis(instance, self._major)
+        tick_list = [tick]
         setattr(instance, attr, tick_list)
         return tick_list
 

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2,6 +2,7 @@
 Classes for the ticks and x- and y-axis.
 """
 
+import contextlib
 import datetime
 import functools
 import logging
@@ -536,6 +537,26 @@ class Ticker:
         self._formatter = formatter
 
 
+@contextlib.contextmanager
+def _rc_context_raw(snapshot):
+    """
+    Like ``mpl.rc_context(snapshot)`` but bypasses ``RcParams`` validators
+    on entry and exit; re-applying a snapshot to its own values must not
+    re-trigger one-shot validator warnings (e.g. ``toolbar='toolmanager'``).
+    ``snapshot=None`` is a no-op.
+    """
+    if snapshot is None:
+        yield
+        return
+    rc = mpl.rcParams
+    orig = dict(rc)
+    rc._update_raw(snapshot)
+    try:
+        yield
+    finally:
+        rc._update_raw(orig)
+
+
 class _LazyTickList:
     """
     A descriptor for lazy instantiation of tick lists.
@@ -553,31 +574,18 @@ class _LazyTickList:
             return self
         # instance._get_tick() can itself try to access the majorTicks
         # attribute (e.g. in certain projection classes which override
-        # e.g. get_xaxis_text1_transform).  In order to avoid infinite
-        # recursion, first set the majorTicks on the instance temporarily
-        # to an empty list. Then create the tick; note that _get_tick()
-        # may call reset_ticks(). Therefore, the final tick list is
-        # created and assigned afterwards.
+        # e.g. get_xaxis_text1_transform).  To avoid infinite recursion,
+        # bind the attribute to an empty list before calling _get_tick().
+        # _get_tick() may also call reset_ticks(), which pops the attribute
+        # from the instance dict; the final setattr below re-binds the
+        # (now non-empty) list so subsequent accesses skip the descriptor.
         attr = 'majorTicks' if self._major else 'minorTicks'
-        setattr(instance, attr, [])
+        tick_list = []
+        setattr(instance, attr, tick_list)
         # Build the Tick (and its sub-artists) under the rcParams captured
         # at the last Axis.clear() so that a lazily-materialized Tick
         # matches an eager (pre-lazy) Tick (see Axis._tick_rcParams).
-        # We avoid rc_context() here because it re-applies rcParams via
-        # RcParams.__setitem__, whose validators emit warnings on every
-        # assignment for keys like toolbar='toolmanager' -- re-setting
-        # the snapshot to its own (identical) values would spuriously
-        # re-trigger those warnings. _update_raw() bypasses the validators
-        # on both entry and exit.
-        if instance._tick_rcParams is not None:
-            rc = mpl.rcParams
-            orig = dict(rc)
-            rc._update_raw(instance._tick_rcParams)
-            try:
-                tick = instance._get_tick(major=self._major)
-            finally:
-                rc._update_raw(orig)
-        else:
+        with _rc_context_raw(instance._tick_rcParams):
             tick = instance._get_tick(major=self._major)
         # Re-apply any set_tick_params() overrides to the fresh Tick.
         # Subclasses of Axis (e.g. the SkewXAxis in the skewt gallery
@@ -591,8 +599,9 @@ class _LazyTickList:
         if tick_kw:
             tick._apply_params(**tick_kw)
         instance._propagate_axis_state_to_tick(tick)
-        setattr(instance, attr, [tick])
-        return getattr(instance, attr)
+        tick_list.append(tick)
+        setattr(instance, attr, tick_list)
+        return tick_list
 
 
 class Axis(martist.Artist):

--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -206,6 +206,13 @@ class Spine(mpatches.Patch):
             self._position = ('outward', 0.0)  # in points
             self.set_position(self._position)
 
+    def _ensure_transform_is_set(self):
+        # Install the default blended transform if the spine still carries
+        # the placeholder from Spine.__init__. No-op for spines whose
+        # transform was set explicitly (e.g. via set_patch_arc/_circle).
+        if self._position is None and self._transform is self.axes.transData:
+            self.set_position(('outward', 0.0))
+
     def register_axis(self, axis):
         """
         Register an axis.


### PR DESCRIPTION
## PR summary


The performance if matplotlibs ticks is a bottleneck in various plots. See for example  the discussions and references in https://github.com/matplotlib/matplotlib/issues/5665, https://github.com/matplotlib/matplotlib/pull/31012, https://github.com/matplotlib/matplotlib/issues/29594.

In this PR we prevent materialization of the `_LazyTickList` when there are no ticks created yet. With the tick-materialization cascade gone from Axes.__clear, the spine transforms the cascade used to install as a side effect are installed explicitly at the end of __clear.

Benchmark results (updated):
```
nit_grid 8x8:                  [main] 177 ms ± 2 ms   -> [branch] 112 ms ± 24 ms:  1.58x faster
clear_grid 8x8:                 [main] 181 ms ± 2 ms   -> [branch] 139 ms ± 22 ms:  1.31x faster
reuse_axes 8x8:                 [main] 154 ms ± 1 ms   -> [branch] 53.8 ms ± 0.4 ms: 2.86x faster
fig100 clear+plot1000+legend:   [main] 9.45 ms ± 2.4 ms -> [branch] 3.28 ms ± 0.02 ms: 2.88x faster

Geometric mean: 2.03x faster
```
<details><summary>Benchmark script</summary>

```
# /// script
# requires-python = ">=3.10"
# dependencies = ['matplotlib', 'numpy', 'pyperf']
# ///
"""pyperf micro-benchmarks for matplotlib axis/tick init+clear cost.

"""
import pyperf

setup = """
import matplotlib
matplotlib.use("Agg")
# matplotlib.use("QtAgg")  # snap/glibc mismatch; use offscreen:
# import os; os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")

import numpy as np
import matplotlib.pyplot as plt

GRID = 8
rng = np.random.default_rng(0)
x1000 = np.arange(1000)
y1000 = rng.standard_normal(1000)

# Pre-create reusable figure for clear_grid / reuse_axes cases.
_fig_clear = plt.figure()
_fig_grid, _axs_grid = plt.subplots(GRID, GRID)
_axs_flat = _axs_grid.ravel()

# Warmup — first call pays font-cache / backend-init costs.
plt.close(plt.subplots(GRID, GRID)[0])
"""

runner = pyperf.Runner()

# Fresh figure each iter — full Axes.__init__ cost for an 8x8 grid.
runner.timeit(
    name="init_grid 8x8",
    stmt="fig, axs = plt.subplots(GRID, GRID); plt.close(fig)",
    setup=setup,
)

# Reuse one Figure, clear + re-populate with an 8x8 grid.
runner.timeit(
    name="clear_grid 8x8",
    stmt="_fig_clear.clear(); _fig_clear.subplots(GRID, GRID)",
    setup=setup,
)

# Iterate ax.clear() across an existing 8x8 grid.
runner.timeit(
    name="reuse_axes 8x8",
    stmt="[ax.clear() for ax in _axs_flat]",
    setup=setup,
)

# Figure num=100: clear + plot 1000-point line + legend. Reuses the same
# numbered figure across iterations so only clear+plot+legend is measured.
runner.timeit(
    name="fig100 clear+plot1000+legend",
    stmt=(
        "fig = plt.figure(num=100);"
        " fig.clear();"
        " ax = fig.add_subplot();"
        " ax.plot(x1000, y1000, label='y');"
        " ax.legend()"
    ),
    setup=setup,
)
```
</details>

Closes #23771.

## AI Disclosure

Claude was used in identifying performance bottlenecks related to tick creation. Initially the goal was to create tick collections (as described in one of the references), but this approach seems to be a small change with large impact.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
