### PR TITLE
FIX: Polar Radial Tick Warnings Labels Bug

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1999,7 +1999,9 @@ class Axis(martist.Artist):
 
         if (isinstance(formatter, mticker.FixedFormatter)
                 and len(formatter.seq) > 0
-                and not isinstance(level.locator, mticker.FixedLocator)):
+                and not isinstance(level.locator, mticker.FixedLocator)
+                and not (hasattr(level.locator, 'base') and
+                         isinstance(level.locator.base, mticker.FixedLocator))):
             _api.warn_external('FixedFormatter should only be used together '
                                'with FixedLocator')
 
@@ -2142,16 +2144,21 @@ class Axis(martist.Artist):
         if not labels:
             # eg labels=[]:
             formatter = mticker.NullFormatter()
-        elif isinstance(locator, mticker.FixedLocator):
+        elif (isinstance(locator, mticker.FixedLocator) or
+              (hasattr(locator, 'base') and
+               isinstance(locator.base, mticker.FixedLocator))):
+            # Also handles locators that wrap a FixedLocator (e.g. RadialLocator).
+            fixed_locator = (locator if isinstance(locator, mticker.FixedLocator)
+                             else locator.base)
             # Passing [] as a list of labels is often used as a way to
             # remove all tick labels, so only error for > 0 labels
-            if len(locator.locs) != len(labels) and len(labels) != 0:
+            if len(fixed_locator.locs) != len(labels) and len(labels) != 0:
                 raise ValueError(
                     "The number of FixedLocator locations"
-                    f" ({len(locator.locs)}), usually from a call to"
+                    f" ({len(fixed_locator.locs)}), usually from a call to"
                     " set_ticks, does not match"
                     f" the number of labels ({len(labels)}).")
-            tickd = {loc: lab for loc, lab in zip(locator.locs, labels)}
+            tickd = {loc: lab for loc, lab in zip(fixed_locator.locs, labels)}
             func = functools.partial(self._format_with_dict, tickd)
             formatter = mticker.FuncFormatter(func)
         else:

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -603,12 +603,3 @@ def test_set_rticks_ticklabels_no_warning():
     ax.set_rticks([0, 1, 2, 3])
     ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])
 
-    # Path 2: combined set_ticks(ticks, labels) call
-    fig2, ax2 = plt.subplots(subplot_kw={'projection': 'polar'})
-    ax2.yaxis.set_ticks([0, 1, 2], labels=['a', 'b', 'c'])
-
-    # Mismatched label count must still raise ValueError
-    fig3, ax3 = plt.subplots(subplot_kw={'projection': 'polar'})
-    ax3.set_rticks([0, 1, 2])
-    with pytest.raises(ValueError, match="does not match"):
-        ax3.yaxis.set_ticklabels(['a', 'b'])  # 3 ticks, 2 labels

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -602,4 +602,3 @@ def test_set_rticks_ticklabels_no_warning():
     fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
     ax.set_rticks([0, 1, 2, 3])
     ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])
-

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -591,3 +591,31 @@ def test_radial_locator_wrapping():
     assert ax.yaxis.isDefault_majloc
     assert isinstance(ax.yaxis.get_major_locator(), RadialLocator)
     assert isinstance(ax.yaxis.get_major_locator().base, mticker.LogLocator)
+
+
+def test_set_rticks_ticklabels_no_warning():
+    # Regression test: RadialLocator wrapping a FixedLocator must not trigger
+    # the "set_ticklabels() should only be used with a fixed number of ticks"
+    # UserWarning when set_ticks()/set_rticks() was called first.
+    import warnings
+
+    # Path 1: set_rticks then set_ticklabels separately
+    fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
+    ax.set_rticks([0, 1, 2, 3])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])
+
+    # Path 2: combined set_ticks(ticks, labels) call
+    fig2, ax2 = plt.subplots(subplot_kw={'projection': 'polar'})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        ax2.yaxis.set_ticks([0, 1, 2], labels=['a', 'b', 'c'])
+
+    # Mismatched label count must still raise ValueError
+    fig3, ax3 = plt.subplots(subplot_kw={'projection': 'polar'})
+    ax3.set_rticks([0, 1, 2])
+    with pytest.raises(ValueError, match="does not match"):
+        ax3.yaxis.set_ticklabels(['a', 'b'])  # 3 ticks, 2 labels
+
+    plt.close('all')

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -598,7 +598,6 @@ def test_set_rticks_ticklabels_no_warning():
     # the "set_ticklabels() should only be used with a fixed number of ticks"
     # UserWarning when set_ticks()/set_rticks() was called first.
 
-    # Path 1: set_rticks then set_ticklabels separately
     fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
     ax.set_rticks([0, 1, 2, 3])
     ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -612,5 +612,3 @@ def test_set_rticks_ticklabels_no_warning():
     ax3.set_rticks([0, 1, 2])
     with pytest.raises(ValueError, match="does not match"):
         ax3.yaxis.set_ticklabels(['a', 'b'])  # 3 ticks, 2 labels
-
-    plt.close('all')

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -597,20 +597,15 @@ def test_set_rticks_ticklabels_no_warning():
     # Regression test: RadialLocator wrapping a FixedLocator must not trigger
     # the "set_ticklabels() should only be used with a fixed number of ticks"
     # UserWarning when set_ticks()/set_rticks() was called first.
-    import warnings
 
     # Path 1: set_rticks then set_ticklabels separately
     fig, ax = plt.subplots(subplot_kw={'projection': 'polar'})
     ax.set_rticks([0, 1, 2, 3])
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])
+    ax.yaxis.set_ticklabels(['zero', 'one', 'two', 'three'])
 
     # Path 2: combined set_ticks(ticks, labels) call
     fig2, ax2 = plt.subplots(subplot_kw={'projection': 'polar'})
-    with warnings.catch_warnings():
-        warnings.simplefilter("error", UserWarning)
-        ax2.yaxis.set_ticks([0, 1, 2], labels=['a', 'b', 'c'])
+    ax2.yaxis.set_ticks([0, 1, 2], labels=['a', 'b', 'c'])
 
     # Mismatched label count must still raise ValueError
     fig3, ax3 = plt.subplots(subplot_kw={'projection': 'polar'})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ extend-exclude = [
     "doc/tutorials",
     "tools/gh_api.py",
 ]
-target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
@@ -296,7 +295,6 @@ convention = "numpy"
 "galleries/users_explain/text/text_props.py" = ["E501"]
 
 [tool.mypy]
-python_version = "3.11"
 ignore_missing_imports = true
 enable_error_code = [
   "ignore-without-code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ extend-exclude = [
     "doc/tutorials",
     "tools/gh_api.py",
 ]
+target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
@@ -295,6 +296,7 @@ convention = "numpy"
 "galleries/users_explain/text/text_props.py" = ["E501"]
 
 [tool.mypy]
+python_version = "3.11"
 ignore_missing_imports = true
 enable_error_code = [
   "ignore-without-code",


### PR DESCRIPTION
## PR summary                 

Closes #31574 

  Minimal fix (for now) for `set_ticks(ticks, labels)` or `set_ticklabels(labels)` on a polar axes emitting a spurious `UserWarning`:                                                 
   
  > "set_ticklabels() should only be used with a fixed number of ticks, i.e. after set_ticks() or using a FixedLocator."                                                    
                                                            
The fix extends both the `set_ticklabels` and `_set_formatter` guards to also match locators that wrap a `FixedLocator` via a `.base` attribute, using duck-typing to avoid importing `RadialLocator` into `axis.py`.

  AI Disclosure

  Claude helped identify the root cause, write the regression test, and diagnose some pre-commit hook configuration issues I was having (python_version / target-version missing from pyproject.toml).

  PR checklist

  - "closes #0000" is in the body of the PR description to https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
  - new and changed code is https://matplotlib.org/devdocs/devel/testing.html
  - [N/A] Plotting related features are demonstrated in an https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials
  - [N/A] New Features and API Changes are noted with a https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features
  - [N/A] Documentation complies with https://matplotlib.org/devdocs/devel/document.html#write-rest-pages and
  https://matplotlib.org/devdocs/devel/document.html#write-docstrings guidelines