### PR TITLE
Fix polar set_ticks labels warning

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1999,7 +1999,7 @@ class Axis(martist.Artist):
 
         if (isinstance(formatter, mticker.FixedFormatter)
                 and len(formatter.seq) > 0
-                and not isinstance(level.locator, mticker.FixedLocator)):
+                and level.locator._get_fixed_locs() is None):
             _api.warn_external('FixedFormatter should only be used together '
                                'with FixedLocator')
 
@@ -2142,16 +2142,16 @@ class Axis(martist.Artist):
         if not labels:
             # eg labels=[]:
             formatter = mticker.NullFormatter()
-        elif isinstance(locator, mticker.FixedLocator):
+        elif (locs := locator._get_fixed_locs()) is not None:
             # Passing [] as a list of labels is often used as a way to
             # remove all tick labels, so only error for > 0 labels
-            if len(locator.locs) != len(labels) and len(labels) != 0:
+            if len(locs) != len(labels) and len(labels) != 0:
                 raise ValueError(
                     "The number of FixedLocator locations"
-                    f" ({len(locator.locs)}), usually from a call to"
+                    f" ({len(locs)}), usually from a call to"
                     " set_ticks, does not match"
                     f" the number of labels ({len(labels)}).")
-            tickd = {loc: lab for loc, lab in zip(locator.locs, labels)}
+            tickd = {loc: lab for loc, lab in zip(locs, labels)}
             func = functools.partial(self._format_with_dict, tickd)
             formatter = mticker.FuncFormatter(func)
         else:

--- a/lib/matplotlib/projections/polar.py
+++ b/lib/matplotlib/projections/polar.py
@@ -448,6 +448,9 @@ class RadialLocator(mticker.Locator):
                 return [tick for tick in self.base() if tick > rorigin]
         return self.base()
 
+    def _get_fixed_locs(self):
+        return self.base._get_fixed_locs()
+
     def _zero_in_bounds(self):
         """
         Return True if zero is within the valid values for the

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -1,4 +1,5 @@
 import sys
+import warnings
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -551,6 +552,25 @@ def test_radial_limits_behavior():
     # negative data also autoscales to negative limits
     ax.plot([1, 2], [-1, -2])
     assert ax.get_ylim() == (-2, 2)
+
+
+def test_polar_set_ticks_with_labels():
+    fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
+    ticks = [0.25, 0.5, 0.75, 1.0]
+    labels = ["A", "B", "C", "D"]
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        ax.yaxis.set_ticks(ticks, labels=labels)
+
+    assert [tick.get_text() for tick in ax.yaxis.get_ticklabels()] == labels
+
+
+def test_polar_set_ticks_with_mismatched_labels():
+    fig, ax = plt.subplots(subplot_kw={"projection": "polar"})
+
+    with pytest.raises(ValueError, match="FixedLocator locations"):
+        ax.yaxis.set_ticks([0.25, 0.5], labels=["A"])
 
 
 def test_radial_locator_wrapping():

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1761,6 +1761,10 @@ class Locator(TickHelper):
         # hence there is no *one* interface to call self.tick_values.
         raise NotImplementedError('Derived must override')
 
+    def _get_fixed_locs(self):
+        """Return the fixed tick locations, or None if locations are not fixed."""
+        return None
+
     def raise_if_exceeds(self, locs):
         """
         Log at WARNING level if *locs* is longer than `Locator.MAXTICKS`.
@@ -1860,6 +1864,9 @@ class FixedLocator(Locator):
 
     def __call__(self):
         return self.tick_values(None, None)
+
+    def _get_fixed_locs(self):
+        return self.locs
 
     def tick_values(self, vmin, vmax):
         """


### PR DESCRIPTION
## PR summary

Closes #31574.

`RadialLocator` wraps the radial axis locator on polar plots, so after `set_ticks(..., labels=...)` the underlying locator is a `FixedLocator` but `Axis.set_ticklabels` no longer recognized it as fixed. This made the safe `set_ticks` path emit the discouraged `set_ticklabels()` warning.

This adds a private locator hook for retrieving fixed locations, implements it for `FixedLocator`, and delegates through `RadialLocator`. `Axis.set_ticklabels` and the related `FixedFormatter` warning now use that hook, preserving the existing fixed-locator validation and label mapping for wrapped fixed locators.

Added tests for polar `yaxis.set_ticks(..., labels=...)` not warning and for preserving the mismatched-labels `ValueError`.

## AI Disclosure

This PR was prepared with assistance from OpenAI Codex via an automated OSS PR workflow. I used it to inspect the issue, implement the focused fix, and run the targeted verification below.

## PR checklist

- [x] "closes #31574" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines

Verification:

```bash
MPLBACKEND=Agg python -m pytest -q --pyargs \
  matplotlib.tests.test_polar::test_polar_set_ticks_with_labels \
  matplotlib.tests.test_polar::test_polar_set_ticks_with_mismatched_labels \
  matplotlib.tests.test_polar::test_radial_locator_wrapping \
  matplotlib.tests.test_axes::test_warn_too_few_labels \
  matplotlib.tests.test_axes::test_subsampled_ticklabels \
  matplotlib.tests.test_axes::test_mismatched_ticklabels \
  matplotlib.tests.test_axes::test_empty_ticks_fixed_loc
# 7 passed
```
