### PR TITLE
BUG: Fix relim() to support Collection artists (scatter, etc.)

### DIFF
--- a/doc/api/next_api_changes/behavior/31530-TZ.rst
+++ b/doc/api/next_api_changes/behavior/31530-TZ.rst
@@ -1,0 +1,6 @@
+``relim()`` now accounts for Collection artists
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Previously, `~.axes.Axes.relim` did not recalculate data limits for
+`.Collection` artists (e.g. those created by `~.axes.Axes.scatter`).
+Calling ``ax.relim()`` followed by ``ax.autoscale_view()`` now correctly
+includes scatter plots and other collections in the axes limits.

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -240,9 +240,6 @@ Supported properties are
         with `.FigureCanvasBase.draw_idle`.  Call `~.axes.Axes.relim` to
         update the Axes limits if desired.
 
-        Note: `~.axes.Axes.relim` will not see collections even if the
-        collection was added to the Axes with *autolim* = True.
-
         Note: there is no support for removing the artist's legend entry.
         """
 

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -268,11 +268,6 @@ Supported properties are
 
         else:
             raise NotImplementedError('cannot remove artist')
-        # TODO: move the limits calculation into the artist itself, including
-        # the property of whether or not the artist should affect the limits.
-        # Then there will be no distinction between axes.add_line,
-        # axes.add_patch, etc.
-        # TODO: add legend support
 
     def have_units(self):
         """Return whether units are set on any axis."""

--- a/lib/matplotlib/artist.py
+++ b/lib/matplotlib/artist.py
@@ -268,10 +268,10 @@ Supported properties are
 
         else:
             raise NotImplementedError('cannot remove artist')
-        # TODO: the fix for the collections relim problem is to move the
-        # limits calculation into the artist itself, including the property of
-        # whether or not the artist should affect the limits.  Then there will
-        # be no distinction between axes.add_line, axes.add_patch, etc.
+        # TODO: move the limits calculation into the artist itself, including
+        # the property of whether or not the artist should affect the limits.
+        # Then there will be no distinction between axes.add_line,
+        # axes.add_patch, etc.
         # TODO: add legend support
 
     def have_units(self):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2418,7 +2418,8 @@ class _AxesBase(martist.Artist):
             collection.set_clip_path(self.patch)
 
         if autolim:
-            collection._set_in_autoscale(True)
+            if autolim != "_datalim_only":
+                collection._set_in_autoscale(True)
             # Make sure viewLim is not stale (mostly to match
             # pre-lazy-autoscale behavior, which is not really better).
             self._unstale_viewLim()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2434,6 +2434,7 @@ class _AxesBase(martist.Artist):
                 self._request_autoscale_view()
 
         self.stale = True
+        collection._set_in_autoscale(True)
         return collection
 
     def add_image(self, image):
@@ -2638,15 +2639,11 @@ class _AxesBase(martist.Artist):
         """
         Recompute the data limits based on current artists.
 
-        At present, `.Collection` instances are not supported.
-
         Parameters
         ----------
         visible_only : bool, default: False
             Whether to exclude invisible artists.
         """
-        # Collections are deliberately not supported (yet); see
-        # the TODO note in artists.py.
         self.dataLim.ignore(True)
         self.dataLim.set_points(mtransforms.Bbox.null().get_points())
         self.ignore_existing_data_limits = True
@@ -2661,6 +2658,23 @@ class _AxesBase(martist.Artist):
                     self._update_patch_limits(artist)
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
+                elif isinstance(artist, mcoll.Collection):
+                    datalim = artist.get_datalim(self.transData)
+                    points = datalim.get_points()
+                    if not np.isinf(datalim.minpos).all():
+                        points = np.concatenate([points,
+                                                 [datalim.minpos]])
+                    x_is_data, y_is_data = (
+                        artist.get_transform()
+                        .contains_branch_separately(self.transData))
+                    ox_is_data, oy_is_data = (
+                        artist.get_offset_transform()
+                        .contains_branch_separately(self.transData))
+                    self.update_datalim(
+                        points,
+                        updatex=x_is_data or ox_is_data,
+                        updatey=y_is_data or oy_is_data,
+                    )
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2432,9 +2432,12 @@ class _AxesBase(martist.Artist):
             )
             if autolim != "_datalim_only":
                 self._request_autoscale_view()
+            # Mark collection as participating in relim() only when autolim
+            # is enabled.  If autolim=False the caller explicitly opted out,
+            # so relim() must not pick this collection up later.
+            collection._set_in_autoscale(True)
 
         self.stale = True
-        collection._set_in_autoscale(True)
         return collection
 
     def add_image(self, image):

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2391,7 +2391,7 @@ class _AxesBase(martist.Artist):
 
             .. versionchanged:: 3.11
 
-               Since 3.11 `autolim=True` matches the standard behavior
+               Since 3.11 ``autolim=True`` matches the standard behavior
                of other ``add_[artist]`` methods: Axes data and view limits
                are both updated in the method, and the collection will
                be considered in future data limit updates through
@@ -2399,7 +2399,7 @@ class _AxesBase(martist.Artist):
 
                Prior to matplotlib 3.11 this was only a one-time update
                of the data limits. Updating view limits required an
-               explicit calls to `~.Axes.autoscale_view`, and collections
+               explicit call to `~.Axes.autoscale_view`, and collections
                did not take part in `.relim`.
 
             As an implementation detail, the value "_datalim_only" is

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2410,26 +2410,7 @@ class _AxesBase(martist.Artist):
             # Make sure viewLim is not stale (mostly to match
             # pre-lazy-autoscale behavior, which is not really better).
             self._unstale_viewLim()
-            datalim = collection.get_datalim(self.transData)
-            points = datalim.get_points()
-            if not np.isinf(datalim.minpos).all():
-                # By definition, if minpos (minimum positive value) is set
-                # (i.e., non-inf), then min(points) <= minpos <= max(points),
-                # and minpos would be superfluous. However, we add minpos to
-                # the call so that self.dataLim will update its own minpos.
-                # This ensures that log scales see the correct minimum.
-                points = np.concatenate([points, [datalim.minpos]])
-            # only update the dataLim for x/y if the collection uses transData
-            # in this direction.
-            x_is_data, y_is_data = (collection.get_transform()
-                                    .contains_branch_separately(self.transData))
-            ox_is_data, oy_is_data = (collection.get_offset_transform()
-                                      .contains_branch_separately(self.transData))
-            self.update_datalim(
-                points,
-                updatex=x_is_data or ox_is_data,
-                updatey=y_is_data or oy_is_data,
-            )
+            self._update_collection_limits(collection)
             if autolim != "_datalim_only":
                 self._request_autoscale_view()
             # Mark collection as participating in relim() only when autolim
@@ -2602,6 +2583,29 @@ class _AxesBase(martist.Artist):
         xys = trf_to_data.transform(vertices)
         self.update_datalim(xys, updatex=updatex, updatey=updatey)
 
+    def _update_collection_limits(self, collection):
+        """Update the data limits for the given collection."""
+        datalim = collection.get_datalim(self.transData)
+        points = datalim.get_points()
+        if not np.isinf(datalim.minpos).all():
+            # By definition, if minpos (minimum positive value) is set
+            # (i.e., non-inf), then min(points) <= minpos <= max(points),
+            # and minpos would be superfluous. However, we add minpos to
+            # the call so that self.dataLim will update its own minpos.
+            # This ensures that log scales see the correct minimum.
+            points = np.concatenate([points, [datalim.minpos]])
+        # only update the dataLim for x/y if the collection uses transData
+        # in this direction.
+        x_is_data, y_is_data = (collection.get_transform()
+                                 .contains_branch_separately(self.transData))
+        ox_is_data, oy_is_data = (collection.get_offset_transform()
+                                   .contains_branch_separately(self.transData))
+        self.update_datalim(
+            points,
+            updatex=x_is_data or ox_is_data,
+            updatey=y_is_data or oy_is_data,
+        )
+
     def add_table(self, tab):
         """
         Add a `.Table` to the Axes; return the table.
@@ -2662,27 +2666,7 @@ class _AxesBase(martist.Artist):
                 elif isinstance(artist, mimage.AxesImage):
                     self._update_image_limits(artist)
                 elif isinstance(artist, mcoll.Collection):
-                    datalim = artist.get_datalim(self.transData)
-                    points = datalim.get_points()
-                    if not np.isinf(datalim.minpos).all():
-                        # As in add_collection: include minpos so that
-                        # self.dataLim updates its own minpos, which ensures
-                        # log scales see the correct minimum.
-                        points = np.concatenate([points,
-                                                 [datalim.minpos]])
-                    # Only update dataLim for x/y if the collection uses
-                    # transData in that direction.
-                    x_is_data, y_is_data = (
-                        artist.get_transform()
-                        .contains_branch_separately(self.transData))
-                    ox_is_data, oy_is_data = (
-                        artist.get_offset_transform()
-                        .contains_branch_separately(self.transData))
-                    self.update_datalim(
-                        points,
-                        updatex=x_is_data or ox_is_data,
-                        updatey=y_is_data or oy_is_data,
-                    )
+                    self._update_collection_limits(artist)
 
     def update_datalim(self, xys, updatex=True, updatey=True):
         """

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2384,15 +2384,23 @@ class _AxesBase(martist.Artist):
         collection : `.Collection`
             The collection to add.
         autolim : bool
-            Whether to update data limits and request autoscaling.
+            Whether to update data and view limits.
 
-            If *False*, the collection is explicitly excluded from
-            `~.Axes.relim`.
+            If *False*, the collection does not take part in any limit
+            operations.
 
             .. versionchanged:: 3.11
 
-               This now also updates the view limits, making explicit
-               calls to `~.Axes.autoscale_view` unnecessary.
+               Since 3.11 `autolim=True` matches the standard behavior
+               of other ``add_[artist]`` methods: Axes data and view limits
+               are both updated in the method, and the collection will
+               be considered in future data limit updates through
+               `.relim`.
+
+               Prior to matplotlib 3.11 this was only a one-time update
+               of the data limits. Updating view limits required an
+               explicit calls to `~.Axes.autoscale_view`, and collections
+               did not take part in `.relim`.
 
             As an implementation detail, the value "_datalim_only" is
             supported to smooth the internal transition from pre-3.11
@@ -2409,11 +2417,8 @@ class _AxesBase(martist.Artist):
         if collection.get_clip_path() is None:
             collection.set_clip_path(self.patch)
 
-        # Keep relim() participation aligned with the autolim argument.
-        # autolim can also be the internal sentinel "_datalim_only".
-        collection._set_in_autoscale(bool(autolim))
-
         if autolim:
+            collection._set_in_autoscale(True)
             # Make sure viewLim is not stale (mostly to match
             # pre-lazy-autoscale behavior, which is not really better).
             self._unstale_viewLim()

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2662,8 +2662,13 @@ class _AxesBase(martist.Artist):
                     datalim = artist.get_datalim(self.transData)
                     points = datalim.get_points()
                     if not np.isinf(datalim.minpos).all():
+                        # As in add_collection: include minpos so that
+                        # self.dataLim updates its own minpos, which ensures
+                        # log scales see the correct minimum.
                         points = np.concatenate([points,
                                                  [datalim.minpos]])
+                    # Only update dataLim for x/y if the collection uses
+                    # transData in that direction.
                     x_is_data, y_is_data = (
                         artist.get_transform()
                         .contains_branch_separately(self.transData))

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2384,7 +2384,10 @@ class _AxesBase(martist.Artist):
         collection : `.Collection`
             The collection to add.
         autolim : bool
-            Whether to update data and view limits.
+            Whether to update data limits and request autoscaling.
+
+            If *False*, the collection is explicitly excluded from
+            `~.Axes.relim`.
 
             .. versionchanged:: 3.11
 
@@ -2406,6 +2409,10 @@ class _AxesBase(martist.Artist):
         if collection.get_clip_path() is None:
             collection.set_clip_path(self.patch)
 
+        # Keep relim() participation aligned with the autolim argument.
+        # autolim can also be the internal sentinel "_datalim_only".
+        collection._set_in_autoscale(bool(autolim))
+
         if autolim:
             # Make sure viewLim is not stale (mostly to match
             # pre-lazy-autoscale behavior, which is not really better).
@@ -2413,10 +2420,6 @@ class _AxesBase(martist.Artist):
             self._update_collection_limits(collection)
             if autolim != "_datalim_only":
                 self._request_autoscale_view()
-            # Mark collection as participating in relim() only when autolim
-            # is enabled.  If autolim=False the caller explicitly opted out,
-            # so relim() must not pick this collection up later.
-            collection._set_in_autoscale(True)
 
         self.stale = True
         return collection

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6532,7 +6532,8 @@ def test_relim_collection():
     ax.relim(visible_only=True)
     # With scatter hidden, limits should be driven by the line only.
     assert_allclose(ax.dataLim.get_points(), [[0, 0], [1, 1]])
-    assert_array_equal(ax.dataLim.minpos, [np.inf, np.inf])
+    # minpos is the minimum *positive* value; line data [0, 1] gives 1.0.
+    assert_array_equal(ax.dataLim.minpos, [1., 1.])
 
 
 def test_relim_collection_autolim_false():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6542,6 +6542,40 @@ def test_relim_collection():
     assert ylim[1] < 10
 
 
+def test_relim_collection_autolim_false():
+    # GH#30859 - Collection added with autolim=False must not participate
+    # in relim() later.
+    import matplotlib.collections as mcollections
+    fig, ax = plt.subplots()
+    ax.set_xlim(0, 1)
+    ax.set_ylim(0, 1)
+    # Build a collection far outside current limits and add it with autolim=False.
+    sc = mcollections.PathCollection([])
+    sc.set_offsets([[100, 200], [300, 400]])
+    ax.add_collection(sc, autolim=False)
+    ax.relim()
+    ax.autoscale_view()
+    # Limits must remain unchanged because autolim=False was requested.
+    assert ax.get_xlim() == (0, 1)
+    assert ax.get_ylim() == (0, 1)
+
+
+def test_relim_collection_log_scale():
+    # GH#30859 - relim() for Collection on a log-scaled axis should
+    # correctly pick up minpos so that log scaling works properly.
+    fig, ax = plt.subplots()
+    ax.set_xscale('log')
+    ax.set_yscale('log')
+    sc = ax.scatter([1e-3, 1e-2, 1e-1], [1e1, 1e2, 1e3])
+    sc.set_offsets([[1e1, 1e4], [1e2, 1e5]])
+    ax.relim()
+    ax.autoscale_view()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    assert xlim[0] <= 1e1 and xlim[1] >= 1e2
+    assert ylim[0] <= 1e4 and ylim[1] >= 1e5
+
+
 def test_text_labelsize():
     """
     tests for issue #1172

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6515,31 +6515,24 @@ def test_relim_collection():
     fig, ax = plt.subplots()
     sc = ax.scatter([1, 2, 3], [4, 5, 6])
     ax.relim()
-    ax.autoscale_view()
-    xlim = ax.get_xlim()
-    ylim = ax.get_ylim()
-    assert xlim[0] <= 1 and xlim[1] >= 3
-    assert ylim[0] <= 4 and ylim[1] >= 6
+    expected = sc.get_datalim(ax.transData)
+    assert_allclose(ax.dataLim.get_points(), expected.get_points())
+    assert_allclose(ax.dataLim.minpos, expected.minpos)
 
     # After updating offsets, relim should track the new data.
     sc.set_offsets([[10, 20], [30, 40]])
     ax.relim()
-    ax.autoscale_view()
-    xlim = ax.get_xlim()
-    ylim = ax.get_ylim()
-    assert xlim[0] <= 10 and xlim[1] >= 30
-    assert ylim[0] <= 20 and ylim[1] >= 40
+    expected = sc.get_datalim(ax.transData)
+    assert_allclose(ax.dataLim.get_points(), expected.get_points())
+    assert_allclose(ax.dataLim.minpos, expected.minpos)
 
     # visible_only=True should ignore hidden collections.
     line, = ax.plot([0, 1], [0, 1])
     sc.set_visible(False)
     ax.relim(visible_only=True)
-    ax.autoscale_view()
-    xlim = ax.get_xlim()
-    ylim = ax.get_ylim()
     # With scatter hidden, limits should be driven by the line only.
-    assert xlim[1] < 10
-    assert ylim[1] < 10
+    assert_allclose(ax.dataLim.get_points(), [[0, 0], [1, 1]])
+    assert_array_equal(ax.dataLim.minpos, [np.inf, np.inf])
 
 
 def test_relim_collection_autolim_false():
@@ -6547,33 +6540,31 @@ def test_relim_collection_autolim_false():
     # in relim() later.
     import matplotlib.collections as mcollections
     fig, ax = plt.subplots()
-    ax.set_xlim(0, 1)
-    ax.set_ylim(0, 1)
+    ax.plot([0, 1], [0, 1])
+    ax.relim()
+    expected = ax.dataLim.frozen()
     # Build a collection far outside current limits and add it with autolim=False.
     sc = mcollections.PathCollection([])
     sc.set_offsets([[100, 200], [300, 400]])
     ax.add_collection(sc, autolim=False)
     ax.relim()
-    ax.autoscale_view()
-    # Limits must remain unchanged because autolim=False was requested.
-    assert ax.get_xlim() == (0, 1)
-    assert ax.get_ylim() == (0, 1)
+    # dataLim must remain unchanged because autolim=False was requested.
+    assert_allclose(ax.dataLim.get_points(), expected.get_points())
+    assert_allclose(ax.dataLim.minpos, expected.minpos)
 
 
 def test_relim_collection_log_scale():
     # GH#30859 - relim() for Collection on a log-scaled axis should
-    # correctly pick up minpos so that log scaling works properly.
+    # correctly propagate minpos into dataLim.
     fig, ax = plt.subplots()
     ax.set_xscale('log')
     ax.set_yscale('log')
     sc = ax.scatter([1e-3, 1e-2, 1e-1], [1e1, 1e2, 1e3])
     sc.set_offsets([[1e1, 1e4], [1e2, 1e5]])
     ax.relim()
-    ax.autoscale_view()
-    xlim = ax.get_xlim()
-    ylim = ax.get_ylim()
-    assert xlim[0] <= 1e1 and xlim[1] >= 1e2
-    assert ylim[0] <= 1e4 and ylim[1] >= 1e5
+    expected = sc.get_datalim(ax.transData)
+    assert_allclose(ax.dataLim.get_points(), expected.get_points())
+    assert_allclose(ax.dataLim.minpos, expected.minpos)
 
 
 def test_text_labelsize():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6511,6 +6511,37 @@ def test_relim_visible_only():
     assert ax.get_ylim() == y1
 
 
+def test_relim_collection():
+    fig, ax = plt.subplots()
+    sc = ax.scatter([1, 2, 3], [4, 5, 6])
+    ax.relim()
+    ax.autoscale_view()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    assert xlim[0] <= 1 and xlim[1] >= 3
+    assert ylim[0] <= 4 and ylim[1] >= 6
+
+    # After updating offsets, relim should track the new data.
+    sc.set_offsets([[10, 20], [30, 40]])
+    ax.relim()
+    ax.autoscale_view()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    assert xlim[0] <= 10 and xlim[1] >= 30
+    assert ylim[0] <= 20 and ylim[1] >= 40
+
+    # visible_only=True should ignore hidden collections.
+    line, = ax.plot([0, 1], [0, 1])
+    sc.set_visible(False)
+    ax.relim(visible_only=True)
+    ax.autoscale_view()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    # With scatter hidden, limits should be driven by the line only.
+    assert xlim[1] < 10
+    assert ylim[1] < 10
+
+
 def test_text_labelsize():
     """
     tests for issue #1172

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -6568,6 +6568,22 @@ def test_relim_collection_log_scale():
     assert_allclose(ax.dataLim.minpos, expected.minpos)
 
 
+def test_relim_collection_autoscale_view():
+    # GH#30859 - end-to-end: after set_offsets(), relim() + autoscale_view()
+    # must update the visible axis limits, not just dataLim.
+    fig, ax = plt.subplots()
+    sc = ax.scatter([], [])
+    xs = np.linspace(0, 10, 50)
+    sc.set_offsets(np.column_stack((xs, np.sin(xs))))
+    ax.relim()
+    ax.autoscale_view()
+    xlim = ax.get_xlim()
+    ylim = ax.get_ylim()
+    # autoscale_view adds a margin, so limits should comfortably contain data
+    assert xlim[0] <= 0 and xlim[1] >= 10, f"xlim should contain [0, 10], got {xlim}"
+    assert ylim[0] <= -1 and ylim[1] >= 1, f"ylim should contain [-1, 1], got {ylim}"
+
+
 def test_text_labelsize():
     """
     tests for issue #1172


### PR DESCRIPTION
## PR summary

`relim()` completely ignored `Collection` artists (scatter plots, `PathCollection`, etc.) — calling `ax.relim()` after `scatter.set_offsets()` had no effect on the axis limits. Closes #30859.

**Why is this change necessary?**
Users who update scatter data dynamically (e.g. animation loops, interactive plots) rely on `relim()` + `autoscale_view()` to recalculate axis limits. For line artists this works; for scatter/Collection artists it silently did nothing.

**What problem does it solve?**
After `scatter.set_offsets(new_data)`, calling `ax.relim(); ax.autoscale_view()` now correctly updates the axis limits to fit the new data.

**Root cause — two bugs, one fix:**

1. `add_collection()` never called `collection._set_in_autoscale()`, unlike `add_line()`, `add_patch()`, and `add_image()`. As a result `relim()` skipped all Collections because `_get_in_autoscale()` returned `False` (the default). The fix calls `_set_in_autoscale(bool(autolim))` so that `autolim=False` correctly opts the collection out of future `relim()` calls.

2. `relim()` in `_base.py` had no `elif isinstance(a, mcoll.Collection)` branch. Even with flag fixed, the data limits would never have been picked up. The fix adds that branch, calling a new `_update_collection_limits()` helper that mirrors the logic already used in `add_collection()`.

**Minimal reproduction:**
```python
import matplotlib.pyplot as plt
import numpy as np

fig, ax = plt.subplots()
scatter = ax.scatter([], [])
xs = np.linspace(0, 10, 100)
scatter.set_offsets(np.column_stack((xs, np.sin(xs))))

ax.relim()
ax.autoscale_view()
print(ax.get_xlim())  # Before fix: (0.0, 1.0)  After fix: (-0.5, 10.5)
plt.show()
```

**Before fix** — axis stays at default `[0, 1]`, data is cut off:

![before fix](https://raw.githubusercontent.com/tinezivic/bug_fixing/main/matplotlib/30859/analysis/before_fix.png)

**After fix** — axis correctly scales to data extent:

![after fix](https://raw.githubusercontent.com/tinezivic/bug_fixing/main/matplotlib/30859/analysis/after_fix.png)

## AI Disclosure

I used GitHub Copilot (Claude Sonnet 4.6) to assist with code generation, diff review, and drafting documentation (including `doc/api/next_api_changes/behavior/31530-TZ.rst`). The root cause analysis, understanding of the `_in_autoscale` mechanism, identification of both bug sites, and verification of the fix logic were done by me.

## PR checklist

- [x] "closes #30859" is in the body of the PR description
- [x] new and changed code is tested — three regression tests in `lib/matplotlib/tests/test_axes.py`:
  - `test_relim_collection`: initial scatter limits, limits after `set_offsets()`, `visible_only=True`
  - `test_relim_collection_autolim_false`: collection added with `autolim=False` must not affect limits after `relim()`
  - `test_relim_collection_log_scale`: `relim()` on log-scaled axes exercises the `minpos` path correctly
- [ ] *Plotting related* features are demonstrated in an example — N/A (bugfix, not a new feature)
- [x] *New Features* and *API Changes* are noted with a directive and release note — added `doc/api/next_api_changes/behavior/31530-TZ.rst`
- [x] Documentation complies with general and docstring guidelines — no public API changed