### PR TITLE
BUG: Skip removed colorbar axes in constrained layout (fixes #31330)

### DIFF
--- a/lib/matplotlib/_constrained_layout.py
+++ b/lib/matplotlib/_constrained_layout.py
@@ -398,6 +398,10 @@ def make_layout_margins(layoutgrids, fig, renderer, *, w_pad=0, h_pad=0,
         # make margin for colorbars.  These margins go in the
         # padding margin, versus the margin for Axes decorators.
         for cbax in ax._colorbars:
+            # Skip colorbar axes that have been removed from the figure
+            # (e.g. via ``cbar.ax.remove()`` instead of ``cbar.remove()``).
+            if cbax.get_figure(root=False) is None:
+                continue
             # note pad is a fraction of the parent width...
             pad = colorbar_get_pad(layoutgrids, cbax)
             # colorbars can be child of more than one subplot spec:
@@ -688,6 +692,8 @@ def reposition_axes(layoutgrids, fig, renderer, *,
         # one colorbar:
         offset = {'left': 0, 'right': 0, 'bottom': 0, 'top': 0}
         for nn, cbax in enumerate(ax._colorbars[::-1]):
+            if cbax.get_figure(root=False) is None:
+                continue  # colorbar axes was removed from the figure
             if ax == cbax._colorbar_info['parents'][0]:
                 reposition_colorbar(layoutgrids, cbax, renderer,
                                     offset=offset, compress=compress)

--- a/lib/matplotlib/tests/test_constrainedlayout.py
+++ b/lib/matplotlib/tests/test_constrainedlayout.py
@@ -809,3 +809,24 @@ def test_submerged_subfig():
     for ax in axs[1:]:
         assert np.allclose(ax.get_position().bounds[-1],
                            axs[0].get_position().bounds[-1], atol=1e-6)
+
+
+def test_colorbar_remove_axes_no_crash():
+    """
+    Regression test for GH #31330.
+
+    Directly removing the colorbar Axes (``cbar.ax.remove()``) should not
+    crash when the figure is subsequently drawn with constrained layout.
+    """
+    import numpy as np
+    x = y = np.linspace(-1, 1, 20)
+    X, Y = np.meshgrid(x, y)
+    Z = X**2 - Y**2
+
+    # cbar.ax.remove() (direct axes removal) should not raise
+    fig, ax = plt.subplots(layout='constrained')
+    CS = ax.contourf(X, Y, Z, cmap='bone')
+    cbar = fig.colorbar(CS)
+    cbar.ax.remove()
+    # Drawing must not crash with AttributeError on transSubfigure
+    fig.draw_without_rendering()


### PR DESCRIPTION
## PR summary

Fixes #31330.

When the user calls `cbar.ax.remove()` directly (instead of the documented `cbar.remove()`), the colorbar Axes is detached from the figure but the parent axes' `_colorbars` list still holds a reference to it. On the next draw with constrained layout, `make_layout_margins()` and `reposition_axes()` iterate over `ax._colorbars` and call `get_pos_and_bbox(cbax, renderer)`, which internally calls `cbax.get_figure(root=False)` — returning `None` for the removed Axes — and then crashes:

```
AttributeError: 'NoneType' object has no attribute 'transSubfigure'
```

**Root cause:** `Artist.remove()` sets `_parent_figure = None`, so `get_figure(root=False)` returns `None` after removal. The constrained layout code does not guard against this.

**Fix:** Add a `get_figure(root=False) is None` guard in both colorbar iteration loops (`make_layout_margins` and `reposition_axes`) to skip colorbar axes that have been removed from the figure.

**Why not remove from `_colorbars` in `Axes.remove()`?**
The current `Colorbar.remove()` API already handles that cleanup correctly. The crash happens only when users bypass it by calling `cbar.ax.remove()` directly. A null guard in the layout engine is the appropriate defense-in-depth fix and avoids changing cleanup semantics.

## AI Disclosure

I used GitHub Copilot as a pair-programming aid to navigate the codebase and assist with writing the fix and test.

## PR checklist

- [x] "closes #31330" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
