### PR TITLE
BLD: add more static analysis

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,36 @@
+---
+# clang-tidy configuration for matplotlib's src/ directory.
+#
+# Philosophy: enable checks that find real bugs (memory safety, undefined
+# behaviour, security) and suppress checks that are high-noise style rules
+# inappropriate for a C/C++ codebase that interfaces heavily with C APIs
+# (CPython, FreeType, libagg) via pybind11.
+#
+# Run with:
+#   clang-tidy -p <build_dir> --config-file=src/.clang-tidy <file>
+
+Checks: >
+  bugprone-*,
+  clang-analyzer-*,
+  objc-*,
+  performance-move-const-arg,
+  performance-move-constructor-init,
+  performance-no-automatic-move,
+  portability-*,
+  -bugprone-assignment-in-if-condition,
+  -bugprone-easily-swappable-parameters,
+  -bugprone-implicit-widening-of-multiplication-result,
+  -bugprone-macro-parentheses,
+  -bugprone-narrowing-conversions,
+  -bugprone-reserved-identifier,
+  -bugprone-throwing-static-initialization,
+  -clang-analyzer-optin.cplusplus.UninitializedObject,
+  -clang-analyzer-optin.performance.Padding,
+
+# Only report findings in matplotlib's own src/ headers, not in pybind11,
+# Python.h, agg, or other vendored includes.
+HeaderFilterRegex: '.*/matplotlib/src/.*'
+
+WarningsAsErrors: ''
+
+CheckOptions: []

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,8 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     groups:
       actions:
         patterns:
@@ -13,9 +15,13 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 7
     exclude-paths:
       - "ci/minver-requirements.txt"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/autoclose_schedule.yml
+++ b/.github/workflows/autoclose_schedule.yml
@@ -23,14 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: '3.13'
       - name: Install PyGithub
         run: pip install -Uq PyGithub
-
-      - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
       - name: Close PRs labeled more than 14 days ago
         run: |

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -108,7 +108,11 @@ jobs:
       - name: Run clang-tidy
         run: |
           set -o pipefail
-          export PATH=$(brew --prefix llvm)/bin:$PATH
+          LLVM_PREFIX=$(brew --prefix llvm)
+          export CC=$LLVM_PREFIX/bin/clang
+          export CXX=$LLVM_PREFIX/bin/clang++
+          export OBJC=$LLVM_PREFIX/bin/clang
+          export PATH=$LLVM_PREFIX/bin:$PATH
           python tools/run_clang_tidy.py
 
   eslint:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -106,7 +106,10 @@ jobs:
         run: pip3 install meson ninja pybind11 setuptools-scm
 
       - name: Run clang-tidy
-        run: python tools/run_clang_tidy.py
+        run: |
+          set -o pipefail
+          export PATH=$(brew --prefix llvm)/bin:$PATH
+          python tools/run_clang_tidy.py
 
   eslint:
     name: eslint

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,6 +84,30 @@ jobs:
               -tee -reporter=github-check -filter-mode nofilter
 
 
+  clang-tidy:
+    name: clang-tidy (macOS / Objective-C)
+    runs-on: macos-latest   # run on macOS so we can lint the objectiveC file
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: '3.14'
+
+      - name: Install OS dependencies
+        run: brew install llvm
+
+      - name: Install build dependencies
+        run: pip3 install meson ninja pybind11 setuptools-scm
+
+      - name: Run clang-tidy
+        run: python tools/run_clang_tidy.py
+
   eslint:
     name: eslint
     runs-on: ubuntu-latest

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,34 @@
+---
+name: zizmor
+
+on:
+  push:
+    branches: [main, v*.x]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '45 19 * * 1'
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: zizmor
+    if: github.repository == 'matplotlib/matplotlib'
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
+        with:
+          advanced-security: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -27,8 +27,4 @@ jobs:
           persist-credentials: false
 
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e  # v0.5.3
-        with:
-          advanced-security: true
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: zizmorcore/zizmor-action@b572f7b1a1c2d41efaab43d504f68d215c3cd727  # v0.5.4

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -12,8 +12,8 @@ rules:
   cache-poisoning:
     ignore:
       # cygwin.yml is a test-only workflow; no artifacts are published.
-      # The three caches (pip, ccache, matplotlib data) are purely for build
-      # acceleration and present no poisoning risk for released artifacts.
+      # This is triggering a low-confidence flag that the  workflow_dispatch:
+      # trigger may imply artifact publishing
       - cygwin.yml:144:9
       - cygwin.yml:151:9
       - cygwin.yml:158:9

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,19 @@
+---
+rules:
+  dangerous-triggers:
+    ignore:
+      # These workflows use pull_request_target solely to obtain write access
+      # for API operations (labeling, commenting) on fork PRs. None of them
+      # check out or execute any PR-supplied code.
+      - autoclose_comment.yml:11
+      - conflictcheck.yml:3
+      - labeler.yml:3
+      - pr_welcome.yml:4
+  cache-poisoning:
+    ignore:
+      # cygwin.yml is a test-only workflow; no artifacts are published.
+      # The three caches (pip, ccache, matplotlib data) are purely for build
+      # acceleration and present no poisoning risk for released artifacts.
+      - cygwin.yml:144:9
+      - cygwin.yml:151:9
+      - cygwin.yml:158:9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -78,6 +78,10 @@ repos:
     hooks:
       - id: yamllint
         args: ["--strict", "--config-file=.yamllint.yml"]
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
+    hooks:
+      - id: shellcheck
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 13614ab716a3113145f1294ed259d9fbe5678ff3  # frozen: 0.37.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -86,6 +86,14 @@ repos:
     rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
     hooks:
       - id: zizmor
+  - repo: https://github.com/simple-icons/svglint
+    rev: 8402586b94f073686e46707a163082e270ee5768  # frozen: v4.2.1
+    hooks:
+      - id: svglint
+        # Override the top-level exclude so that mpl-data/images/ toolbar
+        # icons are also linted.  Exemptions for the intentional interactive
+        # SVG examples are handled in .svglintrc.mjs.
+        exclude: '^$'
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 13614ab716a3113145f1294ed259d9fbe5678ff3  # frozen: 0.37.1
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,6 +82,10 @@ repos:
     rev: 745eface02aef23e168a8afb6b5737818efbea95  # frozen: v0.11.0.1
     hooks:
       - id: shellcheck
+  - repo: https://github.com/zizmorcore/zizmor-pre-commit
+    rev: a4727cbbcd26d7098e96b9cb738169b59711ae51  # frozen: v1.24.1
+    hooks:
+      - id: zizmor
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 13614ab716a3113145f1294ed259d9fbe5678ff3  # frozen: 0.37.1
     hooks:

--- a/.svglintrc.mjs
+++ b/.svglintrc.mjs
@@ -1,0 +1,56 @@
+/** @type {import('svglint').Config} */
+const config = {
+    rules: {
+        // Ensure all SVGs are valid XML.
+        valid: true,
+
+        // Block elements that can execute code or embed arbitrary content.
+        // <script> can run arbitrary JavaScript; <foreignObject> and <iframe>
+        // can embed arbitrary HTML.  Unlike event-handler attributes (which
+        // are a legitimate tool for matplotlib's interactive SVG examples),
+        // there is no use case in this repository for these elements outside
+        // of a <script> already paired with its own exemption.
+        elm: {
+            "script": false,
+            "foreignObject": false,
+            "iframe": false,
+        },
+
+        custom: [
+            // Block external URL references in href / xlink:href.
+            // Internal fragment references (#id), data: URIs, and relative
+            // paths are all fine.  http/https/ftp and protocol-relative URLs
+            // are blocked because they cause the SVG renderer to make an
+            // outbound network request, leaking the viewer's IP and UA to an
+            // attacker-controlled server.
+            (reporter, $, _ast) => {
+                reporter.name = "no-external-references";
+                const externalPattern = /^(https?:|ftp:|\/\/)/i;
+                $("[href], [xlink\\:href]").each((_i, el) => {
+                    if (!el.attribs) { return; }
+                    const href =
+                        el.attribs["href"] ?? el.attribs["xlink:href"];
+                    if (href && externalPattern.test(href)) {
+                        reporter.error(
+                            `Found external reference '${href}' on <${el.name}>. ` +
+                            "External URL references in SVGs cause the renderer " +
+                            "to make an outbound request, leaking viewer IP/UA."
+                        );
+                    }
+                });
+            },
+        ],
+    },
+
+    // These four files are intentional interactive SVG examples that
+    // demonstrate matplotlib's SVG interactivity features.  They contain
+    // embedded ECMAScript by design and are exempted from the <script> rule.
+    ignore: [
+        "doc/_static/svg_histogram.svg",
+        "doc/_static/svg_tooltip.svg",
+        "galleries/examples/user_interfaces/images/svg_histogram.svg",
+        "galleries/examples/user_interfaces/images/svg_tooltip.svg",
+    ],
+};
+
+export default config;

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -134,7 +134,7 @@ C/C++ extensions
 .. _clang-tidy:
 
 Static analysis with clang-tidy
---------------------------------
+-------------------------------
 
 Matplotlib's C/C++ sources in :file:`src/` are checked with
 `clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`__ in CI (see

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -131,6 +131,44 @@ C/C++ extensions
   implement new features only if the required changes cannot be made elsewhere
   in the codebase.  In particular, avoid making style fixes to it.
 
+.. _clang-tidy:
+
+Static analysis with clang-tidy
+--------------------------------
+
+Matplotlib's C/C++ sources in :file:`src/` are checked with
+`clang-tidy <https://clang.llvm.org/extra/clang-tidy/>`__ in CI (see
+:file:`.github/workflows/linting.yml`).  The check
+configuration lives in :file:`.clang-tidy`.
+
+The logic lives in :file:`tools/run_clang_tidy.py`.  It requires
+``clang-tidy`` on ``PATH`` and ``meson`` and ``pybind11`` installed::
+
+    pip install meson pybind11
+
+On macOS, ``clang-tidy`` is not on ``PATH`` after a Homebrew install::
+
+    brew install llvm
+    export PATH=$(brew --prefix llvm)/bin:$PATH
+
+The script uses a dedicated ``build/clang-tidy/`` directory (created
+automatically on first run) and delegates to meson's built-in
+``clang-tidy`` target. To run locally:
+
+.. code-block:: bash
+
+   python tools/run_clang_tidy.py
+
+
+To suppress false-positives use narrow checks and a comment:
+
+.. code-block:: c++
+
+   *indices++ = value;  // NOLINT(clang-analyzer-security.ArrayBound): loop
+   // iterates exactly N times; the analyzer cannot prove this from the macro.
+
+
+
 .. _keyword-argument-processing:
 
 Keyword argument processing

--- a/doc/devel/coding_guide.rst
+++ b/doc/devel/coding_guide.rst
@@ -144,7 +144,7 @@ configuration lives in :file:`.clang-tidy`.
 The logic lives in :file:`tools/run_clang_tidy.py`.  It requires
 ``clang-tidy`` on ``PATH`` and ``meson`` and ``pybind11`` installed::
 
-    pip install meson pybind11
+    pip install meson pybind11 setuptools-scm
 
 On macOS, ``clang-tidy`` is not on ``PATH`` after a Homebrew install::
 

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -47,16 +47,20 @@ static PyOS_sighandler_t originalSigintAction = NULL;
 static void stopWithEvent() {
     [NSApp stop: nil];
     // Post an event to trigger the actual stopping.
-    [NSApp postEvent: [NSEvent otherEventWithType: NSEventTypeApplicationDefined
-                                         location: NSZeroPoint
-                                    modifierFlags: 0
-                                        timestamp: 0
-                                     windowNumber: 0
-                                          context: nil
-                                          subtype: 0
-                                            data1: 0
-                                            data2: 0]
-             atStart: YES];
+    // +[NSEvent otherEventWithType:...] is declared nullable but will not return
+    // nil for these constant, valid arguments; guard defensively anyway.
+    NSEvent* event = [NSEvent otherEventWithType: NSEventTypeApplicationDefined
+                                        location: NSZeroPoint
+                                   modifierFlags: 0
+                                       timestamp: 0
+                                    windowNumber: 0
+                                         context: nil
+                                         subtype: 0
+                                           data1: 0
+                                           data2: 0];
+    if (event) {
+        [NSApp postEvent: event atStart: YES];
+    }
 }
 
 // Signal handler for SIGINT, only argument matching for stopWithEvent
@@ -375,11 +379,12 @@ FigureCanvas_init(FigureCanvas *self, PyObject *args, PyObject *kwds)
     self->view.autoresizingMask = NSViewWidthSizable | NSViewHeightSizable;
     int opts = (NSTrackingMouseEnteredAndExited | NSTrackingMouseMoved |
                 NSTrackingActiveInKeyWindow | NSTrackingInVisibleRect);
-    [self->view addTrackingArea: [
-        [NSTrackingArea alloc] initWithRect: rect
-                                    options: opts
-                                      owner: self->view
-                                   userInfo: nil]];
+    NSTrackingArea* area = [[NSTrackingArea alloc] initWithRect: rect
+                                                        options: opts
+                                                          owner: self->view
+                                                       userInfo: nil];
+    [self->view addTrackingArea: area];
+    [area release];
     [self->view setCanvas: (PyObject*)self];
 
 exit:
@@ -514,6 +519,8 @@ FigureCanvas__start_event_loop(FigureCanvas* self, PyObject* args, PyObject* key
 static PyObject*
 FigureCanvas_stop_event_loop(FigureCanvas* self)
 {
+    // +[NSEvent otherEventWithType:...] is declared nullable but will not return
+    // nil for these constant, valid arguments; guard defensively anyway.
     NSEvent* event = [NSEvent otherEventWithType: NSEventTypeApplicationDefined
                                         location: NSZeroPoint
                                    modifierFlags: 0
@@ -523,7 +530,9 @@ FigureCanvas_stop_event_loop(FigureCanvas* self)
                                          subtype: STOP_EVENT_LOOP
                                            data1: 0
                                            data2: 0];
-    [NSApp postEvent: event atStart: true];
+    if (event) {
+        [NSApp postEvent: event atStart: true];
+    }
     Py_RETURN_NONE;
 }
 
@@ -767,6 +776,9 @@ FigureManager_set_window_title(FigureManager* self,
     if (!PyArg_ParseTuple(args, "s", &title)) {
         return NULL;
     }
+    // PyArg_ParseTuple "s" guarantees valid UTF-8, so stringWithUTF8String: will
+    // not return nil here; the nullable annotation is a false positive.
+    // NOLINTNEXTLINE(clang-analyzer-nullability.NullablePassedToNonnull)
     [self->window setTitle: [NSString stringWithUTF8String: title]];
     Py_RETURN_NONE;
 }
@@ -885,7 +897,8 @@ typedef struct {
 @implementation NavigationToolbar2Handler
 - (NavigationToolbar2Handler*)initWithToolbar:(PyObject*)theToolbar
 {
-    [self init];
+    self = [self init];
+    if (!self) { return nil; }
     toolbar = theToolbar;
     return self;
 }
@@ -1005,8 +1018,10 @@ NavigationToolbar2_init(NavigationToolbar2 *self, PyObject *args, PyObject *kwds
     rect.origin.y = 0.5*(height - rect.size.height);
 
     for (int i = 0; i < 7; i++) {
+        // PyArg_ParseTuple "s" guarantees valid UTF-8; stringWithUTF8String: will not return nil.
         NSString* filename = [NSString stringWithUTF8String: images[i]];
         NSString* tooltip = [NSString stringWithUTF8String: tooltips[i]];
+        // NOLINTNEXTLINE(clang-analyzer-nullability.NullablePassedToNonnull)
         NSImage* image = [[NSImage alloc] initWithContentsOfFile: filename];
         buttons[i] = [[NSButton alloc] initWithFrame: rect];
         [image setSize: size];
@@ -1074,7 +1089,9 @@ NavigationToolbar2_set_message(NavigationToolbar2 *self, PyObject* args)
     NSTextView* messagebox = self->messagebox;
 
     if (messagebox) {
+        // PyArg_ParseTuple "s" guarantees valid UTF-8; stringWithUTF8String: will not return nil.
         NSString* text = [NSString stringWithUTF8String: message];
+        // NOLINTNEXTLINE(clang-analyzer-nullability.NullablePassedToNonnull)
         [messagebox setString: text];
 
         // Adjust width and height with the window size and content
@@ -1131,6 +1148,8 @@ choose_save_file(PyObject* unused, PyObject* args)
     }
     NSSavePanel* panel = [NSSavePanel savePanel];
     [panel setTitle: [NSString stringWithUTF8String: title]];
+    // PyArg_ParseTuple "s" guarantees valid UTF-8; stringWithUTF8String: will not return nil.
+    // NOLINTNEXTLINE(clang-analyzer-nullability.NullablePassedToNonnull)
     [panel setDirectoryURL: [NSURL fileURLWithPath: [NSString stringWithUTF8String: directory]
                                        isDirectory: YES]];
     [panel setNameFieldStringValue: [NSString stringWithUTF8String: default_filename]];
@@ -1386,6 +1405,8 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
 - (BOOL)windowShouldClose:(NSNotification*)notification
 {
     NSWindow* window = [self window];
+    // +[NSEvent otherEventWithType:...] is declared nullable but will not return
+    // nil for these constant, valid arguments; guard defensively anyway.
     NSEvent* event = [NSEvent otherEventWithType: NSEventTypeApplicationDefined
                                         location: NSZeroPoint
                                    modifierFlags: 0
@@ -1395,7 +1416,9 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
                                          subtype: WINDOW_CLOSING
                                            data1: 0
                                            data2: 0];
-    [NSApp postEvent: event atStart: true];
+    if (event) {
+        [NSApp postEvent: event atStart: true];
+    }
     if ([window respondsToSelector: @selector(closeButtonPressed)]) {
         BOOL closed = [((Window*) window) closeButtonPressed];
         /* If closed, the window has already been closed via the manager. */
@@ -1616,7 +1639,12 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
             }
             [returnkey appendString:specialchar];
         } else {
-            [returnkey appendString:[event charactersIgnoringModifiers]];
+            // charactersIgnoringModifiers is nullable; guard defensively in case
+            // an unexpected event type reaches this path.
+            NSString* chars = [event charactersIgnoringModifiers];
+            if (chars) {
+                [returnkey appendString:chars];
+            }
         }
     } else {
         if (([event modifierFlags] & NSEventModifierFlagShift) || keyChangeShift) {

--- a/src/_path.h
+++ b/src/_path.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <limits>
 #include <string>
@@ -115,6 +116,7 @@ void point_in_path_impl(PointArray &points, PathIterator &path, ResultArray &ins
     bool all_done;
 
     size_t n = safe_first_shape(points);
+    assert(safe_first_shape(inside_flag) >= n);
 
     std::vector<uint8_t> yflag0(n);
     std::vector<uint8_t> subpath_flag(n);
@@ -242,6 +244,7 @@ inline void points_in_path(PointArray &points,
                            agg::trans_affine &trans,
                            ResultArray &result)
 {
+    assert(safe_first_shape(result) >= safe_first_shape(points));
     for (auto i = 0; i < safe_first_shape(points); ++i) {
         result[i] = false;
     }
@@ -270,8 +273,7 @@ inline bool point_in_path(
     *points_arr.mutable_data(0, 1) = y;
     auto points = points_arr.mutable_unchecked<2>();
 
-    int result[1];
-    result[0] = 0;
+    std::array<int, 1> result{};
 
     points_in_path(points, r, path, trans, result);
 
@@ -288,8 +290,7 @@ inline bool point_on_path(
     *points_arr.mutable_data(0, 1) = y;
     auto points = points_arr.mutable_unchecked<2>();
 
-    int result[1];
-    result[0] = 0;
+    std::array<int, 1> result{};
 
     auto trans_path = agg::conv_transform{path, trans};
     auto nan_removed_path = PathNanRemover{trans_path, true, path.has_codes()};

--- a/src/_qhull_wrapper.cpp
+++ b/src/_qhull_wrapper.cpp
@@ -54,7 +54,9 @@ static void
 get_facet_vertices(qhT* qh, const facetT* facet, int indices[3])
 {
     vertexT *vertex, **vertexp;
-    FOREACHvertex_(facet->vertices) {
+    // After qh_triangulate() every non-upperdelaunay facet is a triangle, so
+    // this macro iterates exactly 3 times; the analyzer cannot prove this.
+    FOREACHvertex_(facet->vertices) {  // NOLINT(clang-analyzer-security.ArrayBound)
         *indices++ = qh_pointid(qh, vertex->point);
     }
 }
@@ -66,7 +68,9 @@ get_facet_neighbours(const facetT* facet, std::vector<int>& tri_indices,
                      int indices[3])
 {
     facetT *neighbor, **neighborp;
-    FOREACHneighbor_(facet) {
+    // After qh_triangulate() every non-upperdelaunay facet is a triangle with
+    // exactly 3 neighbors; the analyzer cannot prove this.
+    FOREACHneighbor_(facet) {  // NOLINT(clang-analyzer-security.ArrayBound)
         *indices++ = (neighbor->upperdelaunay ? -1 : tri_indices[neighbor->id]);
     }
 }
@@ -229,7 +233,11 @@ delaunay_impl(py::ssize_t npoints, const double* x, const double* y,
             int indices[3];
             tri_indices[facet->id] = i++;
             get_facet_vertices(qh, facet, indices);
-            *triangles_ptr++ = (facet->toporient ? indices[0] : indices[2]);
+            // The analyzer takes a path where FOREACHvertex_ executes zero
+            // times, leaving indices[] uninitialized.  After qh_triangulate()
+            // every non-upperdelaunay facet is a triangle with exactly 3
+            // vertices, so this cannot happen.
+            *triangles_ptr++ = (facet->toporient ? indices[0] : indices[2]);  // NOLINT(clang-analyzer-core.uninitialized.Assign)
             *triangles_ptr++ = indices[1];
             *triangles_ptr++ = (facet->toporient ? indices[2] : indices[0]);
         }

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -527,7 +527,7 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
         ft_object->load_char(charcode, flags, throwaway, false);
     } else if (fallback) {
         FT_UInt final_glyph_index;
-        FT_Error charcode_error, glyph_error;
+        FT_Error charcode_error = FT_Err_Ok, glyph_error = FT_Err_Ok;
         FT2Font *ft_object_with_glyph = this;
         bool was_found = load_char_with_fallback(ft_object_with_glyph, final_glyph_index,
                                                  glyphs, char_to_font,
@@ -595,6 +595,8 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
                                       FT_Error &glyph_error,
                                       std::set<FT_String*> &glyph_seen_fonts)
 {
+    charcode_error = FT_Err_Ok;
+    glyph_error = FT_Err_Ok;
     FT_UInt glyph_index = FT_Get_Char_Index(face, charcode);
     if (!warn_if_used) {
         glyph_seen_fonts.insert(face->family_name);

--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -53,6 +53,8 @@ enum {
 // so that we don't need to access the NPY_INTP_FMT macro here.
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#include <array>
+#include <cstddef>
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -113,6 +115,14 @@ safe_first_shape(const py::detail::unchecked_reference<T, ND> &a)
         return a.shape(0);
     }
 }
+
+template <typename T, std::size_t N>
+constexpr std::size_t
+safe_first_shape(const std::array<T, N> &)
+{
+    return N;
+}
+
 #endif
 
 #endif

--- a/src/tri/_tri.cpp
+++ b/src/tri/_tri.cpp
@@ -1031,7 +1031,7 @@ int TriContourGenerator::get_exit_edge(int tri,
         case 1: return  2;
         case 2: return  0;
         case 3: return  2;
-        case 4: return  1;
+        case 4: return  1; // NOLINT(bugprone-branch-clone)
         case 5: return  1;
         case 6: return  0;
         case 7: return -1;
@@ -1472,7 +1472,7 @@ TrapezoidMapTriFinder::initialize()
     _tree->assert_valid(false);
 
     // Randomly shuffle all edges other than first 2.
-    std::mt19937 rng(1234);
+    std::mt19937 rng(1234);  // NOLINT(bugprone-random-generator-seed)
     std::shuffle(_edges.begin()+2, _edges.end(), rng);
 
     // Add edges, one at a time, to tree.

--- a/tools/create_DejaVuDisplay.sh
+++ b/tools/create_DejaVuDisplay.sh
@@ -11,11 +11,10 @@
 # generate the new font files `DejaVuSansDisplay.ttf` and
 # `DejaVuSerifDisplay.ttf`:
 
-mpldir=$(dirname $0)/../
+mpldir=$(dirname "$0")/../
 
 # test that fontforge is installed
-python -c 'import fontforge' 2> /dev/null
-if [ $? != 0 ]; then
+if ! python -c 'import fontforge' 2> /dev/null; then
     echo "The python installation at $(which python) does not have fontforge"
     echo "installed. Please install it before using subset.py."
     exit 1
@@ -23,7 +22,7 @@ fi
 
 FONTDIR=$mpldir/lib/matplotlib/mpl-data/fonts/ttf/
 
-python $mpldir/tools/subset.py --move-display --subset=dejavu-ext $FONTDIR/DejaVuSans.ttf \
-    $FONTDIR/DejaVuSansDisplay.ttf
-python $mpldir/tools/subset.py --move-display --subset=dejavu-ext $FONTDIR/DejaVuSerif.ttf \
-    $FONTDIR/DejaVuSerifDisplay.ttf
+python "$mpldir"/tools/subset.py --move-display --subset=dejavu-ext "$FONTDIR"/DejaVuSans.ttf \
+    "$FONTDIR"/DejaVuSansDisplay.ttf
+python "$mpldir"/tools/subset.py --move-display --subset=dejavu-ext "$FONTDIR"/DejaVuSerif.ttf \
+    "$FONTDIR"/DejaVuSerifDisplay.ttf

--- a/tools/run_clang_tidy.py
+++ b/tools/run_clang_tidy.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""
+Run clang-tidy on Matplotlib's C/C++ and Objective-C sources.
+
+Build directory
+---------------
+The script uses ``build/clang-tidy/`` as a dedicated meson build directory.
+If it does not exist it is created automatically via ``meson setup``
+(no compilation takes place).
+
+Prerequisites
+-------------
+``meson``, ``pybind11``, and ``clang-tidy`` must be available.
+
+Usage
+-----
+::
+
+    python tools/run_clang_tidy.py
+"""
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+_VENDORED_RE = re.compile(r"[\\/](extern|subprojects)[\\/]")
+_DIAG_RE = re.compile(r"\S.*: (?:warning|error):")
+
+
+def _filter_clang_tidy_output(text: str) -> str:
+    """
+    Filter clang-tidy output to drop entire diagnostic chains that originate
+    in vendored code (``extern/`` or ``subprojects/``).
+
+    clang-tidy output is structured as diagnostic groups: a ``warning:`` or
+    ``error:`` line followed by ``note:`` lines and source snippets, until the
+    next ``warning:``/``error:`` or end of output.  If the triggering
+    diagnostic is in vendored code, the entire group (including notes that
+    reference our own ``src/`` files as execution-path context) is dropped.
+    """
+    groups: list[list[str]] = []
+    current: list[str] = []
+
+    for line in text.splitlines():
+        if _DIAG_RE.match(line):
+            if current:
+                groups.append(current)
+            current = [line]
+        else:
+            current.append(line)
+
+    if current:
+        groups.append(current)
+
+    kept: list[str] = []
+    for group in groups:
+        header = group[0]
+        if _DIAG_RE.match(header) and _VENDORED_RE.search(header):
+            continue
+        kept.extend(group)
+
+    return "\n".join(kept)
+
+
+def main() -> None:
+    repo_root = Path(__file__).resolve().parent.parent
+    build_dir = repo_root / "build" / "clang-tidy"
+
+    result = subprocess.run(
+        ["meson", "setup", "--reconfigure", str(build_dir)],
+        cwd=repo_root,
+    )
+    if result.returncode != 0:
+        sys.exit(result.returncode)
+
+    result = subprocess.run(
+        [
+            "meson",
+            "--internal",
+            "clangtidy",
+            str(repo_root),
+            str(build_dir),
+            "--color",
+            "never",
+        ],
+        cwd=build_dir,
+        capture_output=True,
+        text=True,
+    )
+
+    filtered = _filter_clang_tidy_output(result.stdout)
+    if filtered:
+        print(filtered)
+    if result.stderr:
+        print(result.stderr, end="", file=sys.stderr)
+
+    sys.exit(result.returncode)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## PR summary

This adds more static analysis to our CI / prek config.

- run `clang-tidy` on c/c++/objectiveC code (and fix or ignore issues found).  This found a couple of real issues and will only run on CI (+ a helper script to run it locally).  The dependencies are too heavy to try and launder through prek's virtual environments. 
- run zizmor in prek (and hence automatically on CI).  Had to explictily allow the 4 places we use `pull_request_target` and a couple of places we allow caching.  Also enabled cooldown windows on our dependabot config.  This also flagged we had a redundant checkout step in 
- enable shellcheck in prek to hit the handful of bash scripts we ship and applied the hardening it found.
- ~run ruff on our checked in notebooks as well~  Our exsiting ruff config hits this already
- added static validation of svg files to prek (I got in my head that this could be used to get information out of developer's machines which is probably not possible (beyond what you give up by going to any website)), but now it will be harder for someone to sneak an active SVG into our baseline images.


Not reflected in the commits here, but I did look at https://github.com/PyCQA/bandit but every single thing it flagged was a false positive (either flagging things like `exec` in the plot directive or being too simplistic to notice that we had already mitigated the thing it was flagging in the code).  

## AI Disclosure

I started from the prompt

```
Analyze this repository and identify any programming languages, markup languages, document formats, build artifacts, generated files, embedded assets, or other non-core technologies that could be overlooked by traditional SAST or standard code-scanning tools.

Focus especially on:

languages or file types that are not part of the repository's primary tech stack
obscure, uncommon, legacy, or less frequently scanned formats
executable or scriptable content hidden in non-obvious places
document or graphics formats that may contain logic, macros, scripts, links, or embedded content
Include examples such as LaTeX, PostScript, SVG, and similar formats, but do not limit the analysis to those.

For each item you identify, provide:

the language, format, or artifact type
why it may be missed by classic SAST or scanning tools
the security relevance or potential risk
typical file extensions or repository locations where it may appear
whether it is likely source, generated output, embedded content, or supporting artifact
```

with opus 4.6 and then pushing on addressing the coverage with a mix of opus 4.6 and sonnet 4.6.  I reviewed everything as I committed it and took a very heavy editing pass at the initial version of the documentation.


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
