### PR TITLE
Fix Axes.clear() crash for custom spine types

### DIFF
--- a/lib/matplotlib/spines.py
+++ b/lib/matplotlib/spines.py
@@ -208,9 +208,13 @@ class Spine(mpatches.Patch):
 
     def _ensure_transform_is_set(self):
         # Install the default blended transform if the spine still carries
-        # the placeholder from Spine.__init__. No-op for spines whose
-        # transform was set explicitly (e.g. via set_patch_arc/_circle).
-        if self._position is None and self._transform is self.axes.transData:
+        # the placeholder from Spine.__init__. Restricted to the standard
+        # cartesian spines: set_position/get_spine_transform only support
+        # those, and other spines (polar, cartopy's GeoSpine) manage their
+        # own transform.
+        if (self.spine_type in ('left', 'right', 'top', 'bottom')
+                and self._position is None
+                and self._transform is self.axes.transData):
             self.set_position(('outward', 0.0))
 
     def register_axis(self, axis):

--- a/lib/matplotlib/tests/test_spines.py
+++ b/lib/matplotlib/tests/test_spines.py
@@ -1,8 +1,9 @@
 import numpy as np
 import pytest
 
+import matplotlib.path as mpath
 import matplotlib.pyplot as plt
-from matplotlib.spines import Spines
+from matplotlib.spines import Spine, Spines
 from matplotlib.testing.decorators import check_figures_equal, image_comparison
 
 
@@ -197,3 +198,19 @@ def test_spine_set_bounds_with_none():
         "left bound should be numeric"
     assert np.isclose(left_bound[0], ylim[0]), "Lower bound should match original value"
     assert np.isclose(left_bound[1], ylim[1]), "Upper bound should match original value"
+
+
+def test_clear_with_custom_spine_type():
+    # Spines with a non-cartesian spine_type (e.g. cartopy's GeoSpine) manage
+    # their own transform and may reject set_position(); Axes.clear() must not
+    # call _ensure_transform_is_set() on them. See SciTools/cartopy#2674.
+    class NoPositionSpine(Spine):
+        def __init__(self, axes, **kwargs):
+            super().__init__(axes, 'geo', mpath.Path(np.empty((0, 2))), **kwargs)
+
+        def set_position(self, position):
+            raise NotImplementedError('spine does not support set_position')
+
+    fig, ax = plt.subplots()
+    ax.spines['geo'] = NoPositionSpine(ax)
+    ax.clear()  # must not raise


### PR DESCRIPTION
## PR summary

PR #31525 added a spine-transform nudge in Axes.__clear that calls Spine._ensure_transform_is_set() on every spine. For a spine still carrying the placeholder transform from `Spine.__init__`, this calls set_position(('outward', 0.0)).

Custom spines with a non-cartesian spine_type — e.g. cartopy's GeoSpine — manage their own transform and may reject set_position(), so this raised NotImplementedError on plain subplot creation (SciTools/cartopy#2674).

The nudge now only fires for the four standard cartesian spine types (left, right, top, bottom), the only ones set_position / get_spine_transform support.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->


<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure

Claude code was used in creating a PR.

<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
