### PR TITLE
FIX: scatter with ls="" crashes on PDF savefig

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -36,7 +36,7 @@ def _get_dash_pattern(style):
     if isinstance(style, str):
         style = ls_mapper.get(style, style)
     # un-dashed styles
-    if style in ['solid', 'None']:
+    if style in ['solid', 'None', 'none', '', ' ']:
         offset = 0
         dashes = None
     # dashed styles

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -704,13 +704,9 @@ def test_set_wrong_linestyle():
         c.set_linestyle('fuzzy')
 
 
-@pytest.mark.parametrize('backend', ['agg', 'pdf'])
 @pytest.mark.parametrize('ls', ['', ' ', 'none'])
-def test_scatter_empty_linestyle(backend, ls):
-    # Regression Test: Saving to PDF (and other backends) with ls=""
-    # on a scatter collection used to crash with "zero-size array
-    # to reduction operation maximum".
-    plt.switch_backend(backend)
+def test_scatter_empty_linestyle_pdf(ls):
+    plt.switch_backend('pdf')
     fig, ax = plt.subplots()
     ax.scatter([0, 1], [0, 1], ls=ls)
     fig.savefig(io.BytesIO())

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -704,6 +704,18 @@ def test_set_wrong_linestyle():
         c.set_linestyle('fuzzy')
 
 
+@pytest.mark.parametrize('backend', ['agg', 'pdf', 'svg', 'ps'])
+@pytest.mark.parametrize('ls', ['', ' ', 'none'])
+def test_scatter_empty_linestyle(backend, ls):
+    # Regression Test: Saving to PDF (and other backends) with ls=""
+    # on a scatter collection used to crash with "zero-size array
+    # to reduction operation maximum".
+    plt.switch_backend(backend)
+    fig, ax = plt.subplots()
+    ax.scatter([0, 1], [0, 1], ls=ls)
+    fig.savefig(io.BytesIO())
+
+
 @mpl.style.context('default')
 def test_capstyle():
     col = mcollections.PathCollection([])

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -706,6 +706,9 @@ def test_set_wrong_linestyle():
 
 @pytest.mark.parametrize('ls', ['', ' ', 'none'])
 def test_scatter_empty_linestyle_pdf(ls):
+    # Regression test: '', ' ', and 'none' are documented "draw nothing"
+    # linestyle aliases but were not recognized by _get_dash_pattern, causing
+    # savefig to PDF to crash with "zero-size array to reduction operation maximum".
     plt.switch_backend('pdf')
     fig, ax = plt.subplots()
     ax.scatter([0, 1], [0, 1], ls=ls)

--- a/lib/matplotlib/tests/test_collections.py
+++ b/lib/matplotlib/tests/test_collections.py
@@ -704,7 +704,7 @@ def test_set_wrong_linestyle():
         c.set_linestyle('fuzzy')
 
 
-@pytest.mark.parametrize('backend', ['agg', 'pdf', 'svg', 'ps'])
+@pytest.mark.parametrize('backend', ['agg', 'pdf'])
 @pytest.mark.parametrize('ls', ['', ' ', 'none'])
 def test_scatter_empty_linestyle(backend, ls):
     # Regression Test: Saving to PDF (and other backends) with ls=""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,7 +184,6 @@ extend-exclude = [
     "doc/tutorials",
     "tools/gh_api.py",
 ]
-target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
@@ -296,7 +295,6 @@ convention = "numpy"
 "galleries/users_explain/text/text_props.py" = ["E501"]
 
 [tool.mypy]
-python_version = "3.11"
 ignore_missing_imports = true
 enable_error_code = [
   "ignore-without-code",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,6 +184,7 @@ extend-exclude = [
     "doc/tutorials",
     "tools/gh_api.py",
 ]
+target-version = "py311"
 line-length = 88
 
 [tool.ruff.lint]
@@ -295,6 +296,7 @@ convention = "numpy"
 "galleries/users_explain/text/text_props.py" = ["E501"]
 
 [tool.mypy]
+python_version = "3.11"
 ignore_missing_imports = true
 enable_error_code = [
   "ignore-without-code",


### PR DESCRIPTION
## PR summary                                  
 Closes #31585 

  Fixes a crash when saving a figure containing a scatter plot with `ls=""` (or `ls=" "` / `ls="none"`) to a PDF file.  `""`, `" "`, and `"none"` are documented "draw nothing" linestyle aliases, but `_get_dash_pattern` in `lines.py` did not recognize them — 
  it only handled `"solid"` and `"None"`

##  AI Disclosure

  This PR was developed with Claude Code for triaging. The root cause analysis, fix location, and test coverage were worked out together.

 ## PR checklist

  - [x] "closes #0000" is in the body of the PR description to
  https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
  - [x] new and changed code is https://matplotlib.org/devdocs/devel/testing.html
  - [N/A] Plotting related features are demonstrated in an https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials
  - [N/A] New Features and API Changes are noted with a
  https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features
  - Documentation complies with https://matplotlib.org/devdocs/devel/document.html#write-rest-pages and
  https://matplotlib.org/devdocs/devel/document.html#write-docstrings guidelines