### PR TITLE
Unshare axes before clearing

### DIFF
--- a/doc/api/next_api_changes/behavior/9970-HS.rst
+++ b/doc/api/next_api_changes/behavior/9970-HS.rst
@@ -1,0 +1,7 @@
+Clearing an Axes now unshares shared axes
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Calling `.Axes.clear` or `.Axes.cla` now removes the Axes from any shared-axis
+groups before resetting its state. Sibling Axes remain shared with each other.
+This prevents warnings from shared non-linear scales during clearing and matches
+the expectation that a cleared Axes returns to an unshared, newly-created state.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -738,10 +738,8 @@ class _AxesBase(martist.Artist):
 
         self._rasterization_zorder = None
         self._initializing = True
-        try:
-            self.clear()
-        finally:
-            self._initializing = False
+        self.clear()
+        self._initializing = False
 
         # funcs used to format x and y - fall back on major formatters
         self.fmt_xdata = None

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -737,7 +737,11 @@ class _AxesBase(martist.Artist):
         self.set_axisbelow(mpl.rcParams['axes.axisbelow'])
 
         self._rasterization_zorder = None
-        self.clear()
+        self._initializing = True
+        try:
+            self.clear()
+        finally:
+            self._initializing = False
 
         # funcs used to format x and y - fall back on major formatters
         self.fmt_xdata = None
@@ -1326,6 +1330,40 @@ class _AxesBase(martist.Artist):
         self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
         self.yaxis._scale = other.yaxis._scale
 
+    def _unshare_axis(self, name):
+        """Remove this Axes from the shared-axis group for *name*."""
+        grouper = self._shared_axes[name]
+        if self not in grouper:
+            return
+
+        siblings = grouper.get_siblings(self, include_self=False)
+        grouper.remove(self)
+        setattr(self, f"_share{name}", None)
+
+        # The shared axes use the same Ticker instances.  Detach this axis
+        # before clearing it so the remaining siblings keep their state.
+        axis = self._axis_map[name]
+        axis.major = maxis.Ticker()
+        axis.minor = maxis.Ticker()
+
+        if not siblings:
+            return
+
+        share_attr = f"_share{name}"
+        remaining = siblings[0]
+        for sibling in siblings:
+            if getattr(sibling, share_attr) is self:
+                setattr(sibling, share_attr,
+                        None if sibling is remaining else remaining)
+
+        # Formatters and locators may previously have been associated with the
+        # cleared axis.  Update them to point to an axis still in the group.
+        remaining_axis = remaining._axis_map[name]
+        remaining_axis.get_major_formatter().set_axis(remaining_axis)
+        remaining_axis.get_major_locator().set_axis(remaining_axis)
+        remaining_axis.get_minor_formatter().set_axis(remaining_axis)
+        remaining_axis.get_minor_locator().set_axis(remaining_axis)
+
     def __clear(self):
         """Clear the Axes."""
         # The actual implementation of clear() as long as clear() has to be
@@ -1341,6 +1379,12 @@ class _AxesBase(martist.Artist):
 
         xaxis_visible = self.xaxis.get_visible()
         yaxis_visible = self.yaxis.get_visible()
+        shared_x = self in self._shared_axes["x"] or self._sharex is not None
+        shared_y = self in self._shared_axes["y"] or self._sharey is not None
+
+        if not getattr(self, "_initializing", False):
+            for name in self._axis_names:
+                self._unshare_axis(name)
 
         for axis in self._axis_map.values():
             axis.clear()  # Also resets the scale to linear.
@@ -1435,10 +1479,10 @@ class _AxesBase(martist.Artist):
         self.xaxis.set_clip_path(self.patch)
         self.yaxis.set_clip_path(self.patch)
 
-        if self._sharex is not None:
+        if shared_x:
             self.xaxis.set_visible(xaxis_visible)
             self.patch.set_visible(patch_visible)
-        if self._sharey is not None:
+        if shared_y:
             self.yaxis.set_visible(yaxis_visible)
             self.patch.set_visible(patch_visible)
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -12,6 +12,7 @@ import re
 import sys
 from types import SimpleNamespace
 import unittest.mock
+import warnings
 
 import dateutil.tz
 
@@ -545,15 +546,15 @@ def test_inverted_cla():
     for ax in fig.axes:
         ax.remove()
     # 5. two shared axes. Inverting the leader axis should invert the shared
-    # axes; clearing the leader axis should bring axes in shared
-    # axes back to normal.
+    # axes; clearing the leader axis should return it to an unshared state.
     ax0 = plt.subplot(211)
     ax1 = plt.subplot(212, sharey=ax0)
     ax0.yaxis.set_inverted(True)
     assert ax1.yaxis_inverted()
     ax1.plot(x, np.cos(x))
     ax0.cla()
-    assert not ax1.yaxis_inverted()
+    assert ax1.yaxis_inverted()
+    assert not ax0.get_shared_y_axes().joined(ax0, ax1)
     ax1.cla()
     # 6. clearing the follower should not touch limits
     ax0.imshow(img)
@@ -9251,19 +9252,56 @@ def test_2dcolor_plot(fig_test, fig_ref):
     axs[4].bar(np.arange(10), np.arange(10), color=color.reshape((1, -1)))
 
 
-@check_figures_equal()
-def test_shared_axes_clear(fig_test, fig_ref):
-    x = np.arange(0.0, 2*np.pi, 0.01)
-    y = np.sin(x)
+def test_shared_axes_clear():
+    _fig, axs = plt.subplots(2, 2, sharex=True, sharey=True)
+    shared_x = axs[0, 0].get_shared_x_axes()
+    shared_y = axs[0, 0].get_shared_y_axes()
 
-    axs = fig_ref.subplots(2, 2, sharex=True, sharey=True)
-    for ax in axs.flat:
-        ax.plot(x, y)
+    axs[0, 0].clear()
 
-    axs = fig_test.subplots(2, 2, sharex=True, sharey=True)
-    for ax in axs.flat:
-        ax.clear()
-        ax.plot(x, y)
+    for ax in axs.flat[1:]:
+        assert not shared_x.joined(axs[0, 0], ax)
+        assert not shared_y.joined(axs[0, 0], ax)
+
+    assert shared_x.joined(axs[0, 1], axs[1, 0])
+    assert shared_y.joined(axs[0, 1], axs[1, 0])
+
+
+def test_shared_axes_clear_with_non_linear_scale():
+    _fig, (ax0, ax1) = plt.subplots(1, 2, sharex=True)
+    x = range(1, 10)
+    ax0.plot(x, x)
+    ax1.semilogx(x, x)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            "Attempt to set non-positive xlim on a log-scaled axis "
+            "will be ignored.",
+            UserWarning,
+        )
+        ax0.clear()
+
+    assert not ax0.get_shared_x_axes().joined(ax0, ax1)
+    assert ax0.get_xscale() == "linear"
+    assert ax1.get_xscale() == "log"
+    assert isinstance(ax1.xaxis.get_major_locator(), mticker.LogLocator)
+
+
+def test_figure_clear_with_shared_non_linear_scale():
+    fig, (ax0, ax1) = plt.subplots(1, 2, sharex=True)
+    x = range(1, 10)
+    ax0.plot(x, x)
+    ax1.semilogx(x, x)
+
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "error",
+            "Attempt to set non-positive xlim on a log-scaled axis "
+            "will be ignored.",
+            UserWarning,
+        )
+        fig.clear()
 
 
 def test_shared_axes_retick():


### PR DESCRIPTION
## PR summary

Closes #9970.

Clearing an Axes now removes it from its shared-axis groups before resetting
axis state. This avoids propagating the clear-time limit reset through a sibling
log axis during `ax.clear()` / `ax.cla()` / `fig.clear()`, which previously
emitted an "Attempt to set non-positive xlim" warning.

The implementation detaches the cleared Axes' ticker instances before calling
`Axis.clear()`, so remaining siblings keep their locators/formatters and remain
shared with each other. It also skips this unsharing step during Axes
construction so initial `sharex`, `sharey`, and `sharez` setup is preserved.

Minimum example fixed by this PR:

```python
import matplotlib.pyplot as plt

fig, (ax0, ax1) = plt.subplots(1, 2, sharex=True)
x = range(1, 10)
ax0.plot(x, x)
ax1.semilogx(x, x)
fig.clear()
```

## AI Disclosure

I used OpenAI Codex to inspect the issue, implement the patch, and run local
tests. I reviewed the generated changes before opening this PR.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [x] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines
