### PR TITLE
plt.stairs: fix unit handling for orientation="horizontal"

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7827,8 +7827,12 @@ such objects
         if edges is None:
             edges = np.arange(len(values) + 1)
 
-        edges, values, baseline = self._process_unit_info(
-            [("x", edges), ("y", values), ("y", baseline)], kwargs)
+        if orientation == "vertical":
+            edges, values, baseline = self._process_unit_info(
+                [("x", edges), ("y", values), ("y", baseline)], kwargs)
+        else:
+            edges, values, baseline = self._process_unit_info(
+                [("y", edges), ("x", values), ("x", baseline)], kwargs)
 
         patch = mpatches.StepPatch(values,
                                    edges,


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
plt.stairs or Axes.stairs calls `self._process_unit_info` as required for e.g. time dimensions on one axis. This PR introduces a distinction between vertical and horizontal orientation to fix the unit processing for orientation="horizontal".

### Example
```python
>>> import matplotlib.pyplot as plt
>>> import numpy as np
>>> times = np.arange(10).astype("M8[Y]")
>>> plt.stairs(np.random.random(9), times, orientation="horizontal")
<matplotlib.patches.StepPatch object at 0x7f5a834a3410>
>>> plt.show()
>>> # Old behavior: sets the x axis to time coordinates, but the y axis should contain time values.
>>> # New behavior: sets the y axis to time coordinates.
```

## AI Disclosure
No AI was used for this PR.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
