### PR TITLE
FIX: Inverted PyErr_Occurred check in enum type caster (_enums.h)

### DIFF
--- a/src/_enums.h
+++ b/src/_enums.h
@@ -80,7 +80,7 @@ namespace p11x {
           auto ival = PyLong_AsLong(tmp); \
           value = decltype(value)(ival); \
           Py_DECREF(tmp); \
-          return !(ival == -1 && !PyErr_Occurred()); \
+          return !(ival == -1 && PyErr_Occurred()); \
         } else { \
           return false; \
         } \


### PR DESCRIPTION
## PR summary
Fix an inverted error-check in the pybind11 enum type caster in src/_enums.h. `PyLong_AsLong` signals failure by returning -1 and setting a Python exception.  The correct way to check for failure should be: `return !(ival == -1 && PyErr_Occurred());`

Part of #31424 

_this is my first PR here; I just wanted to get the flow down of contributing here before making any larger changes :)_

## AI Disclosure
I used Claude Code to help understand the codebase. The fix itself is a one-character change I applied.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines