### PR TITLE
ci: Re-arrange AppVeyor pipeline

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -29,15 +29,11 @@ environment:
 
   matrix:
     - PYTHON_VERSION: "3.11"
-      TEST_ALL: "yes"
 
 # We always use a 64-bit machine, but can build x86 distributions
 # with the PYTHON_ARCH variable
 platform:
   - x64
-
-# all our python builds have to happen in tests_script...
-build: false
 
 cache:
   - '%LOCALAPPDATA%\pip\Cache'
@@ -57,10 +53,18 @@ init:
   - micromamba info
 
 install:
-  - micromamba env create -f environment.yml python=%PYTHON_VERSION% pywin32
+  - set EXTRA_PACKAGES=pywin32 codecov
+  # These are optional dependencies so that we don't skip so many tests...
+  - set EXTRA_PACKAGES=%EXTRA_PACKAGES% ffmpeg inkscape
+  # miktex is available on conda, but seems to fail with permission errors.
+  # missing packages on conda-forge for imagemagick
+  # This install sometimes failed randomly :-(
+  # - choco install imagemagick
+
+  - micromamba env create -f environment.yml python=%PYTHON_VERSION% %EXTRA_PACKAGES%
   - micromamba activate mpl-dev
 
-test_script:
+build_script:
   # Now build the thing..
   - set LINK=/LIBPATH:%cd%\lib
   - pip install -v --no-build-isolation --editable .[dev]
@@ -68,13 +72,7 @@ test_script:
   - set "DUMPBIN=%VS140COMNTOOLS%\..\..\VC\bin\dumpbin.exe"
   - '"%DUMPBIN%" /DEPENDENTS lib\matplotlib\ft2font*.pyd | findstr freetype.*.dll && exit /b 1 || exit /b 0'
 
-  # this are optional dependencies so that we don't skip so many tests...
-  - if x%TEST_ALL% == xyes micromamba install -q ffmpeg inkscape
-  # miktex is available on conda, but seems to fail with permission errors.
-  # missing packages on conda-forge for imagemagick
-  # This install sometimes failed randomly :-(
-  # - choco install imagemagick
-
+test_script:
   # Test import of tkagg backend
   - python -c
     "import matplotlib as m; m.use('tkagg');
@@ -90,7 +88,6 @@ artifacts:
     type: Zip
 
 on_finish:
-  - micromamba install codecov
   - codecov -e PYTHON_VERSION PLATFORM -n "%PYTHON_VERSION% Windows"
 
 on_failure:


### PR DESCRIPTION
## PR summary

Move the extra packages into the initial install step, and drop the conditional, since `TEST_ALL` is always on. Also, put the build step into the actual build phase of the pipeline.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines