### PR TITLE
Fix zero-size array error in PDF backend draw_path_collection

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2003,7 +2003,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                 linewidths, linestyles, antialiaseds, urls,
                 offset_position, hatchcolors=hatchcolors)
 
-        padding = np.max(linewidths)
+        padding = np.max(linewidths) if len(linewidths) else 0
         path_codes = []
         path_extents = []
         for i, (path, transform) in enumerate(self._iter_collection_raw_paths(


### PR DESCRIPTION
When linewidths is empty (which can happen when `ls=''` empty linestyle is used in scatter), `np.max()` raises a `ValueError: zero-size array to reduction operation maximum which has no identity`.

The fix checks if linewidths has elements before calling `np.max()`, falling back to 0 padding when empty.

Fixes #31585