### PR TITLE
DOC: replace dolphin license RDF block with prose attribution

### DIFF
--- a/galleries/examples/shapes_and_collections/dolphin.py
+++ b/galleries/examples/shapes_and_collections/dolphin.py
@@ -37,12 +37,7 @@ im.set_clip_path(circle)
 
 plt.plot(x, y, 'o', color=(0.9, 0.9, 1.0), alpha=0.8)
 
-# Dolphin from OpenClipart library by Andy Fitzsimon
-#   <cc:License rdf:about="http://web.resource.org/cc/PublicDomain">
-#     <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
-#     <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
-#     <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
-#   </cc:License>
+# Dolphin from OpenClipart library by Andy Fitzsimon (Public Domain).
 
 dolphin = """
 M -0.59739425,160.18173 C -0.62740401,160.18885 -0.57867129,160.11183


### PR DESCRIPTION
## PR summary

Addresses one of the broken links collected in #30306 and the review
feedback from @jklymak on the original revision of this PR.

Instead of migrating the dead \`web.resource.org/cc/*\` URIs in
\`galleries/examples/shapes_and_collections/dolphin.py\` to the current
\`creativecommons.org/ns#\` namespace (which would have locked us into
chasing future namespace changes), the RDF block is replaced with a
single plain-text attribution line. The block was never rendered it
only carried provenance metadata in a comment so prose serves the
same purpose without the maintenance burden.

### Diff

\`\`\`diff
-# Dolphin from OpenClipart library by Andy Fitzsimon
-#   <cc:License rdf:about="http://web.resource.org/cc/PublicDomain">
-#     <cc:permits rdf:resource="http://web.resource.org/cc/Reproduction"/>
-#     <cc:permits rdf:resource="http://web.resource.org/cc/Distribution"/>
-#     <cc:permits rdf:resource="http://web.resource.org/cc/DerivativeWorks"/>
-#   </cc:License>
+# Dolphin from OpenClipart library by Andy Fitzsimon (Public Domain).
\`\`\`

## PR checklist

- [x] Author credit preserved.
- [x] License status preserved (Public Domain).
- [x] No code change; only a comment block is updated.