### PR TITLE
DOC: fix broken link to wxPython Widget Inspection Tool

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -275,6 +275,7 @@ intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'scipy': ('https://docs.scipy.org/doc/scipy/', None),
     'tornado': ('https://www.tornadoweb.org/en/stable/', None),
+    'wx': ('https://docs.wxpython.org/', None),
     'xarray': ('https://docs.xarray.dev/en/stable/', None),
     'meson-python': ('https://mesonbuild.com/meson-python/', None),
     'pip': ('https://pip.pypa.io/en/stable/', None),

--- a/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -5,12 +5,11 @@ Embed in wx #5
 
 .. tip::
 
-    :class:`wx.lib.mixins.inspection.InspectableApp` is a drop-in
-    replacement for :class:`wx.App` that opens an inspection window
-    letting you browse the live widget and sizer tree. It is a useful
-    debugging aid when embedding Matplotlib in wxPython. See the
-    `wx.lib.inspection documentation
-    <https://docs.wxpython.org/wx.lib.inspection.html>`_.
+    As a development and debugging aid, you can replace :class:`wx.App`
+    by :class:`wx.lib.mixins.inspection.InspectableApp`.
+    This adds the capability to start the `Widget Inspection Tool
+    <https://wiki.wxpython.org/How%20to%20use%20Widget%20Inspection%20Tool%20-%20WIT%20%28Phoenix%29>`_
+    via :kbd:`Ctrl-Alt-I`.
 """
 
 import wx

--- a/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -47,7 +47,7 @@ def demo():
     # Alternatively you could use:
     # app = wx.App()
     # InspectableApp is a great debug tool, see:
-    # http://wiki.wxpython.org/Widget%20Inspection%20Tool
+    # https://docs.wxpython.org/wx.lib.inspection.html
     app = wit.InspectableApp()
     frame = wx.Frame(None, -1, 'Plotter')
     plotter = PlotNotebook(frame)

--- a/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -3,11 +3,18 @@
 Embed in wx #5
 ==============
 
+.. tip::
+
+    :class:`wx.lib.mixins.inspection.InspectableApp` is a drop-in
+    replacement for :class:`wx.App` that opens an inspection window
+    letting you browse the live widget and sizer tree. It is a useful
+    debugging aid when embedding Matplotlib in wxPython. See the
+    `wx.lib.inspection documentation
+    <https://docs.wxpython.org/wx.lib.inspection.html>`_.
 """
 
 import wx
 import wx.lib.agw.aui as aui
-import wx.lib.mixins.inspection as wit
 
 from matplotlib.backends.backend_wxagg import FigureCanvasWxAgg as FigureCanvas
 from matplotlib.backends.backend_wxagg import \
@@ -44,11 +51,7 @@ class PlotNotebook(wx.Panel):
 
 
 def demo():
-    # Alternatively you could use:
-    # app = wx.App()
-    # InspectableApp is a great debug tool, see:
-    # https://docs.wxpython.org/wx.lib.inspection.html
-    app = wit.InspectableApp()
+    app = wx.App()
     frame = wx.Frame(None, -1, 'Plotter')
     plotter = PlotNotebook(frame)
     axes1 = plotter.add('figure 1').add_subplot()


### PR DESCRIPTION
## PR summary

One of the broken links collected in #30306: the URL
`http://wiki.wxpython.org/Widget%20Inspection%20Tool` in the
`embedding_in_wx5_sgskip` gallery example now returns 404 (the old
wxPython wiki is defunct).

The current equivalent is on the official wxPython documentation:
https://docs.wxpython.org/wx.lib.inspection.html — which returns 200
and documents the same `wx.lib.inspection` module.

## PR checklist

- [x] Link replacement verified (new URL returns 200, old URL returns 404).
- [x] No code change; only a comment URL is updated.