### PR TITLE
Supporting fontweight options 

### DIFF
--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -96,6 +96,9 @@ weight_dict = {
     'extrabold':  800,
     'superbold':  800,
     'ultrabold':  800,
+    'ultrablack': 1000,
+    'superblack': 1000,
+    'extrablack': 1000,
     'black':      900,
 }
 _weight_regexes = [

--- a/lib/matplotlib/font_manager.py
+++ b/lib/matplotlib/font_manager.py
@@ -93,6 +93,9 @@ weight_dict = {
     'bold':       700,
     'heavy':      800,
     'extra bold': 800,
+    'extrabold':  800,
+    'superbold':  800,
+    'ultrabold':  800,
     'black':      900,
 }
 _weight_regexes = [

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -430,6 +430,9 @@ def test_normalize_weights():
     assert _normalize_weight('extrabold') == 800
     assert _normalize_weight('superbold') == 800
     assert _normalize_weight('ultrabold') == 800
+    assert _normalize_weight('ultrablack') == 1000
+    assert _normalize_weight('superblack') == 1000
+    assert _normalize_weight('extrablack') == 1000
     assert _normalize_weight('black') == 900
     with pytest.raises(KeyError):
         _normalize_weight('invalid')

--- a/lib/matplotlib/tests/test_font_manager.py
+++ b/lib/matplotlib/tests/test_font_manager.py
@@ -427,6 +427,9 @@ def test_normalize_weights():
     assert _normalize_weight('bold') == 700
     assert _normalize_weight('heavy') == 800
     assert _normalize_weight('extra bold') == 800
+    assert _normalize_weight('extrabold') == 800
+    assert _normalize_weight('superbold') == 800
+    assert _normalize_weight('ultrabold') == 800
     assert _normalize_weight('black') == 900
     with pytest.raises(KeyError):
         _normalize_weight('invalid')


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
This PR fixes an inconsistency in how font weights are handled. Some weight names like extrabold, superbold, and ultrabold were already supported internally when parsing font metadata, but they were not accepted when passed directly as user input. This created a mismatch where these values could be read from fonts but not used explicitly.
To fix this, I added the missing weight names to weight_dict so that user input handling is consistent with internal parsing. This keeps existing behavior unchanged while resolving the asymmetry. I also updated the existing test to cover these cases.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #31506 " is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
