### PR TITLE
docs: clarify markevery float spacing

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -592,9 +592,10 @@ class Line2D(Artist):
         -----
         Setting *markevery* will still only draw markers at actual data points.
         While the float argument form aims for uniform visual spacing, it has
-        to coerce from the ideal spacing to the nearest available data point.
-        Depending on the number and distribution of data points, the result
-        may still not look evenly spaced.
+        to coerce from the ideal spacing along the drawn line to the nearest
+        available data point. Depending on the number and distribution of data
+        points, and on how jagged the line is, the result may still not look
+        evenly spaced along the x- or y-axis.
 
         When using a start offset to specify the first marker, the offset will
         be from the first data point which may be different from the first


### PR DESCRIPTION
## PR summary

Closes #27842.

Clarify the `Line2D.set_markevery` docstring for float `markevery` values. The updated wording explains that the ideal spacing is measured along the drawn line and then coerced to the nearest data point, so jagged lines may not appear evenly spaced along the x- or y-axis.

Validation:
- `python -m py_compile lib\matplotlib\lines.py`
- `git diff --check`
- Parsed `lib/matplotlib/lines.py` with `ast` to confirm the updated `Line2D.set_markevery` docstring contains the new wording.

## AI Disclosure

I used Codex locally to help identify the issue, draft the wording, and run validation. I reviewed the final one-file diff before opening this PR.

## PR checklist

- [x] "closes #27842" is in the body of the PR description to link the related issue
- [N/A] new and changed code is tested: this is a docstring-only change, validated with `py_compile`, `git diff --check`, and an AST docstring check
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines
