### PR TITLE
Fix contour behavior when Z is constant (zmin == zmax)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -6,7 +6,7 @@ from contextlib import ExitStack
 import functools
 import math
 from numbers import Integral
-
+import warnings
 import numpy as np
 from numpy import ma
 
@@ -998,6 +998,15 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         one contour line, but two filled regions, and therefore
         three levels to provide boundaries for both regions.
         """
+       
+
+        if self.zmin == self.zmax:
+            warnings.warn(
+                "Z is constant; contour levels are not meaningful.",
+                stacklevel=2
+            )
+            return np.array([self.zmin])
+
         lev = self.locator.tick_values(self.zmin, self.zmax)
 
         try:
@@ -1006,7 +1015,7 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         except AttributeError:
             pass
 
-        # Trim excess levels the locator may have supplied.
+    # Trim excess levels the locator may have supplied.
         under = np.nonzero(lev < self.zmin)[0]
         i0 = under[-1] if len(under) else 0
         over = np.nonzero(lev > self.zmax)[0]

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -876,3 +876,16 @@ def test_contour_aliases(fig_test, fig_ref):
 def test_contour_singular_color():
     with pytest.raises(TypeError):
         plt.figure().add_subplot().contour([[0, 1], [2, 3]], color="r")
+
+def test_contour_constant_z_warns_and_single_level():
+    Z = np.ones((10, 10))
+
+    fig, ax = plt.subplots()
+
+    # Expect a warning
+    with pytest.warns(UserWarning, match="Z is constant"):
+        cs = ax.contour(Z)
+
+    # Ensure only one level is created
+    assert len(cs.levels) == 1
+    assert cs.levels[0] == 1.0


### PR DESCRIPTION
Fixes #31493.

This PR addresses an issue where contour/contourf produces invalid or misleading output when the input data is constant (i.e., zmin == zmax).

### Problem
When Z is constant, the automatic level generation in `_autolev` passes identical values to the locator, which results in invalid or non-informative contour levels.

### Changes
- Added a guard in `_autolev` to detect the case `zmin == zmax`
- Emit a `UserWarning` indicating that contour levels are not meaningful for constant data
- Return a single valid contour level (`[zmin]`) to prevent downstream errors

### Behavior
- No crash occurs for constant input data
- A warning is issued to inform the user
- Contour generation remains stable and predictable

### Testing
Added a test case in `test_contour.py` to verify:
- Warning is raised for constant Z
- Only one contour level is generated