### PR TITLE
Fix get_tightbbox to include axis labels in 3D axes

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -4155,7 +4155,7 @@ class Axes3D(Axes):
         return errlines, caplines, limmarks
 
     def get_tightbbox(self, renderer=None, *, call_axes_locator=True,
-                      bbox_extra_artists=None, for_layout_only=False):
+                    bbox_extra_artists=None, for_layout_only=False):
         ret = super().get_tightbbox(renderer,
                                     call_axes_locator=call_axes_locator,
                                     bbox_extra_artists=bbox_extra_artists,
@@ -4168,6 +4168,10 @@ class Axes3D(Axes):
                         axis, renderer)
                     if axis_bb:
                         batch.append(axis_bb)
+                    if not for_layout_only and axis.label.get_visible():
+                        label_bb = axis.label.get_window_extent(renderer)
+                        if label_bb.width > 0 or label_bb.height > 0:
+                            batch.append(label_bb)
         return mtransforms.Bbox.union(batch)
 
     @_preprocess_data()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3177,6 +3177,7 @@ def test_scale3d_calc_coord():
     assert pane_idx == 1
     assert point[pane_idx] == pytest.approx(ax.get_ylim()[1])
 
+
 def test_tightbbox_3d_labels_not_clipped():
     # Regression test for GH#31568 - zlabel and xlabel were excluded from
     # get_tightbbox(), causing them to be clipped by savefig(bbox_inches='tight')

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3176,3 +3176,34 @@ def test_scale3d_calc_coord():
     # Pane coordinate should match axis limit (y-pane at max)
     assert pane_idx == 1
     assert point[pane_idx] == pytest.approx(ax.get_ylim()[1])
+
+def test_tightbbox_3d_labels_not_clipped():
+    # Regression test for GH#31568 - zlabel and xlabel were excluded from
+    # get_tightbbox(), causing them to be clipped by savefig(bbox_inches='tight')
+    fig = plt.figure(figsize=(3, 3))
+    ax = fig.add_subplot(projection='3d')
+    ax.plot([0, 1], [0, 1], [0, 1])
+    ax.set_zlabel("Z axis label")
+    ax.set_xlabel("X axis label")
+
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+
+    tightbbox = ax.get_tightbbox(renderer)
+
+    for axis in [ax.xaxis, ax.zaxis]:
+        if axis.label.get_visible():
+            label_bb = axis.label.get_window_extent(renderer)
+            if label_bb.width > 0 or label_bb.height > 0:
+                assert tightbbox.x0 <= label_bb.x0 + 1e-6, (
+                    f"{axis.axis_name}label left edge outside tightbbox: "
+                    f"{label_bb.x0:.1f} > {tightbbox.x0:.1f}"
+                )
+                assert tightbbox.x1 >= label_bb.x1 - 1e-6, (
+                    f"{axis.axis_name}label right edge outside tightbbox: "
+                    f"{label_bb.x1:.1f} > {tightbbox.x1:.1f}"
+                )
+                assert tightbbox.y0 <= label_bb.y0 + 1e-6, (
+                    f"{axis.axis_name}label bottom edge outside tightbbox: "
+                    f"{label_bb.y0:.1f} < {tightbbox.y0:.1f}"
+                )


### PR DESCRIPTION
savefig(bbox_inches='tight') was clipping zlabel and xlabel on 3D axes because Axes3D.get_tightbbox() did not include axis label bounding boxes in its calculation. On 2D axes the superclass handles this correctly.

Fixes #31568
Related to #28117

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
