### PR TITLE
FIX: Added ft2font null checks added

### DIFF
--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -41,7 +41,7 @@ inline char const* ft_error_string(FT_Error error) {
 #undef __FTERRORS_H__
 #define FT_ERROR_START_LIST     switch (error) {
 #define FT_ERRORDEF( e, v, s )    case v: return s;
-#define FT_ERROR_END_LIST         default: return NULL; }
+#define FT_ERROR_END_LIST         default: return "unknown error"; }
 #include FT_ERRORS_H
 }
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -409,9 +409,9 @@ class PyFT2Font final : public FT2Font
     {
         std::set<FT_String*>::iterator it = family_names.begin();
         std::stringstream ss;
-        ss<<*it;
+        ss<< (*it ? *it : "unknown family name");
         while(++it != family_names.end()){
-            ss<<", "<<*it;
+            ss<<", "<< (*it ? *it : "unknown family name");
         }
 
         auto text_helpers = py::module_::import("matplotlib._text_helpers");


### PR DESCRIPTION
 ## PR summary                                                                                                                                           
                                                                                                                                                          
  Fix two potential null pointer crashes in `src/ft2font.h` and `src/ft2font_wrapper.cpp`.                                                                
   
  **1. `ft_error_string` returning NULL (`ft2font.h:44`)**                                                                                                
                  
Fixed by changing the `default` case to return `"unknown error"` instead of `NULL`, so the function always returns a valid string.

  **2. NULL `family_name` streamed in `ft_glyph_warn` (`ft2font_wrapper.cpp:408`)**

Fixed by guarding each stream insertion with `(*it ? *it : "unknown")`.

  ## AI Disclosure

  I used Claude Code to help understand the codebase. The fixes were applied by me.

  ## PR checklist

  - [N/A] "closes #0000" — no linked issue
  - [x] new and changed code is tested 
  - [N/A] *Plotting related* features are demonstrated in an example
  - [N/A] *New Features* and *API Changes* are noted with a directive and release note — these are defensive bug fixes with no API changes
  - [N/A] Documentation complies with general and docstring guidelines — no docs changed
