### PR TITLE
DOC, DX: Add note about stepping back from PR reviews

### DIFF
--- a/doc/devel/pr_guide.rst
+++ b/doc/devel/pr_guide.rst
@@ -208,11 +208,20 @@ Review
   push changes to the contributor branch, or merge the PR and then
   open a new PR against upstream.
 
-* If you push to a contributor branch leave a comment explaining what
+* If you push to a contributor branch, leave a comment explaining what
   you did, ex "I took the liberty of pushing a small clean-up PR to
   your branch, thanks for your work.".  If you are going to make
   substantial changes to the code or intent of the PR please check
   with the contributor first.
+
+* If you find yourself spending too much time on a PR, or feeling frustrated,
+  it's ok to step back. You can ask for help from other reviewers, or if you are
+  the only reviewer, you can ask the contributor to find another reviewer or to
+  wait until you have more time. Make sure to communicate with the contributor
+  to set the right expectations, e.g. "I currently don't have the bandwidth to
+  review this PR, but will try to loop someone else in." If you feel like this
+  PR is not a good fit for the project, you can close it with an explanation or
+  add the "status: autoclose candidate" label to trigger the autoclose workflow.
 
 .. _pr-approval:
 


### PR DESCRIPTION
## PR summary

Adds a note to the PR review guide about stepping back from PR review.

## AI Disclosure
No AI used

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
