### PR TITLE
FIX: use axis lines tight bbox within axis artist tight bbox

### DIFF
--- a/lib/mpl_toolkits/axisartist/axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/axis_artist.py
@@ -1086,7 +1086,7 @@ class AxisArtist(martist.Artist):
             *self.minor_ticklabels.get_window_extents(renderer),
             self.label.get_window_extent(renderer),
             self.offsetText.get_window_extent(renderer),
-            self.line.get_window_extent(renderer),
+            self.line.get_tightbbox(renderer),
         ]
         bb = [b for b in bb if b and (b.width != 0 or b.height != 0)]
         if bb:

--- a/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
+++ b/lib/mpl_toolkits/axisartist/tests/test_axis_artist.py
@@ -1,7 +1,13 @@
-import matplotlib.pyplot as plt
-from matplotlib.testing.decorators import image_comparison
+import numpy as np
 
-from mpl_toolkits.axisartist import AxisArtistHelperRectlinear
+import matplotlib as mpl
+import matplotlib.pyplot as plt
+from matplotlib.projections import PolarAxes
+from matplotlib.testing.decorators import image_comparison
+from matplotlib.transforms import Affine2D
+
+from mpl_toolkits.axisartist import (AxisArtistHelperRectlinear, GridHelperCurveLinear,
+                                     HostAxes)
 from mpl_toolkits.axisartist.axis_artist import (AxisArtist, AxisLabel,
                                                  LabelBase, Ticks, TickLabels)
 
@@ -90,3 +96,24 @@ def test_axis_artist():
     axisline.label.set_pad(5)
 
     ax.set_ylabel("Test")
+
+
+@mpl.style.context('default')
+def test_axisartist_tightbbox():
+    fig = plt.figure()
+    tr = Affine2D().scale(np.pi / 180., 1.) + PolarAxes.PolarTransform()
+    grid_helper = GridHelperCurveLinear(tr)
+    ax = fig.add_subplot(axes_class=HostAxes, grid_helper=grid_helper)
+    ax.axis["lon"] = ax.new_floating_axis(1, 9)
+
+    ax.set_xlim(-5, 12)
+    ax.set_ylim(-5, 10)
+
+    ax.axis['lon'].major_ticklabels.set_visible(False)
+
+    # Since the labels are invisible and the lines are clipped to the axes,
+    # the axis's tight bbox should be contained in the axes box.
+    renderer = fig._get_renderer()
+    tight_points = ax.axis['lon'].get_tightbbox(renderer).get_points()
+    for point in tight_points:
+        assert ax.bbox.contains(*point)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Fixes #31622.  Since the axis lines appear to be clipped to the axes, we should use their tight bounding box instead of their window extent in their parent's tight bounding box.  The code from the issue now gives

<img width="500" height="500" alt="floating_axis_default" src="https://github.com/user-attachments/assets/75888a01-9484-4970-9c55-210b24b8e711" />

<img width="500" height="500" alt="floating_axis_tight" src="https://github.com/user-attachments/assets/d7f01223-0251-42a9-8aa4-5c48b6a7e353" />

<img width="500" height="500" alt="floating_axis_constrained" src="https://github.com/user-attachments/assets/825f5476-d094-4908-b88e-c5f8065a45e9" />



I welcome any guidance on whether there is a better/simpler example to use for the test.  I am not familiar with axis artists.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
None

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
