### PR TITLE
[Doc] Remove invalid 'ultrabold' option from fontweight documentation

### DIFF
--- a/galleries/users_explain/text/text_props.py
+++ b/galleries/users_explain/text/text_props.py
@@ -34,14 +34,14 @@ name or fontname            string e.g., [``'Sans'`` | ``'Courier'`` | ``'Helvet
 picker                      [None|float|bool|callable]
 position                    (x, y)
 rotation                    [ angle in degrees | ``'vertical'`` | ``'horizontal'`` ]
-        size or fontsize            [ size in points | relative size, e.g., ``'small'``, ``'x-large'`` ]
+size or fontsize            [ size in points | relative size, e.g., ``'small'``, ``'x-large'`` ]
 style or fontstyle          [ ``'normal'`` | ``'italic'`` | ``'oblique'`` ]
 text                        string or anything printable with '%s' conversion
 transform                   `~matplotlib.transforms.Transform` subclass
 variant                     [ ``'normal'`` | ``'small-caps'`` ]
 verticalalignment or va     [ ``'center'`` | ``'top'`` | ``'bottom'`` | ``'baseline'`` ]
 visible                     bool
-weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultrabold'`` | ``'ultralight'``]
+weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultralight'`` ]
 x                           `float`
 y                           `float`
 zorder                      any number


### PR DESCRIPTION
Closes #31506

PR summary

Removes the invalid "'ultrabold'" option from the "fontweight" documentation in "text_props".

The option "'ultrabold'" raises a "ValueError" and is not supported in Matplotlib, so it has been removed to align the documentation with actual behavior.

AI Disclosure

This contribution was created with assistance from ChatGPT for guidance and structuring. The final changes were reviewed and modified by me.

PR checklist

- [x] closes #31506 is in the body of the PR description
- [x] new and changed code is tested (not applicable for docs)
- [ ] Plotting related features are demonstrated in an example (not applicable)
- [ ] New Features and API Changes are noted (not applicable)
- [x] Documentation complies with general and docstring guidelines