### PR TITLE
BUG: Fix box_handle_props initialization in PolygonSelector

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1717,6 +1717,44 @@ def test_polygon_selector_box(ax):
         tool._box.extents, (20.0, 40.0, 30.0, 40.0))
 
 
+def test_polygon_selector_box_props_handle_props(ax):
+    props = dict(color='r')
+    handle_props = dict(marker='o', markerfacecolor='w', markeredgecolor='r')
+    box_props = dict(linestyle=':', facecolor='c', edgecolor='b')
+    box_handle_props = dict(markeredgecolor='y')
+
+    tool = widgets.PolygonSelector(
+        ax, draw_bounding_box=True,
+        props=props, handle_props=handle_props,
+        box_props=box_props, box_handle_props=box_handle_props)
+
+    for event in [
+        *polygon_place_vertex(ax, (50, 50)),
+        *polygon_place_vertex(ax, (150, 50)),
+        *polygon_place_vertex(ax, (50, 150)),
+        *polygon_place_vertex(ax, (50, 50)),
+    ]:
+        event._process()
+
+    artist = tool._selection_artist
+    assert mcolors.same_color(artist.get_color(), 'r')
+    for artist in tool._handles_artists:
+        assert artist.get_marker() == 'o'
+        assert mcolors.same_color(artist.get_markerfacecolor(), 'w')
+        assert mcolors.same_color(artist.get_markeredgecolor(), 'r')
+
+    box_artist = tool._box._selection_artist
+    assert box_artist.get_linestyle() == ':'
+    assert mcolors.same_color(box_artist.get_facecolor(), 'c')
+    assert mcolors.same_color(box_artist.get_edgecolor(), 'b')
+    for artist in tool._box._handles_artists:
+        # marker and markerfacecolor are inherited from handle_props
+        # markeredgecolor is overridden by box_handle_props.
+        assert artist.get_marker() == 'o'
+        assert mcolors.same_color(artist.get_markerfacecolor(), 'w')
+        assert mcolors.same_color(artist.get_markeredgecolor(), 'y')
+
+
 def test_polygon_selector_clear_method(ax):
     onselect = mock.Mock(spec=noop, return_value=None)
     tool = widgets.PolygonSelector(ax, onselect)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4118,7 +4118,7 @@ class PolygonSelector(_SelectorWidget):
 
         if box_handle_props is None:
             box_handle_props = {}
-        self._box_handle_props = self._handle_props.update(box_handle_props)
+        self._box_handle_props = {**self._handle_props, **box_handle_props}
         self._box_props = box_props
 
     def _get_bbox(self):


### PR DESCRIPTION
## PR summary

This PR fixes a bug in PolygonSelector where `box_handle_props` is incorrectly set to None because dict.update() returns None. Discovered while working on #31623.

### Why is this change necessary? / What problem does it solve?

When using PolygonSelector with `draw_bounding_box=True`, any provided `box_handle_props` are not applied correctly. Instead the bounding box handles fall back to default props from RectangleSelector.

### What is the reasoning for this implementation?

The fix ensures `box_handle_props` inherits from `handle_props`, overrides are applied correctly, and the original `handle_props` dictionary is not mutated.

### Example

The issue can be reproduced by specifying `box_handle_props`:

```py
import matplotlib.pyplot as plt
from matplotlib.widgets import PolygonSelector

fig, ax = plt.subplots()

box_handle_props = dict(marker='o', markerfacecolor='g', markeredgecolor='b')

selector = PolygonSelector(ax, draw_bounding_box=True,
                           box_handle_props=box_handle_props)

selector.verts = [(0.3, 0.3), (0.7, 0.4), (0.4, 0.8)]

plt.show()
```

<img width="873" height="339" alt="box_handle_props_image_comparison" src="https://github.com/user-attachments/assets/18418faa-c578-49e3-899e-9618b8700b7b" />

## AI Disclosure

None.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
