### PR TITLE
ci: Only run PR triage on main repo

### DIFF
--- a/.github/workflows/triage_board.yml
+++ b/.github/workflows/triage_board.yml
@@ -10,6 +10,7 @@ permissions: {}
 
 jobs:
   pr-triage:
+    if: github.repository == 'matplotlib/matplotlib'
     runs-on: ubuntu-latest
     steps:
       - name: Update PR Triage Board


### PR DESCRIPTION
## PR summary

I keep getting notifications from GitHub that this is failing to run on my fork.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines