### PR TITLE
DOC: Inline ScalarMappable reStructuredText entries

### DIFF
--- a/doc/api/.gitignore
+++ b/doc/api/.gitignore
@@ -1,1 +1,0 @@
-scalarmappable.gen_rst

--- a/doc/api/cm_api.rst
+++ b/doc/api/cm_api.rst
@@ -7,4 +7,20 @@
    :undoc-members:
    :show-inheritance:
 
-.. include:: scalarmappable.gen_rst
+.. class:: ScalarMappable(colorizer, **kwargs)
+   :canonical: matplotlib.colorizer._ScalarMappable
+
+   .. automethod:: autoscale
+   .. automethod:: autoscale_None
+   .. automethod:: changed
+   .. autoproperty:: colorbar
+   .. automethod:: get_alpha
+   .. automethod:: get_array
+   .. automethod:: get_clim
+   .. automethod:: get_cmap
+   .. autoproperty:: norm
+   .. automethod:: set_array
+   .. automethod:: set_clim
+   .. automethod:: set_cmap
+   .. automethod:: set_norm
+   .. automethod:: to_rgba

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -837,58 +837,6 @@ else:
     extensions.append('sphinx.ext.viewcode')
 
 
-def generate_ScalarMappable_docs():
-
-    import matplotlib.colorizer
-    from numpydoc.docscrape_sphinx import get_doc_object
-    from pathlib import Path
-    import textwrap
-    from sphinx.util.inspect import stringify_signature
-    target_file = Path(__file__).parent / 'api' / 'scalarmappable.gen_rst'
-    with open(target_file, 'w') as fout:
-        fout.write("""
-.. class:: ScalarMappable(colorizer, **kwargs)
-   :canonical: matplotlib.colorizer._ScalarMappable
-
-""")
-        for meth in [
-                matplotlib.colorizer._ScalarMappable.autoscale,
-                matplotlib.colorizer._ScalarMappable.autoscale_None,
-                matplotlib.colorizer._ScalarMappable.changed,
-                """
-   .. attribute:: colorbar
-
-        The last colorbar associated with this ScalarMappable. May be None.
-""",
-                matplotlib.colorizer._ScalarMappable.get_alpha,
-                matplotlib.colorizer._ScalarMappable.get_array,
-                matplotlib.colorizer._ScalarMappable.get_clim,
-                matplotlib.colorizer._ScalarMappable.get_cmap,
-                """
-   .. property:: norm
-""",
-                matplotlib.colorizer._ScalarMappable.set_array,
-                matplotlib.colorizer._ScalarMappable.set_clim,
-                matplotlib.colorizer._ScalarMappable.set_cmap,
-                matplotlib.colorizer._ScalarMappable.set_norm,
-                matplotlib.colorizer._ScalarMappable.to_rgba,
-        ]:
-            if isinstance(meth, str):
-                fout.write(meth)
-            else:
-                name = meth.__name__
-                sig = stringify_signature(inspect.signature(meth))
-                docstring = textwrap.indent(
-                    str(get_doc_object(meth)),
-                    '      '
-                ).rstrip()
-                fout.write(f"""
-   .. method::  {name}{sig}
-{docstring}
-
-""")
-
-
 # -----------------------------------------------------------------------------
 # Sphinx setup
 # -----------------------------------------------------------------------------
@@ -902,5 +850,4 @@ def setup(app):
     app.connect('autodoc-process-bases', autodoc_process_bases)
     if sphinx.version_info[:2] < (7, 1):
         app.connect('html-page-context', add_html_cache_busting, priority=1000)
-    generate_ScalarMappable_docs()
     app.config.autodoc_use_legacy_class_based = True


### PR DESCRIPTION
## PR summary

There is nothing that is dynamic here, so there's no need to generate this with code.

The only difference here is that `automethod` recognizes `self` and trims it from the signature.

## AI Disclosure
None

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines