### PR TITLE
MNT: Remove pre-commit/rstcheck dependency on tomli

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -71,7 +71,6 @@ repos:
       - id: rstcheck
         additional_dependencies:
           - sphinx>=1.8.1
-          - tomli
   - repo: https://github.com/adrienverge/yamllint
     rev: cba56bcde1fdd01c1deb3f945e69764c291a6530  # frozen: v1.38.0
     hooks:


### PR DESCRIPTION
This was only needed to support python<=3.11 and is thus not needed anymore on the main branch.

I'm unclear whether we should also remove `sphinx>=1.8.1`. It's far off and I'm quite sure we do not systematically specify lower compatibility boundaries.
