### PR TITLE
Fixed bug with an uninitialized colormap in parallel threads

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -1162,16 +1162,18 @@ class LinearSegmentedColormap(Colormap):
         self._gamma = gamma
 
     def _init(self):
-        self._lut = np.ones((self.N + 3, 4), float)
-        self._lut[:-3, 0] = _create_lookup_table(
+        # Assemble the LUT first in a local variable in case of parallel threads
+        lut = np.ones((self.N + 3, 4), float)
+        lut[:-3, 0] = _create_lookup_table(
             self.N, self._segmentdata['red'], self._gamma)
-        self._lut[:-3, 1] = _create_lookup_table(
+        lut[:-3, 1] = _create_lookup_table(
             self.N, self._segmentdata['green'], self._gamma)
-        self._lut[:-3, 2] = _create_lookup_table(
+        lut[:-3, 2] = _create_lookup_table(
             self.N, self._segmentdata['blue'], self._gamma)
         if 'alpha' in self._segmentdata:
-            self._lut[:-3, 3] = _create_lookup_table(
+            lut[:-3, 3] = _create_lookup_table(
                 self.N, self._segmentdata['alpha'], 1)
+        self._lut = lut
         self._isinit = True
         self._update_lut_extremes()
 
@@ -1362,8 +1364,10 @@ class ListedColormap(Colormap):
         super().__init__(name, N, bad=bad, under=under, over=over)
 
     def _init(self):
-        self._lut = np.zeros((self.N + 3, 4), float)
-        self._lut[:-3] = to_rgba_array(self.colors)
+        # Assemble the LUT first in a local variable in case of parallel threads
+        lut = np.zeros((self.N + 3, 4), float)
+        lut[:-3] = to_rgba_array(self.colors)
+        self._lut = lut
         self._isinit = True
         self._update_lut_extremes()
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

This PR fixes a race condition between parallel threads when using the same colormap that is not yet initialized.  The LUT is currently generated for `LinearSegmentedColormap` and `ListedColormap` by modifying a private variable (`_lut`) in a non-atomic fashion.  When two threads both see the same uninitialized colormap, the earlier thread can finish the LUT generation and believe the LUT is safe to use at the same time that the later thread has actually erased the LUT and is in the middle of re-generating it.

This PR generates the LUT first in a local variable and then overwrites `_lut` in a single assignment.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

N/A

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
