### PR TITLE
Fix #9970: suppress spurious warning when clearing axes with shared non-linear axes

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -902,6 +902,21 @@ class _AxesBase(martist.Artist):
             for name in need_scale:
                 for ax in self._shared_axes[name].get_siblings(self):
                     ax._stale_viewlims[name] = False
+            # Skip autoscale for an axis if the leader's scale is 'linear' but
+            # a follower's scale is non-linear (e.g., 'log'). Autoscale computes
+            # bounds using the leader's scale, which the follower's non-linear
+            # scale would reject. This prevents spurious warnings when clearing
+            # an axes with shared non-linear axes.
+            for name in need_scale:
+                if need_scale[name]:
+                    leader_axis = getattr(self, f"{name}axis")
+                    if leader_axis.get_scale() == 'linear':
+                        for ax in self._shared_axes[name].get_siblings(self):
+                            follow_axis = ax._axis_map[name]
+                            if follow_axis is not leader_axis and \
+                                    follow_axis.get_scale() != 'linear':
+                                need_scale[name] = False
+                                break
             self.autoscale_view(**{f"scale{name}": scale
                                    for name, scale in need_scale.items()})
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1303,9 +1303,9 @@ class _AxesBase(martist.Artist):
         self._sharex = other
         self.xaxis.major = other.xaxis.major  # Ticker instances holding
         self.xaxis.minor = other.xaxis.minor  # locator and formatter.
+        self.xaxis._scale = other.xaxis._scale
         x0, x1 = other.get_xlim()
         self.set_xlim(x0, x1, emit=False, auto=other.get_autoscalex_on())
-        self.xaxis._scale = other.xaxis._scale
 
     def sharey(self, other):
         """
@@ -1322,9 +1322,9 @@ class _AxesBase(martist.Artist):
         self._sharey = other
         self.yaxis.major = other.yaxis.major  # Ticker instances holding
         self.yaxis.minor = other.yaxis.minor  # locator and formatter.
+        self.yaxis._scale = other.yaxis._scale
         y0, y1 = other.get_ylim()
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
-        self.yaxis._scale = other.yaxis._scale
 
     def __clear(self):
         """Clear the Axes."""


### PR DESCRIPTION
## Fix #9970: suppress spurious warning when clearing axes with shared non-linear axes

### Bug
When `ax1.clear()` is called on an axes with a shared follower axes (`ax2, sharex=ax1`), `ax1`'s xaxis is reset to `linear` scale and `_set_lim(0, 1, auto=True)` is called. This triggers `_unstale_viewLim` which sees that the follower's xaxis is still stale and calls `autoscale_view()`. `autoscale_view()` computes bounds using the leader's `linear` scale but then `_set_lim` propagates to the follower's xaxis which still has `log` scale - triggering the `non-positive limits on log-scale axis` warning.

### Fix
In `_unstale_viewLim`, skip autoscale for an axis if the leader's scale is `linear` but any follower's scale is non-linear. The autoscale would compute `linear` bounds that the follower's non-linear scale would reject.

### Testing
A manual test:
```python
import matplotlib.pyplot as plt
fig = plt.figure()
ax1 = fig.add_subplot(1, 2, 1)
ax1.loglog(range(10))
ax2 = fig.add_subplot(1, 2, 2, sharex=ax1)
ax2.loglog(range(10))
fig.clf()  # Previously warned: Attempt to set non-positive xlim on a log-scaled axis
```

Fixes #9970