### PR TITLE
31537 text wrap figure edge

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -778,8 +778,8 @@ def test_wrap_on_figure_edge(x, y, rotation):
 
 
 def test_wrap_on_figure_edge_transform_rotates_text():
-    # Regression test for #31537 - transform_rotates_text with an axis-aligned
-    # transform can make get_rotation() float-round to 360.0.
+    # transform_rotates_text with an axis-aligned transform can make
+    # get_rotation() float-round to 360.0, breaking the wrap logic.
     s = 'This is a very long text that should be wrapped multiple times.'
 
     fig = plt.figure(figsize=(6, 4))

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -778,20 +778,22 @@ def test_wrap_on_figure_edge(x, y, rotation):
 
 
 def test_wrap_on_figure_edge_transform_rotates_text():
-    # With transform_rotates_text=True, get_rotation() goes through
-    # transform_angles() and can return near-cardinal angles with float
-    # noise (e.g. -90.00000000000003 for a 270 degree rotation), which
-    # used to skip the cardinal-angle short-circuit in _get_dist_to_box.
-    from matplotlib.transforms import Affine2D
-    fig = plt.figure(figsize=(6, 4))
+    # Regression test for #31537 - transform_rotates_text with an axis-aligned
+    # transform can make get_rotation() float-round to 360.0.
     s = 'This is a very long text that should be wrapped multiple times.'
-    # rotate_deg(90).rotate_deg(-90) is identity geometrically, but carries
-    # enough numerical slop to perturb transform_angles.
-    transform = Affine2D().rotate_deg(90).rotate_deg(-90) + fig.transFigure
-    t = fig.text(0.0, 0.5, s, transform=transform, wrap=True, rotation=270,
-                 transform_rotates_text=True)
+
+    fig = plt.figure(figsize=(6, 4))
+    transform = mtransforms.Affine2D().rotate_deg(270) + fig.transFigure
+    t = fig.text(0.0, 0.0, s, transform=transform, wrap=True,
+                 rotation=90, transform_rotates_text=True)
     fig.canvas.draw()
-    assert any(' ' in line for line in t._get_wrapped_text().split('\n'))
+
+    fig_ref = plt.figure(figsize=(6, 4))
+    t_ref = fig_ref.text(0.0, 0.0, s, wrap=True, rotation=0)
+    fig_ref.canvas.draw()
+
+    assert 0 <= t.get_rotation() < 360
+    assert t._get_wrapped_text() == t_ref._get_wrapped_text()
 
 
 @check_figures_equal()

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -753,6 +753,47 @@ def test_wrap_no_wrap():
     assert text._get_wrapped_text() == 'non wrapped text'
 
 
+@pytest.mark.parametrize(
+    "x, y, rotation",
+    [(0.0, 1.0, 0),
+     (1.0, 0.5, 90),
+     (0.5, 1.0, 180),
+     (0.0, 0.5, 270)])
+def test_wrap_on_figure_edge(x, y, rotation):
+    # Regression test for #31537 - wrap collapsed to zero on figure edges.
+    s = 'This is a very long text that should be wrapped multiple times.'
+    fig = plt.figure(figsize=(6, 4))
+    t = fig.text(x, y, s, wrap=True, rotation=rotation)
+    fig.canvas.draw()
+
+    # Compare to a nudged-off-the-edge reference that should wrap the same.
+    nudge = 1e-4
+    x_ref = x - nudge if x == 1.0 else x + nudge if x == 0.0 else x
+    y_ref = y - nudge if y == 1.0 else y + nudge if y == 0.0 else y
+    fig_ref = plt.figure(figsize=(6, 4))
+    t_ref = fig_ref.text(x_ref, y_ref, s, wrap=True, rotation=rotation)
+    fig_ref.canvas.draw()
+
+    assert t._get_wrapped_text() == t_ref._get_wrapped_text()
+
+
+def test_wrap_on_figure_edge_transform_rotates_text():
+    # With transform_rotates_text=True, get_rotation() goes through
+    # transform_angles() and can return near-cardinal angles with float
+    # noise (e.g. -90.00000000000003 for a 270 degree rotation), which
+    # used to skip the cardinal-angle short-circuit in _get_dist_to_box.
+    from matplotlib.transforms import Affine2D
+    fig = plt.figure(figsize=(6, 4))
+    s = 'This is a very long text that should be wrapped multiple times.'
+    # rotate_deg(90).rotate_deg(-90) is identity geometrically, but carries
+    # enough numerical slop to perturb transform_angles.
+    transform = Affine2D().rotate_deg(90).rotate_deg(-90) + fig.transFigure
+    t = fig.text(0.0, 0.5, s, transform=transform, wrap=True, rotation=270,
+                 transform_rotates_text=True)
+    fig.canvas.draw()
+    assert any(' ' in line for line in t._get_wrapped_text().split('\n'))
+
+
 @check_figures_equal()
 def test_buffer_size(fig_test, fig_ref):
     # On old versions of the Agg renderer, large non-ascii single-character

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -757,6 +757,21 @@ class Text(Artist):
         Return the distance from the given points to the boundaries of a
         rotated box, in pixels.
         """
+        # Normalize rotation; transform_angles can return values outside
+        # [0, 360) with tiny float noise.
+        rotation = rotation % 360
+        # Short-circuit cardinal angles, otherwise cos(radians(90)) makes
+        # the trig formula below blow up when the text is on the edge.
+        tol = 1e-10
+        if rotation < tol or rotation > 360 - tol:
+            return figure_box.x1 - x0
+        if abs(rotation - 90) < tol:
+            return figure_box.y1 - y0
+        if abs(rotation - 180) < tol:
+            return x0 - figure_box.x0
+        if abs(rotation - 270) < tol:
+            return y0 - figure_box.y0
+
         if rotation > 270:
             quad = rotation - 270
             h1 = (y0 - figure_box.y0) / math.cos(math.radians(quad))

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -759,34 +759,29 @@ class Text(Artist):
         Return the distance from the given points to the boundaries of a
         rotated box, in pixels.
         """
-        # Short-circuit cardinals; otherwise cos(radians(90)) makes the trig
-        # formula below blow up when the text is on the matching edge.
-        if rotation == 0:
-            return figure_box.x1 - x0
-        if rotation == 90:
-            return figure_box.y1 - y0
-        if rotation == 180:
-            return x0 - figure_box.x0
-        if rotation == 270:
-            return y0 - figure_box.y0
+        # Branch bounds are inclusive at the cardinals so each cardinal lands
+        # in a branch where quad=0 — there cos(0)=1 and sin(0)=0 exactly,
+        # avoiding the float noise that cos(radians(90)) would introduce.
+        # sin(radians(x)) replaces cos(radians(90 - x)) so the div-by-0
+        # propagates to +inf, and fmin discards it (and any 0/0 NaN at corners).
+        with np.errstate(divide="ignore", invalid="ignore"):
+            if rotation >= 270:
+                quad = rotation - 270
+                h1 = (y0 - figure_box.y0) / np.cos(np.radians(quad))
+                h2 = (figure_box.x1 - x0) / np.sin(np.radians(quad))
+            elif rotation >= 180:
+                quad = rotation - 180
+                h1 = (x0 - figure_box.x0) / np.cos(np.radians(quad))
+                h2 = (y0 - figure_box.y0) / np.sin(np.radians(quad))
+            elif rotation >= 90:
+                quad = rotation - 90
+                h1 = (figure_box.y1 - y0) / np.cos(np.radians(quad))
+                h2 = (x0 - figure_box.x0) / np.sin(np.radians(quad))
+            else:
+                h1 = (figure_box.x1 - x0) / np.cos(np.radians(rotation))
+                h2 = (figure_box.y1 - y0) / np.sin(np.radians(rotation))
 
-        if rotation > 270:
-            quad = rotation - 270
-            h1 = (y0 - figure_box.y0) / math.cos(math.radians(quad))
-            h2 = (figure_box.x1 - x0) / math.cos(math.radians(90 - quad))
-        elif rotation > 180:
-            quad = rotation - 180
-            h1 = (x0 - figure_box.x0) / math.cos(math.radians(quad))
-            h2 = (y0 - figure_box.y0) / math.cos(math.radians(90 - quad))
-        elif rotation > 90:
-            quad = rotation - 90
-            h1 = (figure_box.y1 - y0) / math.cos(math.radians(quad))
-            h2 = (x0 - figure_box.x0) / math.cos(math.radians(90 - quad))
-        else:
-            h1 = (figure_box.x1 - x0) / math.cos(math.radians(rotation))
-            h2 = (figure_box.y1 - y0) / math.cos(math.radians(90 - rotation))
-
-        return min(h1, h2)
+        return np.fmin(h1, h2)
 
     def _get_rendered_text_width(self, text):
         """

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -339,8 +339,10 @@ class Text(Artist):
     def get_rotation(self):
         """Return the text angle in degrees in the range [0, 360)."""
         if self.get_transform_rotates_text():
-            return self.get_transform().transform_angles(
+            angle = self.get_transform().transform_angles(
                 [self._rotation], [self.get_unitless_position()]).item(0) % 360
+            # `(tiny_negative) % 360` can float-round to exactly 360.0.
+            return 0.0 if angle == 360 else angle
         else:
             return self._rotation
 
@@ -757,19 +759,15 @@ class Text(Artist):
         Return the distance from the given points to the boundaries of a
         rotated box, in pixels.
         """
-        # Normalize rotation; transform_angles can return values outside
-        # [0, 360) with tiny float noise.
-        rotation = rotation % 360
-        # Short-circuit cardinal angles, otherwise cos(radians(90)) makes
-        # the trig formula below blow up when the text is on the edge.
-        tol = 1e-10
-        if rotation < tol or rotation > 360 - tol:
+        # Short-circuit cardinals; otherwise cos(radians(90)) makes the trig
+        # formula below blow up when the text is on the matching edge.
+        if rotation == 0:
             return figure_box.x1 - x0
-        if abs(rotation - 90) < tol:
+        if rotation == 90:
             return figure_box.y1 - y0
-        if abs(rotation - 180) < tol:
+        if rotation == 180:
             return x0 - figure_box.x0
-        if abs(rotation - 270) < tol:
+        if rotation == 270:
             return y0 - figure_box.y0
 
         if rotation > 270:


### PR DESCRIPTION
Text placed exactly on a figure edge with an axis-aligned rotation and wrap=True collapses to zero wrap width, producing one word per line. Minimal reproducer from the issue:
         
```python                                                                                                                                                                       
  import matplotlib.pyplot as plt
  fig = plt.figure()                                                                                                                                                            
  fig.text(0.0, 1.0, "Helo World! thisisalongassstring aneventextralongassstring",
           verticalalignment="top", horizontalalignment="left",                                                                                                                 
           multialignment="left", wrap=True)                                                                                                                                    
  plt.show()
```                   
                                                                                                                                                             
  Root cause is in `Text._get_dist_to_box`: the trig formula divides by `cos(radians(90))` (~6e-17). Away from the edge the degenerate term evaluates to a huge number (non-zero distance over a tiny denominator) and loses `min()` to the sensible other side. On the edge the numerator is zero too, so the result collapses to zero.
                                                                                                                                                                                
  The fix short-circuits the four cardinal rotations and normalizes rotation to `[0, 360)` with a small tolerance, so that near-cardinal angles coming out of `transform_angles` (e.g. `-90.00000000000003` when `transform_rotates_text=True`) also take the fast path. Direction follows @rcomer's suggestion in the issue thread.
                                                                                                                                                                                
  **closes #31537**   
                                                                                                                                                                                
  PR checklist    

  - closes #31537 is in the body of the PR description                                                                                                                        
  - new and changed code is tested (`test_wrap_on_figure_edge`, `test_wrap_on_figure_edge_transform_rotates_text` in `lib/matplotlib/tests/test_text.py`)
  - [N/A] Plotting related features are demonstrated in an example                                                                                                              
  - [N/A] New Features and API Changes are noted with a directive and release note (bugfix only)                                                                                
  - [N/A] Documentation complies with general and docstring guidelines     