### PR TITLE
Backport an additional fix to qhull printf strings

### DIFF
--- a/subprojects/packagefiles/qhull-143.patch
+++ b/subprojects/packagefiles/qhull-143.patch
@@ -1,11 +1,13 @@
-From cd8c281da87d38820ecc4c452bbf6fd921155915 Mon Sep 17 00:00:00 2001
+From 61c21986f4ebd1fb68b615ac89231ad1173f6b84 Mon Sep 17 00:00:00 2001
 From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 Date: Thu, 28 Mar 2024 00:54:59 -0400
-Subject: [PATCH 1/3] Annotate printf-like functions with GCC's format
+Subject: [PATCH 1/4] Annotate printf-like functions with GCC's format
  attribute
 
 This allows checking format strings when building with `-Wformat` (or
 with `-Wall`).
+
+Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 ---
  src/libqhull/libqhull.h     | 13 ++++++++++---
  src/libqhull_r/libqhull_r.h | 13 ++++++++++---
@@ -13,7 +15,7 @@ with `-Wall`).
  3 files changed, 22 insertions(+), 8 deletions(-)
 
 diff --git a/src/libqhull/libqhull.h b/src/libqhull/libqhull.h
-index 90c0519b..1080ec11 100644
+index 90c0519..1080ec1 100644
 --- a/src/libqhull/libqhull.h
 +++ b/src/libqhull/libqhull.h
 @@ -60,6 +60,13 @@
@@ -48,7 +50,7 @@ index 90c0519b..1080ec11 100644
  /***** -geom.c/geom2.c/random.c prototypes (duplicated from geom.h, random.h) ****************/
  
 diff --git a/src/libqhull_r/libqhull_r.h b/src/libqhull_r/libqhull_r.h
-index 023e0181..917f96af 100644
+index 376c1e2..b5185bc 100644
 --- a/src/libqhull_r/libqhull_r.h
 +++ b/src/libqhull_r/libqhull_r.h
 @@ -48,6 +48,13 @@
@@ -83,7 +85,7 @@ index 023e0181..917f96af 100644
  /***** -geom_r.c/geom2_r.c/random_r.c prototypes (duplicated from geom_r.h, random_r.h) ****************/
  
 diff --git a/src/testqset_r/testqset_r.c b/src/testqset_r/testqset_r.c
-index 671494f3..b0253e0e 100644
+index 671494f..b0253e0 100644
 --- a/src/testqset_r/testqset_r.c
 +++ b/src/testqset_r/testqset_r.c
 @@ -117,7 +117,7 @@ int error_count= 0;  /* Global error_count.  checkSetContents(qh) keeps its own
@@ -104,12 +106,16 @@ index 671494f3..b0253e0e 100644
  void    qh_fprintf(qhT *qh, FILE *fp, int msgcode, const char *fmt, ... )
  {
      static int needs_cr= 0;  /* True if qh_fprintf needs a CR. testqset_r is not itself reentrant */
+-- 
+2.54.0
 
-From cc7e366259866d4cd24a312a4aaf891ff0abe85a Mon Sep 17 00:00:00 2001
+
+From 14f0beeffbfb2505c5b0bf4b8d1b0981025461f5 Mon Sep 17 00:00:00 2001
 From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 Date: Thu, 28 Mar 2024 01:05:06 -0400
-Subject: [PATCH 2/3] Fix arguments inconsistent with their format strings
+Subject: [PATCH 2/4] Fix arguments inconsistent with their format strings
 
+Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 ---
  src/libqhull/global.c       |  2 +-
  src/libqhull/merge.c        | 11 +++++------
@@ -123,7 +129,7 @@ Subject: [PATCH 2/3] Fix arguments inconsistent with their format strings
  9 files changed, 28 insertions(+), 28 deletions(-)
 
 diff --git a/src/libqhull/global.c b/src/libqhull/global.c
-index 27babbb4..faf67f37 100644
+index 9a81001..47dc46d 100644
 --- a/src/libqhull/global.c
 +++ b/src/libqhull/global.c
 @@ -2248,7 +2248,7 @@ void qh_lib_check(int qhullLibraryType, int qhTsize, int vertexTsize, int ridgeT
@@ -136,7 +142,7 @@ index 27babbb4..faf67f37 100644
      }
      if (last_errcode) {
 diff --git a/src/libqhull/merge.c b/src/libqhull/merge.c
-index de3a0b00..89392dc6 100644
+index de3a0b0..89392dc 100644
 --- a/src/libqhull/merge.c
 +++ b/src/libqhull/merge.c
 @@ -427,7 +427,7 @@ void qh_appendmergeset(facetT *facet, facetT *neighbor, mergeType mergetype, coo
@@ -186,7 +192,7 @@ index de3a0b00..89392dc6 100644
                ridge->mergevertex= True; /* disables check for duplicate vertices in qh_checkfacet */
                ridgeA->mergevertex= True;
 diff --git a/src/libqhull/poly2.c b/src/libqhull/poly2.c
-index 0bdfa6d6..9077b9c3 100644
+index 4a207b8..b30a2b6 100644
 --- a/src/libqhull/poly2.c
 +++ b/src/libqhull/poly2.c
 @@ -1144,7 +1144,7 @@ boolT qh_checklists(facetT *facetlist) {
@@ -209,7 +215,7 @@ index 0bdfa6d6..9077b9c3 100644
          facet->flipped= False;
          facet->toporient ^= (unsigned char)True;
 diff --git a/src/libqhull_r/global_r.c b/src/libqhull_r/global_r.c
-index 3a0b9c62..c681a715 100644
+index 04b9b4d..01dfe8e 100644
 --- a/src/libqhull_r/global_r.c
 +++ b/src/libqhull_r/global_r.c
 @@ -2201,7 +2201,7 @@ void qh_lib_check(int qhullLibraryType, int qhTsize, int vertexTsize, int ridgeT
@@ -222,7 +228,7 @@ index 3a0b9c62..c681a715 100644
      }
      if (last_errcode) {
 diff --git a/src/libqhull_r/mem_r.c b/src/libqhull_r/mem_r.c
-index 7d5509eb..d811f733 100644
+index 7d5509e..d811f73 100644
 --- a/src/libqhull_r/mem_r.c
 +++ b/src/libqhull_r/mem_r.c
 @@ -186,7 +186,7 @@ void qh_memcheck(qhT *qh) {
@@ -244,7 +250,7 @@ index 7d5509eb..d811f733 100644
  
  /*-<a                             href="qh-mem_r.htm#TOC"
 diff --git a/src/libqhull_r/merge_r.c b/src/libqhull_r/merge_r.c
-index f3c899cd..55a86afd 100644
+index f3c899c..55a86af 100644
 --- a/src/libqhull_r/merge_r.c
 +++ b/src/libqhull_r/merge_r.c
 @@ -427,7 +427,7 @@ void qh_appendmergeset(qhT *qh, facetT *facet, facetT *neighbor, mergeType merge
@@ -294,7 +300,7 @@ index f3c899cd..55a86afd 100644
                ridge->mergevertex= True; /* disables check for duplicate vertices in qh_checkfacet */
                ridgeA->mergevertex= True;
 diff --git a/src/libqhull_r/poly2_r.c b/src/libqhull_r/poly2_r.c
-index 01758340..4d9a0c51 100644
+index 1ab5244..a97254e 100644
 --- a/src/libqhull_r/poly2_r.c
 +++ b/src/libqhull_r/poly2_r.c
 @@ -1145,7 +1145,7 @@ boolT qh_checklists(qhT *qh, facetT *facetlist) {
@@ -317,7 +323,7 @@ index 01758340..4d9a0c51 100644
          facet->flipped= False;
          facet->toporient ^= (unsigned char)True;
 diff --git a/src/libqhullcpp/Qhull.cpp b/src/libqhullcpp/Qhull.cpp
-index d5c75e92..3123e8ae 100644
+index d5c75e9..3123e8a 100644
 --- a/src/libqhullcpp/Qhull.cpp
 +++ b/src/libqhullcpp/Qhull.cpp
 @@ -357,7 +357,7 @@ initializeFeasiblePoint(int hulldim)
@@ -330,7 +336,7 @@ index d5c75e92..3123e8ae 100644
          }
          qh_qh->feasible_point= static_cast<coordT*>(qh_malloc(static_cast<size_t>(hulldim) * sizeof(coordT)));
 diff --git a/src/testqset_r/testqset_r.c b/src/testqset_r/testqset_r.c
-index b0253e0e..5ea87394 100644
+index b0253e0..5ea8739 100644
 --- a/src/testqset_r/testqset_r.c
 +++ b/src/testqset_r/testqset_r.c
 @@ -532,7 +532,7 @@ void testSetequalInEtc(qhT *qh, int numInts, int *intarray, int checkEvery)
@@ -380,19 +386,23 @@ index b0253e0e..5ea87394 100644
              error_count++;
          }
      }
+-- 
+2.54.0
 
-From f7c3bbdfd23c034f5af66fa1f067691aac3378d8 Mon Sep 17 00:00:00 2001
+
+From 2dda51b2f2ec394462cb95ce37b5afc9701c8446 Mon Sep 17 00:00:00 2001
 From: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 Date: Thu, 28 Mar 2024 05:11:33 -0400
-Subject: [PATCH 3/3] Don't pass user-defined input as format string
+Subject: [PATCH 3/4] Don't pass user-defined input as format string
 
+Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
 ---
  src/libqhull/io.c     | 2 +-
  src/libqhull_r/io_r.c | 2 +-
  2 files changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/libqhull/io.c b/src/libqhull/io.c
-index beed156a..7b7f4546 100644
+index beed156..7b7f454 100644
 --- a/src/libqhull/io.c
 +++ b/src/libqhull/io.c
 @@ -1618,7 +1618,7 @@ void qh_printcenter(FILE *fp, qh_PRINT format, const char *string, facetT *facet
@@ -405,7 +415,7 @@ index beed156a..7b7f4546 100644
      num= qh hull_dim-1;
      if (!facet->normal || !facet->upperdelaunay || !qh ATinfinity) {
 diff --git a/src/libqhull_r/io_r.c b/src/libqhull_r/io_r.c
-index a80a5b14..389b1aa6 100644
+index a80a5b1..389b1aa 100644
 --- a/src/libqhull_r/io_r.c
 +++ b/src/libqhull_r/io_r.c
 @@ -1618,7 +1618,7 @@ void qh_printcenter(qhT *qh, FILE *fp, qh_PRINT format, const char *string, face
@@ -417,3 +427,48 @@ index a80a5b14..389b1aa6 100644
    if (qh->CENTERtype == qh_ASvoronoi) {
      num= qh->hull_dim-1;
      if (!facet->normal || !facet->upperdelaunay || !qh->ATinfinity) {
+-- 
+2.54.0
+
+
+From b6d5a184cd64d160a50d799ad8b179efeffed121 Mon Sep 17 00:00:00 2001
+From: Brad Barber <bradb@shore.net>
+Date: Sun, 7 Sep 2025 14:52:49 -0400
+Subject: [PATCH 4/4] poly2.c, poly2_r.c: fixed missing
+ 'getid_(previousvertex)' for #143
+
+Signed-off-by: Elliott Sales de Andrade <quantum.analyst@gmail.com>
+---
+ src/libqhull/poly2.c     | 2 +-
+ src/libqhull_r/poly2_r.c | 2 +-
+ 2 files changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/src/libqhull/poly2.c b/src/libqhull/poly2.c
+index b30a2b6..f70180e 100644
+--- a/src/libqhull/poly2.c
++++ b/src/libqhull/poly2.c
+@@ -1144,7 +1144,7 @@ boolT qh_checklists(facetT *facetlist) {
+       vertex->visitid= qh vertex_visit;
+       if (vertex->previous != previousvertex) {
+         qh_fprintf(qh ferr, 6427, "qhull internal error (qh_checklists): expecting v%d.previous == v%d.  Got v%d\n",
+-              vertex->id, previousvertex->id, getid_(vertex->previous));
++              vertex->id, getid_(previousvertex), getid_(vertex->previous));
+         waserror= True;
+         errorvertex= vertex;
+       }
+diff --git a/src/libqhull_r/poly2_r.c b/src/libqhull_r/poly2_r.c
+index a97254e..44110db 100644
+--- a/src/libqhull_r/poly2_r.c
++++ b/src/libqhull_r/poly2_r.c
+@@ -1145,7 +1145,7 @@ boolT qh_checklists(qhT *qh, facetT *facetlist) {
+       vertex->visitid= qh->vertex_visit;
+       if (vertex->previous != previousvertex) {
+         qh_fprintf(qh, qh->ferr, 6427, "qhull internal error (qh_checklists): expecting v%d.previous == v%d.  Got v%d\n",
+-              vertex->id, previousvertex->id, getid_(vertex->previous));
++              vertex->id, getid_(previousvertex), getid_(vertex->previous));
+         waserror= True;
+         errorvertex= vertex;
+       }
+-- 
+2.54.0
+


### PR DESCRIPTION
## PR summary

Some time after my PR was merged, an additional commit was made to the upstream repository fixing a missed NULL check on an internal error message:
https://github.com/qhull/qhull/commit/d1c2fc0caa5f644f3a0f220290d4a868c68ed4f6

I have backported the patch, dropping the changelog, and reverting all the whitespace changes so that the change is minimal.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines