### PR TITLE
FIX: URL links in SVG should have target='_blank'

### DIFF
--- a/doc/api/next_api_changes/behavior/31578-TH.rst
+++ b/doc/api/next_api_changes/behavior/31578-TH.rst
@@ -1,0 +1,10 @@
+SVG links open in new tab or window
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`.Artist.set_url` allows to turn the Artist into a link. In SVG output,
+this has been implemented without specifying a `target`_ attribute. The default
+target value "_self" resulted in replacing the SVG document with the linked page
+when the link was clicked.
+
+The target is now set to "_blank" so that the link opens in a new tab or window.
+
+.. _target: https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/target

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -697,7 +697,7 @@ class RendererSVG(RendererBase):
             sketch=gc.get_sketch_params())
 
         if gc.get_url() is not None:
-            self.writer.start('a', {'xlink:href': gc.get_url()})
+            self.writer.start('a', {'xlink:href': gc.get_url(), 'target': '_blank'})
         self.writer.element('path', d=path_data, **self._get_clip_attrs(gc),
                             style=self._get_style(gc, rgbFace))
         if gc.get_url() is not None:
@@ -730,7 +730,7 @@ class RendererSVG(RendererBase):
 
         writer.start('g', **self._get_clip_attrs(gc))
         if gc.get_url() is not None:
-            self.writer.start('a', {'xlink:href': gc.get_url()})
+            self.writer.start('a', {'xlink:href': gc.get_url(), 'target': '_blank'})
         trans_and_flip = self._make_flip_transform(trans)
         attrib = {'xlink:href': f'#{oid}'}
         clip = (0, 0, self.width*72, self.height*72)
@@ -788,7 +788,7 @@ class RendererSVG(RendererBase):
                 antialiaseds, urls, offset_position, hatchcolors=hatchcolors):
             url = gc0.get_url()
             if url is not None:
-                writer.start('a', attrib={'xlink:href': url})
+                writer.start('a', attrib={'xlink:href': url, 'target': '_blank'})
             clip_attrs = self._get_clip_attrs(gc0)
             if clip_attrs:
                 writer.start('g', **clip_attrs)
@@ -966,7 +966,7 @@ class RendererSVG(RendererBase):
 
         url = gc.get_url()
         if url is not None:
-            self.writer.start('a', attrib={'xlink:href': url})
+            self.writer.start('a', attrib={'xlink:href': url, 'target': '_blank'})
 
         attrib = {}
         oid = gc.get_gid()
@@ -1288,7 +1288,7 @@ class RendererSVG(RendererBase):
             self.writer.start('g', **clip_attrs)
 
         if gc.get_url() is not None:
-            self.writer.start('a', {'xlink:href': gc.get_url()})
+            self.writer.start('a', {'xlink:href': gc.get_url(), 'target': '_blank'})
 
         if mpl.rcParams['svg.fonttype'] == 'path':
             self._draw_text_as_path(gc, x, y, s, prop, angle, ismath, mtext)

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -65,7 +65,7 @@ def test_text_urls():
         fig.savefig(fd, format='svg')
         buf = fd.getvalue().decode()
 
-    expected = f'<a xlink:href="{test_url}">'
+    expected = f'<a xlink:href="{test_url}" target="_blank">'
     assert expected in buf
 
 


### PR DESCRIPTION
When embedding SVG in HTML, link `href`s can target different browsing contexts. This e.g. leads to links inside SVGs in #31497 replacing the SVG image instead of opening a new browser window.

The solution is to set `target="_blank"` for all links that implement `Artist.get_url()`. This is always intended as an external link, so universally adding `target="_blank"` is justified.

Background info:
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/target
https://developer.mozilla.org/en-US/docs/Web/SVG/Reference/Attribute/target#_blank

