### PR TITLE
Fix typos in docstrings and comments

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1010,7 +1010,7 @@ class FontConstantsBase:
 
 class ComputerModernFontConstants(FontConstantsBase):
     # Previously, the x-height of Computer Modern was obtained from the font
-    # table. However, that x-height was greater than the the actual (rendered)
+    # table. However, that x-height was greater than the actual (rendered)
     # x-height by a factor of 1.771484375 (at font size 12, DPI 100 and hinting
     # type 32). Now that we're using the rendered x-height, some font constants
     # have been increased by the same factor to compensate.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3520,7 +3520,7 @@ class MultiNorm(Norm):
             - If iterable, must be of length `n_components`. Each element can be a
               scalar or array-like and is mapped through the corresponding norm.
             - If structured array, must have `n_components` fields. Each field
-              is mapped through the the corresponding norm.
+              is mapped through the corresponding norm.
 
         """
         values = self._iterable_components_in_data(values, self.n_components)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -1614,7 +1614,7 @@ class OffsetFrom:
 
         ref_coord : (float, float)
             If *artist* is an `.Artist` or `.BboxBase`, this values is
-            the location to of the offset origin in fractions of the
+            the location of the offset origin in fractions of the
             *artist* bounding box.
 
             If *artist* is a transform, the offset origin is the


### PR DESCRIPTION

**Repo:** matplotlib/matplotlib (⭐ 20000)
**Type:** docs
**Files changed:** 3
**Lines:** +3/-3

## What
Fix three small typos in user-facing docstrings and an internal comment:
- `lib/matplotlib/_mathtext.py`: "the the actual" → "the actual" (comment).
- `lib/matplotlib/colors.py`: "through the the corresponding norm" → "through the corresponding norm" (rendered docstring for `Colorizer.inverse`).
- `lib/matplotlib/text.py`: "the location to of the offset origin" → "the location of the offset origin" (rendered docstring for `OffsetFrom`).

## Why
Two of the three errors appear in published API docstrings, where they are visible
to downstream users and on matplotlib.org. The third is in a comment but reads as
a doubled-word typo. Fixes are isolated and unambiguous.

## Testing
Pure documentation/comment edits — no behavior change. Verified each change is a
self-contained word-level fix and leaves surrounding prose grammatical.

## Risk
Low — comment/docstring text only, no code paths touched.
