### PR TITLE
Debugging: verbose appveyor env creation

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -69,7 +69,7 @@ test_script:
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'
 
   # this are optional dependencies so that we don't skip so many tests...
-  - if x%TEST_ALL% == xyes micromamba install -q ffmpeg inkscape
+  - if x%TEST_ALL% == xyes micromamba install -vv -q ffmpeg inkscape
   # miktex is available on conda, but seems to fail with permission errors.
   # missing packages on conda-forge for imagemagick
   # This install sometimes failed randomly :-(

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -57,7 +57,7 @@ init:
   - micromamba info
 
 install:
-  - micromamba env create -f environment.yml python=%PYTHON_VERSION% pywin32
+  - micromamba env create -vv -f environment.yml python=%PYTHON_VERSION% pywin32
   - micromamba activate mpl-dev
 
 test_script:


### PR DESCRIPTION
Appveyor appears to be failing at the micromamba environment creation stage, so make that verbose to see if the problem becomes clearer.