### PR TITLE
docs: Remove invalid 'ultrabold' from fontweight options in text_props

### DIFF
--- a/galleries/users_explain/text/text_props.py
+++ b/galleries/users_explain/text/text_props.py
@@ -41,7 +41,7 @@ transform                   `~matplotlib.transforms.Transform` subclass
 variant                     [ ``'normal'`` | ``'small-caps'`` ]
 verticalalignment or va     [ ``'center'`` | ``'top'`` | ``'bottom'`` | ``'baseline'`` ]
 visible                     bool
-weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultrabold'`` | ``'ultralight'``]
+weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'extra bold'`` | ``'ultralight'``]
 x                           `float`
 y                           `float`
 zorder                      any number


### PR DESCRIPTION
## Summary

The narrative documentation at `galleries/users_explain/text/text_props.py` listed 'ultrabold' as a valid font weight option, but `validate_fontweight()` does not accept it (only 'extra bold' is the corresponding string value).

This PR removes the invalid 'ultrabold' from the documentation.

Fixes #31506.