### PR TITLE
FIX: removing colorbar's axes also removes colorbar

### DIFF
--- a/lib/matplotlib/colorbar.py
+++ b/lib/matplotlib/colorbar.py
@@ -11,6 +11,7 @@ In Matplotlib they are drawn into a dedicated `~.axes.Axes`.
    End-users most likely won't need to directly use this module's API.
 """
 
+import functools
 import logging
 
 import numpy as np
@@ -192,6 +193,17 @@ class _ColorbarAxesLocator:
         return (
             self._cbar.ax.get_subplotspec()
             or getattr(self._orig_locator, "get_subplotspec", lambda: None)())
+
+
+def _remove_cbar_axes(ax, cbar):
+    """
+    Replacement remove method for a colorbar's axes, so that the colorbar is
+    properly removed.
+
+    Note we define this at the module level to preserve pickling. A lambda or
+    local def within the Colorbar.__init__ method will not work.
+    """
+    cbar.remove()
 
 
 @_docstring.interpd
@@ -426,6 +438,14 @@ class Colorbar:
             "xlim_changed", self._do_extends)
         self._extend_cid2 = self.ax.callbacks.connect(
             "ylim_changed", self._do_extends)
+
+        # Ensure proper cleanup when `cbar.ax.remove()` is called.  We ensure
+        # this by overriding the Axes' remove method, so that `cbar.ax.remove()`
+        # actually calls `cbar.remove()`.  In turn, we store the original Axes'
+        # remove method in `_ax_remove`, which `cbar.remove()` will eventually
+        # call to clean up the Axes itself.
+        self._ax_remove = self.ax._remove_method
+        self.ax._remove_method = functools.partial(_remove_cbar_axes, cbar=self)
 
     @property
     def long_axis(self):
@@ -1032,7 +1052,7 @@ class Colorbar:
                 if self.ax in a._colorbars:
                     a._colorbars.remove(self.ax)
 
-        self.ax.remove()
+        self._ax_remove(self.ax)
 
         self.mappable.callbacks.disconnect(self.mappable.colorbar_cid)
         self.mappable.colorbar = None

--- a/lib/matplotlib/tests/test_colorbar.py
+++ b/lib/matplotlib/tests/test_colorbar.py
@@ -1,4 +1,5 @@
 import platform
+from unittest import mock
 
 import numpy as np
 import pytest
@@ -309,6 +310,18 @@ def test_remove_from_figure_cl():
     post_position = ax.get_position()
     np.testing.assert_allclose(pre_position.get_points(),
                                post_position.get_points())
+
+
+def test_axes_remove():
+    """Removing the colorbar's axes should also remove the colorbar"""
+    fig, ax = plt.subplots()
+    sc = ax.scatter([1, 2], [3, 4])
+    cb = fig.colorbar(sc)
+
+    with mock.patch.object(cb, 'remove') as mock_cb_remove:
+        cb.ax.remove()
+
+    mock_cb_remove.assert_called()
 
 
 def test_colorbarbase():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Closes #31330

Replace the colorbar axes's remove method so it calls the colorbar's own remove method.  The code from the issue now gives me a plot.  I also thought about having the axes remove method raise an exception with a message to use the colorbar's method instead.  However, I think either way we'd need to replace the method and it's no bigger change to support it than to make it raise.

This is an alternative solution to #31549, which was opened first.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
None

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
