### PR TITLE
MNT: Make a note that setuptools-scm can be unpinned

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ requires = [
     # you really need it and aren't using an sdist.
     "meson-python>=0.13.2,!=0.17.*",
     "pybind11>=2.13.2,!=2.13.3",
+    # setuptools_scm 10 breaks versioning in editable installs. You can remove this pin
+    # if you're a downstream distributor just building wheels or your equivalent.
     "setuptools_scm>=7,<10",
 ]
 


### PR DESCRIPTION
## PR summary

This is fine for non-developers and downstream distributors.

## AI Disclosure
None

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines