### PR TITLE
Discourage Lasso widget in docs

### DIFF
--- a/doc/api/next_api_changes/deprecations/19221-HS.rst
+++ b/doc/api/next_api_changes/deprecations/19221-HS.rst
@@ -1,0 +1,6 @@
+``Lasso`` is discouraged
+~~~~~~~~~~~~~~~~~~~~~~~~
+
+The use of `.Lasso` is discouraged for new code. Use `.LassoSelector`
+instead, which follows the selector-widget interface and remains connected
+to the Axes until disconnected.

--- a/galleries/examples/event_handling/lasso_demo.py
+++ b/galleries/examples/event_handling/lasso_demo.py
@@ -6,6 +6,12 @@ Lasso Demo
 Use a lasso to select a set of points and get the indices of the selected points.
 A callback is used to change the color of the selected points.
 
+This example uses the low-level `~matplotlib.widgets.Lasso` widget. For new
+code, prefer `~matplotlib.widgets.LassoSelector`, which is shown in the
+:doc:`/gallery/widgets/lasso_selector_demo_sgskip` example. `~.LassoSelector`
+uses the same interface as the other selector widgets and remains connected
+until it is disconnected.
+
 .. note::
     This example exercises the interactive capabilities of Matplotlib, and this
     will not appear in the static documentation. Please run this code on your

--- a/galleries/examples/widgets/lasso_selector_demo_sgskip.py
+++ b/galleries/examples/widgets/lasso_selector_demo_sgskip.py
@@ -5,9 +5,14 @@ Lasso Selector
 
 Interactively selecting data points with the lasso tool.
 
-This examples plots a scatter plot. You can then select a few points by drawing
+This example plots a scatter plot. You can then select a few points by drawing
 a lasso loop around the points on the graph. To draw, just click
 on the graph, hold, and drag it around the points you need to select.
+
+For most lasso-selection use cases, prefer `~matplotlib.widgets.LassoSelector`
+over `~matplotlib.widgets.Lasso`, which is shown in the
+:doc:`/gallery/event_handling/lasso_demo` example. `~.LassoSelector` follows
+the selector-widget API and stays connected until explicitly disconnected.
 """
 
 

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4376,7 +4376,13 @@ class PolygonSelector(_SelectorWidget):
 
 class Lasso(AxesWidget):
     """
-    Selection curve of an arbitrary shape.
+    [*Discouraged*] Selection curve of an arbitrary shape.
+
+    .. admonition:: Discouraged
+
+        The use of `Lasso` is discouraged for new code. Use `LassoSelector`
+        instead, which uses the selector-widget interface and remains
+        connected to the Axes until disconnected.
 
     The selected path can be used in conjunction with
     `~matplotlib.path.Path.contains_point` to select data points from an image.


### PR DESCRIPTION
## Summary

- mark `matplotlib.widgets.Lasso` as discouraged in its API docstring and recommend `LassoSelector`
- cross-reference the `Lasso` and `LassoSelector` gallery examples so users can compare the low-level widget and the preferred selector API
- add a next API-change note documenting that `Lasso` is discouraged for new code
- fix a small typo in the `LassoSelector` gallery intro

Refs #19221.

## Validation

- `python3 -m py_compile lib/matplotlib/widgets.py galleries/examples/event_handling/lasso_demo.py galleries/examples/widgets/lasso_selector_demo_sgskip.py`
- `/Users/whyharshit/Documents/Codex/2026-05-11/i-want-you-to-browse-for/bulwark-mcp/.venv/bin/ruff check lib/matplotlib/widgets.py galleries/examples/event_handling/lasso_demo.py galleries/examples/widgets/lasso_selector_demo_sgskip.py`
- `git diff --check`

I did not run a full docs build locally.