### PR TITLE
BLD: Unpin setuptools-scm again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,9 +60,7 @@ requires = [
     # you really need it and aren't using an sdist.
     "meson-python>=0.13.2,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
-    # setuptools_scm 10 breaks versioning in editable installs. You can remove this pin
-    # if you're a downstream distributor just building wheels or your equivalent.
-    "setuptools_scm>=7,<10",
+    "setuptools_scm>=7",
 ]
 
 [dependency-groups]
@@ -81,7 +79,7 @@ build = [
     # Should be the same as `[build-system] requires` above.
     "meson-python>=0.13.1,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
-    "setuptools_scm>=7,<10",
+    "setuptools_scm>=7",
     # Not required by us but setuptools_scm without a version, so _if_
     # installed, then setuptools_scm 8 requires at least this version.
     # Unfortunately, we can't do a sort of minimum-if-installed dependency, so


### PR DESCRIPTION
## PR summary

The upstream issue https://github.com/pypa/setuptools-scm/issues/1314 was fixed some time ago.

## AI Disclosure
Nada

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines