### PR TITLE
Fix violinplot crash on empty datasets (#31700)

### DIFF
--- a/doc/api/next_api_changes/behavior/violinplot_empty.rst
+++ b/doc/api/next_api_changes/behavior/violinplot_empty.rst
@@ -1,0 +1,4 @@
+Axes.violinplot and cbook.violin_stats safely handle empty datasets
+-------------------------------------------------------------------
+
+`~matplotlib.axes.Axes.violinplot` and `matplotlib.cbook.violin_stats` now safely handle empty datasets without crashing and automatically drop masked/non-finite values.

--- a/doc/api/next_api_changes/behavior/violinplot_empty.rst
+++ b/doc/api/next_api_changes/behavior/violinplot_empty.rst
@@ -1,4 +1,4 @@
-Axes.violinplot and cbook.violin_stats safely handle empty datasets
--------------------------------------------------------------------
+Axes.violinplot and cbook.violin_stats ignore non-finite values
+---------------------------------------------------------------
 
-`~matplotlib.axes.Axes.violinplot` and `matplotlib.cbook.violin_stats` now safely handle empty datasets without crashing and ignore masked and non-finite values.
+`~matplotlib.axes.Axes.violinplot` and `matplotlib.cbook.violin_stats` now ignore masked and non-finite (NaN and inf) values.

--- a/doc/api/next_api_changes/behavior/violinplot_empty.rst
+++ b/doc/api/next_api_changes/behavior/violinplot_empty.rst
@@ -1,4 +1,4 @@
 Axes.violinplot and cbook.violin_stats safely handle empty datasets
 -------------------------------------------------------------------
 
-`~matplotlib.axes.Axes.violinplot` and `matplotlib.cbook.violin_stats` now safely handle empty datasets without crashing and automatically drop masked/non-finite values.
+`~matplotlib.axes.Axes.violinplot` and `matplotlib.cbook.violin_stats` now safely handle empty datasets without crashing and ignore masked and non-finite values.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8958,7 +8958,7 @@ such objects
             - sequence of 1D arrays: A violin is drawn for each array in the sequence.
             - 2D array: A violin is drawn for each column in the array.
 
-            NaN, infinite values, and masked points are automatically stripped.
+            Non-finite and masked values are ignored.
 
         positions : array-like, default: [1, 2, ..., n]
             The positions of the violins; i.e. coordinates on the x-axis for

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -9329,7 +9329,8 @@ such objects
         for stats, pos, width, facecolor in bodies_zip:
             # The 0.5 factor reflects the fact that we plot from v-p to v+p.
             vals = np.array(stats['vals'])
-            vals = 0.5 * width * vals / vals.max()
+            if len(vals) != 0:
+                vals = 0.5 * width * vals / vals.max()
             bodies += [fill(stats['coords'],
                             -vals + pos if side in ['both', 'low'] else pos,
                             vals + pos if side in ['both', 'high'] else pos,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -9329,7 +9329,7 @@ such objects
         for stats, pos, width, facecolor in bodies_zip:
             # The 0.5 factor reflects the fact that we plot from v-p to v+p.
             vals = np.array(stats['vals'])
-            if len(vals) != 0:
+            if len(vals) > 0:
                 vals = 0.5 * width * vals / vals.max()
             bodies += [fill(stats['coords'],
                             -vals + pos if side in ['both', 'low'] else pos,

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8958,6 +8958,8 @@ such objects
             - sequence of 1D arrays: A violin is drawn for each array in the sequence.
             - 2D array: A violin is drawn for each column in the array.
 
+            NaN, infinite values, and masked points are automatically stripped.
+
         positions : array-like, default: [1, 2, ..., n]
             The positions of the violins; i.e. coordinates on the x-axis for
             vertical violins (or y-axis for horizontal violins).

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1593,6 +1593,9 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
         # note tricksiness, append up here and then mutate below
         vpstats.append(stats)
 
+        x = np.asarray(x)
+        x = x[~(np.isnan(x) | np.isinf(x))]
+
         # if empty, bail
         if len(x) == 0:
             stats['vals'] = np.array([])

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1602,23 +1602,25 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
             stats['min'] = np.nan
             stats['max'] = np.nan
             stats['quantiles'] = np.array([])
-        else:
-            # Calculate basic stats for the distribution
-            min_val = np.min(x)
-            max_val = np.max(x)
-            quantile_val = np.percentile(x, 100 * q)
+            vpstats.append(stats)
+            continue
 
-            # Evaluate the kernel density estimate
-            coords = np.linspace(min_val, max_val, points)
-            stats['vals'] = method(x, coords)
-            stats['coords'] = coords
+        # Calculate basic stats for the distribution
+        min_val = np.min(x)
+        max_val = np.max(x)
+        quantile_val = np.percentile(x, 100 * q)
 
-            # Store additional statistics for this distribution
-            stats['mean'] = np.mean(x)
-            stats['median'] = np.median(x)
-            stats['min'] = min_val
-            stats['max'] = max_val
-            stats['quantiles'] = np.atleast_1d(quantile_val)
+        # Evaluate the kernel density estimate
+        coords = np.linspace(min_val, max_val, points)
+        stats['vals'] = method(x, coords)
+        stats['coords'] = coords
+
+        # Store additional statistics for this distribution
+        stats['mean'] = np.mean(x)
+        stats['median'] = np.median(x)
+        stats['min'] = min_val
+        stats['max'] = max_val
+        stats['quantiles'] = np.atleast_1d(quantile_val)
 
         vpstats.append(stats)
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1590,6 +1590,18 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
         # Dictionary of results for this distribution
         stats = {}
 
+        # if empty, bail
+        if len(x) == 0:
+            stats['vals'] = np.array([])
+            stats['coords'] = np.array([])
+            stats['mean'] = np.nan
+            stats['median'] = np.nan
+            stats['min'] = np.nan
+            stats['max'] = np.nan
+            stats['quantiles'] = np.array([])
+            vpstats.append(stats)
+            continue
+
         # Calculate basic stats for the distribution
         min_val = np.min(x)
         max_val = np.max(x)

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1586,43 +1586,35 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
                          " must have the same length")
 
     # Zip x and quantiles
-    for (x, q) in zip(X, quantiles):
-        # Dictionary of results for this distribution
-        stats = {}
-
+    for (x, quantile) in zip(X, quantiles):
+        # Drop NaNs and infs before length check to safely handle all-NaN datasets
         x = np.asarray(x)
         x = x[~(np.isnan(x) | np.isinf(x))]
 
-        # if empty, bail
         if len(x) == 0:
-            stats['vals'] = np.array([])
-            stats['coords'] = np.array([])
-            stats['mean'] = np.nan
-            stats['median'] = np.nan
-            stats['min'] = np.nan
-            stats['max'] = np.nan
-            stats['quantiles'] = np.array([])
-            vpstats.append(stats)
-            continue
+            vpstats.append({
+                'vals': np.array([]),
+                'coords': np.array([]),
+                'mean': np.nan,
+                'median': np.nan,
+                'min': np.nan,
+                'max': np.nan,
+                'quantiles': np.array([]),
+            })
+        else:
+            min_val = np.min(x)
+            max_val = np.max(x)
+            coords = np.linspace(min_val, max_val, points)
 
-        # Calculate basic stats for the distribution
-        min_val = np.min(x)
-        max_val = np.max(x)
-        quantile_val = np.percentile(x, 100 * q)
-
-        # Evaluate the kernel density estimate
-        coords = np.linspace(min_val, max_val, points)
-        stats['vals'] = method(x, coords)
-        stats['coords'] = coords
-
-        # Store additional statistics for this distribution
-        stats['mean'] = np.mean(x)
-        stats['median'] = np.median(x)
-        stats['min'] = min_val
-        stats['max'] = max_val
-        stats['quantiles'] = np.atleast_1d(quantile_val)
-
-        vpstats.append(stats)
+            vpstats.append({
+                'vals': method(x, coords),
+                'coords': coords,
+                'mean': np.mean(x),
+                'median': np.median(x),
+                'min': min_val,
+                'max': max_val,
+                'quantiles': np.atleast_1d(np.percentile(x, 100 * quantile))
+            })
 
     return vpstats
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1590,9 +1590,6 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
         # Dictionary of results for this distribution
         stats = {}
 
-        # note tricksiness, append up here and then mutate below
-        vpstats.append(stats)
-
         x = np.asarray(x)
         x = x[~(np.isnan(x) | np.isinf(x))]
 
@@ -1605,24 +1602,25 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
             stats['min'] = np.nan
             stats['max'] = np.nan
             stats['quantiles'] = np.array([])
-            continue
+        else:
+            # Calculate basic stats for the distribution
+            min_val = np.min(x)
+            max_val = np.max(x)
+            quantile_val = np.percentile(x, 100 * q)
+    
+            # Evaluate the kernel density estimate
+            coords = np.linspace(min_val, max_val, points)
+            stats['vals'] = method(x, coords)
+            stats['coords'] = coords
+    
+            # Store additional statistics for this distribution
+            stats['mean'] = np.mean(x)
+            stats['median'] = np.median(x)
+            stats['min'] = min_val
+            stats['max'] = max_val
+            stats['quantiles'] = np.atleast_1d(quantile_val)
 
-        # Calculate basic stats for the distribution
-        min_val = np.min(x)
-        max_val = np.max(x)
-        quantile_val = np.percentile(x, 100 * q)
-
-        # Evaluate the kernel density estimate
-        coords = np.linspace(min_val, max_val, points)
-        stats['vals'] = method(x, coords)
-        stats['coords'] = coords
-
-        # Store additional statistics for this distribution
-        stats['mean'] = np.mean(x)
-        stats['median'] = np.median(x)
-        stats['min'] = min_val
-        stats['max'] = max_val
-        stats['quantiles'] = np.atleast_1d(quantile_val)
+        vpstats.append(stats)
 
     return vpstats
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1589,7 +1589,7 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
     # Zip x and quantiles
     for (x, quantile) in zip(X, quantiles):
         x = np.asarray(x)
-        x = x[~(np.isnan(x) | np.isinf(x))]
+        x, = delete_masked_points(x)
 
         if len(x) == 0:
             vpstats.append({

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1499,7 +1499,7 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
     ----------
     X : 1D array or sequence of 1D arrays or 2D array
         Sample data that will be used to produce the gaussian kernel density
-        estimates. NaN and infinite values are automatically stripped.
+        estimates. Non-finite and masked values are ignored.
         Possible values:
 
         - 1D array: Statistics are computed for that array.

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1590,6 +1590,9 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
         # Dictionary of results for this distribution
         stats = {}
 
+        # note tricksiness, append up here and then mutate below
+        vpstats.append(stats)
+
         # if empty, bail
         if len(x) == 0:
             stats['vals'] = np.array([])
@@ -1599,7 +1602,6 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
             stats['min'] = np.nan
             stats['max'] = np.nan
             stats['quantiles'] = np.array([])
-            vpstats.append(stats)
             continue
 
         # Calculate basic stats for the distribution
@@ -1618,9 +1620,6 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
         stats['min'] = min_val
         stats['max'] = max_val
         stats['quantiles'] = np.atleast_1d(quantile_val)
-
-        # Append to output
-        vpstats.append(stats)
 
     return vpstats
 

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1499,8 +1499,8 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
     ----------
     X : 1D array or sequence of 1D arrays or 2D array
         Sample data that will be used to produce the gaussian kernel density
-        estimates. Must have a length of at least 1. NaN and infinite values are
-        automatically stripped. Possible values:
+        estimates. NaN and infinite values are automatically stripped.
+        Possible values:
 
         - 1D array: Statistics are computed for that array.
         - sequence of 1D arrays: Statistics are computed for each array in the sequence.

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1607,12 +1607,12 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
             min_val = np.min(x)
             max_val = np.max(x)
             quantile_val = np.percentile(x, 100 * q)
-    
+
             # Evaluate the kernel density estimate
             coords = np.linspace(min_val, max_val, points)
             stats['vals'] = method(x, coords)
             stats['coords'] = coords
-    
+
             # Store additional statistics for this distribution
             stats['mean'] = np.mean(x)
             stats['median'] = np.median(x)

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1499,7 +1499,8 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
     ----------
     X : 1D array or sequence of 1D arrays or 2D array
         Sample data that will be used to produce the gaussian kernel density
-        estimates. Possible values:
+        estimates. Must have a length of at least 1. NaN and infinite values are
+        automatically stripped. Possible values:
 
         - 1D array: Statistics are computed for that array.
         - sequence of 1D arrays: Statistics are computed for each array in the sequence.
@@ -1587,7 +1588,6 @@ def violin_stats(X, method=("GaussianKDE", "scott"), points=100, quantiles=None)
 
     # Zip x and quantiles
     for (x, quantile) in zip(X, quantiles):
-        # Drop NaNs and infs before length check to safely handle all-NaN datasets
         x = np.asarray(x)
         x = x[~(np.isnan(x) | np.isinf(x))]
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10410,4 +10410,5 @@ def test_errorbar_uses_rcparams():
 def test_violinplot_empty_dataset():
     fig, ax = plt.subplots()
     # This should not raise an exception
-    ax.violinplot([np.random.randn(100), []])
+    parts = ax.violinplot([np.random.randn(100), [], [np.nan, np.nan]])
+    assert len(parts["bodies"]) == 3

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10405,3 +10405,9 @@ def test_errorbar_uses_rcparams():
     assert_allclose([cap.get_markeredgewidth() for cap in caplines], 2.5)
     for barcol in barlinecols:
         assert_allclose(barcol.get_linewidths(), 1.75)
+
+
+def test_violinplot_empty_dataset():
+    fig, ax = plt.subplots()
+    # This should not raise an exception
+    ax.violinplot([np.random.randn(100), []])


### PR DESCRIPTION
## PR summary
closes #31700

This PR fixes a bug where passing an empty dataset to `violinplot` causes it to crash (`ValueError: zero-size array to reduction operation minimum`), whereas `boxplot` handles the exact same scenario gracefully by simply drawing nothing.

**Reasoning for this implementation:**
I updated `cbook.violin_stats` to check if the input dataset is empty. If it is, it bypasses the min/max/KDE math operations and returns an empty stats dictionary for that specific dataset. I also added a safeguard in `axes.violin` to prevent width-scaling calculations on empty density arrays. 

This allows `violinplot` to safely skip rendering violins for empty datasets, perfectly mirroring the resilient behavior of `boxplot`. I have also included a regression test to ensure this remains fixed.

## AI Disclosure
I used an AI assistant strictly to help navigate the codebase, locate the specific statistics functions in `cbook.py` and `_axes.py`, and draft the boilerplate for the pytest. The core logic was manually reviewed, applied, and tested locally to ensure complete compliance with Matplotlib's standards.

## PR checklist
- [x] "closes #31700" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines