### PR TITLE
ENH: Add color rcParam support for suptitle

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -393,8 +393,9 @@ default: %(va)s
     def suptitle(self, t, **kwargs):
         # docstring from _suplabels...
         info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
-                'ha': 'center', 'va': 'top', 'rotation': 0,
-                'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
+                    'ha': 'center', 'va': 'top', 'rotation': 0,
+                    'size': 'figure.titlesize', 'weight': 'figure.titleweight',
+                    'color': 'figure.titlecolor'}
         return self._suplabels(t, info, **kwargs)
 
     def get_suptitle(self):


### PR DESCRIPTION
## PR Summary

This PR adds `figure.titlecolor` rcParam support to `suptitle()`, 
allowing users to set a default color for the figure's super title 
via rcParams instead of passing it manually every time.

### Why is this change necessary?
Currently, `suptitle()` supports `figure.titlesize` and 
`figure.titleweight` via rcParams, but not color. This adds 
consistency.

### What problem does it solve?
Closes #24090

### Minimum example:
```python
import matplotlib.pyplot as plt
import matplotlib as mpl

mpl.rcParams['figure.titlecolor'] = 'red'
fig, ax = plt.subplots()
fig.suptitle('My Title')  # will now appear in red by default
plt.show()
```

## AI Disclosure
I used AI assistance to help understand the codebase structure.