### PR TITLE
BUG: avoid a deprecation warning from numpy 2.5 (calling `datetime64('NaT')` without a unit is deprecated)

### DIFF
--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -325,9 +325,7 @@ def _dt64_to_ordinalf(d):
     dt += extra.astype(np.float64) / 1.0e9
     dt = dt / SEC_PER_DAY
 
-    NaT_int = np.datetime64('NaT', 's').astype(np.int64)
-    d_int = d.astype(np.int64)
-    dt[d_int == NaT_int] = np.nan
+    dt[np.isnat(d)] = np.nan
     return dt
 
 

--- a/lib/matplotlib/dates.py
+++ b/lib/matplotlib/dates.py
@@ -325,7 +325,7 @@ def _dt64_to_ordinalf(d):
     dt += extra.astype(np.float64) / 1.0e9
     dt = dt / SEC_PER_DAY
 
-    NaT_int = np.datetime64('NaT').astype(np.int64)
+    NaT_int = np.datetime64('NaT', 's').astype(np.int64)
     d_int = d.astype(np.int64)
     dt[d_int == NaT_int] = np.nan
     return dt


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
xref https://github.com/numpy/numpy/pull/31213 
xref https://github.com/numpy/numpy/pull/31282

## AI Disclosure
no AI was used at any point.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
