### PR TITLE
FIX: Pin rstcheck to prevent CI failure

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -70,6 +70,7 @@ repos:
     hooks:
       - id: rstcheck
         additional_dependencies:
+          - rstcheck-core!=1.3  # https://github.com/rstcheck/rstcheck-core/pull/114#pullrequestreview-4239740896
           - sphinx>=1.8.1
           - tomli
   - repo: https://github.com/adrienverge/yamllint


### PR DESCRIPTION
While rstcheck itself is frozen and also was not updated, it depends on rstcheck-core, which was recently updated to 1.3 and contains a bug that results in a false error.

https://github.com/rstcheck/rstcheck-core/pull/114#pullrequestreview-4239740896

This PR excludes that version to fix pre-commit rstcheck in our CI.

