### PR TITLE
Make Scale axis parameter handling more flexible

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -138,7 +138,7 @@ def _make_axis_parameter_optional(init_func):
 
     This decorator ensures backward compatibility for scale classes that
     previously required an *axis* parameter. It allows constructors to be
-    callerd with or without the *axis* parameter.
+    called with or without the *axis* parameter.
 
     For simplicity, this does not handle the case when *axis*
     is passed as a keyword. However,
@@ -170,12 +170,16 @@ def _make_axis_parameter_optional(init_func):
     """
     @wraps(init_func)
     def wrapper(self, *args, **kwargs):
-        if args and isinstance(args[0], mpl.axis.Axis):
-            return init_func(self, *args, **kwargs)
+        sig = inspect.signature(init_func)
+        try:
+            # Try old signature.
+            sig.bind(self, *args, **kwargs)
+        except TypeError:
+            # Use the new signature and pass in an unused axis=None.
+            init_func(self, None, *args, **kwargs)
         else:
-            # Remove 'axis' from kwargs to avoid double assignment
-            axis = kwargs.pop('axis', None)
-            return init_func(self, axis, *args, **kwargs)
+            # Use the old signature.
+            init_func(self, *args, **kwargs)
     return wrapper
 
 
@@ -449,6 +453,11 @@ class FuncScaleLog(LogScale):
         ----------
         axis : `~matplotlib.axis.Axis`
             The axis for the scale.
+
+            .. note::
+                This parameter is unused and about to be removed in the future.
+                It can already now be left out because of special preprocessing,
+                so that ``FuncScaleLog(functions=(forward, inverse))`` is valid.
         functions : (callable, callable)
             two-tuple of the forward and inverse functions for the scale.
             The forward function must be monotonic.

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -3,6 +3,7 @@ import copy
 import matplotlib.pyplot as plt
 from matplotlib.scale import (
     AsinhScale, AsinhTransform,
+    FuncScale, LogitScale,
     LogTransform, InvertedLogTransform,
     SymmetricalLogTransform)
 import matplotlib.scale as mscale
@@ -17,6 +18,49 @@ import numpy as np
 from numpy.testing import assert_allclose
 import io
 import pytest
+
+
+def test_optional_axis_signature():
+    # There are three types of original signatures possible, and this only tests one
+    # example class of each:
+    # 1. `axis` without default: LinearScale, FuncScale, FuncScaleLog
+    # 2. `axis` with default and more positional parameters: LogitScale
+    # 3. `axis` with default and only keyword-only parameters: LogScale, AsinhScale,
+    #    SymmetricalLogScale
+    # Testing with None is sufficient as detection is purely based on the
+    # signature structure; no type information is involved.
+    axis = None
+
+    # Old signature with axis positionally.
+    FuncScale(axis, (lambda x: x, lambda x: x))
+    FuncScale(axis, functions=(lambda x: x, lambda x: x))
+    LogitScale(axis)
+    LogitScale(axis, 'clip')
+    LogitScale(axis, nonpositive='clip')
+    LogitScale(axis, use_overline=True)
+    AsinhScale(axis)
+    AsinhScale(axis, linear_width=2)
+    AsinhScale(axis, base=3)
+    AsinhScale(axis, subs=[2, 6])
+    # Old signature with axis as keyword.
+    FuncScale(axis=axis, functions=(lambda x: x, lambda x: x))
+    LogitScale(axis=axis)
+    LogitScale(axis=axis, nonpositive='clip')
+    LogitScale(axis=axis, use_overline=True)
+    AsinhScale(axis=axis)
+    AsinhScale(axis=axis, linear_width=2)
+    AsinhScale(axis=axis, base=3)
+    AsinhScale(axis=axis, subs=[2, 6])
+    # New signature without axis.
+    FuncScale((lambda x: x, lambda x: x))
+    FuncScale(functions=(lambda x: x, lambda x: x))
+    LogitScale()
+    LogitScale(nonpositive='clip')
+    LogitScale(use_overline=True)
+    AsinhScale()
+    AsinhScale(linear_width=2)
+    AsinhScale(base=3)
+    AsinhScale(subs=[2, 6])
 
 
 @check_figures_equal()


### PR DESCRIPTION
## PR summary

Instead of checking the types ourselves, try to bind the old signature, and if possible, use it. Otherwise, try to use the new signature. This is similar to `_api.select_matching_signature` without needing to write a callable for each signature.

Note there are some _invalid_ call signatures that might error in less than clear ways, but they already did so, and I did not attempt to make these clearer. (For example, `FuncScale(axis)` will try to use the `Axis` as `functions` and fail to unpack it as a tuple, but this was true with the original `_make_axis_parameter_optional`.)

Closes #31590

## AI Disclosure
None

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines