### PR TITLE
DOC: Add axis sharing section to subplot_mosaic guide

### DIFF
--- a/galleries/users_explain/axes/mosaic.py
+++ b/galleries/users_explain/axes/mosaic.py
@@ -420,8 +420,8 @@ identify_axes(axd)
 # ---------------------------------
 #
 # When the mosaic layout has blank spaces (empty sentinels), axis sharing
-# can produce unexpected results.  In the following example, the top-left
-# cell is empty and ``sharey=True`` is used:
+# can produce inintended results.  In the following example, there are no
+# tick labels in the top row:
 
 fig, axd = plt.subplot_mosaic(".A;BC", sharey=True, layout="constrained")
 for ax in axd.values():
@@ -429,11 +429,8 @@ for ax in axd.values():
 identify_axes(axd)
 
 # %%
-# Because the left column's topmost Axes is blank, Axes ``"B"`` would
-# normally be the leftmost visible Axes in its row, but axis sharing has
-# already removed its y-axis tick labels (since it is not the first column
-# in the grid).  As a result, *none* of the Axes in the top row display
-# y-axis tick labels, which is usually not what you want.
+# The reason for this behavior is that sharing removes tick labels from
+# all but the most-left / most-bottom grid positions.
 #
 # The fix is to manually re-enable tick labels on the Axes that should
 # display them using `.Axes.tick_params`:
@@ -442,7 +439,7 @@ fig, axd = plt.subplot_mosaic(".A;BC", sharey=True, layout="constrained")
 for ax in axd.values():
     ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
 
-# Re-enable y-axis tick labels on Axes "B"
-axd["B"].tick_params(labelleft=True)
+# Re-enable y-axis tick labels on Axes "A"
+axd["A"].tick_params(labelleft=True)
 
 identify_axes(axd)

--- a/galleries/users_explain/axes/mosaic.py
+++ b/galleries/users_explain/axes/mosaic.py
@@ -390,3 +390,59 @@ axd = plt.figure(layout="constrained").subplot_mosaic(
     empty_sentinel=0,
 )
 identify_axes(axd)
+
+
+# %%
+# Axis sharing
+# ============
+#
+# `.Figure.subplot_mosaic` supports *sharex* and *sharey* as does
+# `.Figure.subplots`.  When ``True``, all Axes in the mosaic share
+# the same x-axis or y-axis, which is useful for directly comparing
+# data across panels.
+
+fig = plt.figure(layout="constrained")
+axd = fig.subplot_mosaic("AC;BC", sharex=True)
+axd["A"].set_title("Axes A")
+axd["B"].set_title("Axes B")
+axd["C"].set_title("Axes C")
+for ax in axd.values():
+    ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
+identify_axes(axd)
+
+# %%
+# Note that when using ``sharex=True`` only the bottom row of Axes shows
+# x-axis tick labels, and when using ``sharey=True`` only the left column
+# shows y-axis tick labels.  This is identical to the behavior of
+# `.Figure.subplots`.
+#
+# Interaction with empty sentinels
+# ---------------------------------
+#
+# When the mosaic layout has blank spaces (empty sentinels), axis sharing
+# can produce unexpected results.  In the following example, the top-left
+# cell is empty and ``sharey=True`` is used:
+
+fig, axd = plt.subplot_mosaic(".A;BC", sharey=True, layout="constrained")
+for ax in axd.values():
+    ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
+identify_axes(axd)
+
+# %%
+# Because the left column's topmost Axes is blank, Axes ``"B"`` would
+# normally be the leftmost visible Axes in its row, but axis sharing has
+# already removed its y-axis tick labels (since it is not the first column
+# in the grid).  As a result, *none* of the Axes in the top row display
+# y-axis tick labels, which is usually not what you want.
+#
+# The fix is to manually re-enable tick labels on the Axes that should
+# display them using `.Axes.tick_params`:
+
+fig, axd = plt.subplot_mosaic(".A;BC", sharey=True, layout="constrained")
+for ax in axd.values():
+    ax.plot([1, 2, 3, 4], [1, 4, 2, 3])
+
+# Re-enable y-axis tick labels on Axes "B"
+axd["B"].tick_params(labelleft=True)
+
+identify_axes(axd)


### PR DESCRIPTION
PR summary
Adds a new "Axis sharing" section to the subplot_mosaic user guide (galleries/users_explain/axes/mosaic.py), as requested in #31699 (extracted from #25417).
The section includes:

A basic sharex=True example with "AC;BC" showing standard sharing behavior
A demonstration of the gotcha when combining sharey=True with empty sentinels (".A;BC"), where y-axis tick labels unexpectedly disappear
The tick_params(labelleft=True) workaround to restore them

Closes 

 #31699

AI Disclosure

None

PR checklist

 

- [x] "closes #31699" 
- [ ]  new and changed code is tested (docs-only change, no new code to test)
- [x] Plotting related features are demonstrated in an example
- [ ] New Features and API Changes are noted with a directive and release note (not applicable, docs-only)
- [x] Documentation complies with general and docstring guidelines
