### PR TITLE
FIX: axhline() / axvline() now always do autoscaling

### DIFF
--- a/doc/api/next_api_changes/behavior/31596-TH.rst
+++ b/doc/api/next_api_changes/behavior/31596-TH.rst
@@ -1,0 +1,10 @@
+``avhline()`` / ``axvline()`` always trigger autoscaling
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+`~.axes.Axes.axhline` and `~.axes.Axes.axvline` now always trigger autoscaling,
+like most other plotting functions.
+
+Previously, autoscaling was not executed when the lines were already in the
+view limits; i.e. they were still visible, but margins were not expanded.
+The lines were still added to the data limits so that any subsequent,
+explicitly called or through another plotting function, would only then
+take the lines into account for margins.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -818,14 +818,14 @@ class Axes(_AxesBase):
 
         # Strip away the units for comparison with non-unitized bounds.
         yy, = self._process_unit_info([("y", y)], kwargs)
-        scaley = (yy < ymin) or (yy > ymax)
 
         trans = self.get_yaxis_transform(which='grid')
         l = mlines.Line2D([xmin, xmax], [y, y], transform=trans, **kwargs)
         self.add_line(l)
         l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        if scaley:
-            self._request_autoscale_view("y")
+
+        self._request_autoscale_view("y")
+
         return l
 
     @_docstring.interpd
@@ -901,14 +901,14 @@ class Axes(_AxesBase):
 
         # Strip away the units for comparison with non-unitized bounds.
         xx, = self._process_unit_info([("x", x)], kwargs)
-        scalex = (xx < xmin) or (xx > xmax)
 
         trans = self.get_xaxis_transform(which='grid')
         l = mlines.Line2D([x, x], [ymin, ymax], transform=trans, **kwargs)
         self.add_line(l)
         l.get_path()._interpolation_steps = mpl.axis.GRIDLINE_INTERPOLATION_STEPS
-        if scalex:
-            self._request_autoscale_view("x")
+
+        self._request_autoscale_view("x")
+
         return l
 
     @staticmethod


### PR DESCRIPTION
Closes #14651.

As they are regularly added wih `add_line()`, they were always added to the data limits, but autoscaling was only updated under certain conditions, which led to an inconsistent state. See https://github.com/matplotlib/matplotlib/issues/14651#issuecomment-4325311941

Because of the inconsistent state, I'll classify this as a bug fix and justify that change can happen immediately without a deprecation.

