### PR TITLE
Add unregister_scale() function to matplotlib.scale

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -955,6 +955,19 @@ def register_scale(scale_class):
             pending=True,
         )
 
+def unregister_scale(name):
+    """
+    Remove a custom scale from the registry.
+
+    Parameters
+    ----------
+    name : str
+        The name of the scale to remove.
+    """
+    if name not in _scale_mapping:
+        raise ValueError(f"Scale '{name}' is not registered.")
+    del _scale_mapping[name]
+
 
 def _get_scale_docs():
     """

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -433,3 +433,22 @@ def test_val_in_range_base_fallback():
     assert s.val_in_range(np.nan) is False
     assert s.val_in_range(np.inf) is False
     assert s.val_in_range(-np.inf) is False
+
+def test_unregister_scale():
+    """Test that unregister_scale removes a scale correctly."""
+    # Register a temporary custom scale
+    class TempScale(mscale.LinearScale):
+        name = 'temp_test_scale'
+
+    mscale.register_scale(TempScale)
+    assert 'temp_test_scale' in mscale._scale_mapping
+
+    # Now unregister it
+    mscale.unregister_scale('temp_test_scale')
+    assert 'temp_test_scale' not in mscale._scale_mapping
+
+
+def test_unregister_scale_invalid():
+    """Test that unregister_scale raises ValueError for unknown scale."""
+    with pytest.raises(ValueError, match="not registered"):
+        mscale.unregister_scale('this_does_not_exist')


### PR DESCRIPTION
Added unregister_scale(name) function that allows users to remove previously registered custom scales from the registry.

Raises ValueError if the scale name is not found.

## PR Summary

Currently matplotlib has register_scale() but no way to undo it. This becomes a problem when a custom scale is created for just one plot — there's no cleanup option after the plot is done.

This PR adds unregister_scale(name) to fix that gap. It removes the scale from _scale_mapping, and raises a ValueError if the name doesn't exist.

## AI Disclosure

I used AI to help understand where to place the function and for guidance on the implementation approach. 

## PR Checklist

- [x] Closes #5791 is in the PR description
- [x] New code is tested