### PR TITLE
Fix legend settings not preserved when regenerating in Qt figure options

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -248,11 +248,30 @@ def figure_edit(axes, parent=None):
         if generate_legend:
             draggable = None
             ncols = 1
+            # Collect legend properties from the old legend to preserve them
+            legend_kwargs = {}
             if axes.legend_ is not None:
                 old_legend = axes.get_legend()
                 draggable = old_legend._draggable is not None
                 ncols = old_legend._ncols
-            new_legend = axes.legend(ncols=ncols)
+                legend_kwargs['ncols'] = ncols
+                # Preserve bbox_to_anchor
+                if old_legend._bbox_to_anchor is not None:
+                    bbox = old_legend._bbox_to_anchor._bbox
+                    legend_kwargs['bbox_to_anchor'] = (
+                        bbox.x0, bbox.y0,
+                        bbox.x1 - bbox.x0, bbox.y1 - bbox.y0
+                    )
+                # Preserve loc
+                legend_kwargs['loc'] = old_legend._loc_real
+                # Preserve mode (horizontal vs vertical distribution)
+                if old_legend._mode is not None:
+                    legend_kwargs['mode'] = old_legend._mode
+                # Preserve borderaxespad
+                legend_kwargs['borderaxespad'] = old_legend.borderaxespad
+            else:
+                legend_kwargs['ncols'] = ncols
+            new_legend = axes.legend(**legend_kwargs)
             if new_legend:
                 new_legend.set_draggable(draggable)
 


### PR DESCRIPTION
Good day

When '(Re)-generate automatic legend' is checked in the Figure Options dialog, the regenerated legend previously only preserved 'ncols' and 'draggable' settings. Other important legend properties like 'bbox_to_anchor', 'loc', 'mode', and 'borderaxespad' were discarded.

This fix captures these additional properties from the existing legend (if present) and passes them to `axes.legend()`, preserving the user's intended legend appearance.

**Before (only ncols preserved):**
```python
new_legend = axes.legend(ncols=ncols)
```

**After (all key properties preserved):**
```python
legend_kwargs = {
    'ncols': ncols,
    'bbox_to_anchor': bbox_to_anchor,
    'loc': loc,
    'mode': mode,
    'borderaxespad': borderaxespad,
}
new_legend = axes.legend(**legend_kwargs)
```

**Testing:**
- Verified that `ncols`, `loc`, `mode`, `borderaxespad`, and `bbox_to_anchor` are all correctly preserved when regenerating a legend with `bbox_to_anchor=(0, 1.02, 1, 0.2), loc='lower left', mode='expand', borderaxespad=0, ncol=3`
- Verified that the no-legend case (first legend creation) still works correctly
- Verified that legends without `bbox_to_anchor` or `mode` set still work correctly

Fixes https://github.com/matplotlib/matplotlib/issues/17775

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly,
RoomWithOutRoof