### PR TITLE
Expire some missed deprecations from 3.9

### DIFF
--- a/doc/api/next_api_changes/removals/31588-ES.rst
+++ b/doc/api/next_api_changes/removals/31588-ES.rst
@@ -1,0 +1,18 @@
+``boxplot`` tick labels
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The parameter *labels* has been removed in favour of *tick_labels* for clarity and
+consistency with `~.Axes.bar`.
+
+Image path semantics of toolmanager-based tools
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Previously, MEP22 ("toolmanager-based") Tools would try to load their icon
+(``tool.image``) relative to the current working directory, or, as a fallback, from
+Matplotlib's own image directory. Because both approaches are problematic for
+third-party tools (the end-user may change the current working directory at any time,
+and third-parties cannot add new icons in Matplotlib's image directory), this behavior
+has been removed; instead, ``tool.image`` is now interpreted relative to the directory
+containing the source file where the ``Tool.image`` class attribute is defined.
+(Defining ``tool.image`` as an absolute path also works and is compatible with both the
+old and the new semantics.)

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -4302,7 +4302,6 @@ or pandas.DataFrame
 
     @_api.make_keyword_only("3.10", "notch")
     @_preprocess_data()
-    @_api.rename_parameter("3.9", "labels", "tick_labels")
     def boxplot(self, x, notch=None, sym=None, vert=None,
                 orientation='vertical', whis=None, positions=None,
                 widths=None, patch_artist=None, bootstrap=None,
@@ -4444,8 +4443,7 @@ or pandas.DataFrame
             values.
 
             .. versionchanged:: 3.9
-                Renamed from *labels*, which is deprecated since 3.9
-                and will be removed in 3.11.
+                Renamed from *labels*, which is also removed in 3.11.
 
         manage_ticks : bool, default: True
             If True, the tick locations and labels will be adjusted to match

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -3516,20 +3516,6 @@ class ToolContainerBase:
         for filename in [filename, filename + self._icon_extension]:
             if os.path.isfile(filename):
                 return os.path.abspath(filename)
-        for fname in [  # Fallback; once deprecation elapses.
-            tool.image,
-            tool.image + self._icon_extension,
-            cbook._get_data_path("images", tool.image),
-            cbook._get_data_path("images", tool.image + self._icon_extension),
-        ]:
-            if os.path.isfile(fname):
-                _api.warn_deprecated(
-                    "3.9", message=f"Loading icon {tool.image!r} from the current "
-                    "directory or from Matplotlib's image directory.  This behavior "
-                    "is deprecated since %(since)s and will be removed in %(removal)s; "
-                    "Tool.image should be set to a path relative to the Tool's source "
-                    "file, or to an absolute path.")
-                return os.path.abspath(fname)
 
     def trigger_tool(self, name):
         """

--- a/lib/matplotlib/hatch.py
+++ b/lib/matplotlib/hatch.py
@@ -206,7 +206,7 @@ def _validate_hatch_pattern(hatch):
             invalids = ''.join(sorted(invalids))
             _api.warn_deprecated(
                 '3.4',
-                removal='3.11',  # one release after custom hatches (#20690)
+                removal='3.13',  # one release after custom hatches (#20690)
                 message=f'hatch must consist of a string of "{valid}" or '
                         'None, but found the following invalid values '
                         f'"{invalids}". Passing invalid values is deprecated '

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10047,21 +10047,13 @@ def test_axes_clear_reference_cycle():
 
 
 def test_boxplot_tick_labels():
-    # Test the renamed `tick_labels` parameter.
-    # Test for deprecation of old name `labels`.
+    # Test the `tick_labels` parameter.
     np.random.seed(19680801)
     data = np.random.random((10, 3))
 
-    fig, axs = plt.subplots(nrows=1, ncols=2, sharey=True)
-    # Should get deprecation warning for `labels`
-    with pytest.warns(mpl.MatplotlibDeprecationWarning,
-                      match='has been renamed \'tick_labels\''):
-        axs[0].boxplot(data, labels=['A', 'B', 'C'])
-    assert [l.get_text() for l in axs[0].get_xticklabels()] == ['A', 'B', 'C']
-
-    # Test the new tick_labels parameter
-    axs[1].boxplot(data, tick_labels=['A', 'B', 'C'])
-    assert [l.get_text() for l in axs[1].get_xticklabels()] == ['A', 'B', 'C']
+    fig, ax = plt.subplots()
+    ax.boxplot(data, tick_labels=['A', 'B', 'C'])
+    assert [l.get_text() for l in ax.get_xticklabels()] == ['A', 'B', 'C']
 
 
 @needs_usetex


### PR DESCRIPTION
## PR summary

These should be removed in 3.11.

Also, bump the expiry for invalid hatch patterns, as custom hatch patterns still haven't been implemented.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines