### PR TITLE
[Bug]: Fix 3D surface corruption on non-linear scales by masking invalid values

### DIFF
--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2452,6 +2452,12 @@ class Axes3D(Axes):
 
         Z = cbook._to_unmasked_float_array(Z)
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
+
+        # Mask out values that are invalid for the current scale
+        X = np.where(self.xaxis._scale.val_in_range(X), X, np.nan)
+        Y = np.where(self.yaxis._scale.val_in_range(Y), Y, np.nan)
+        Z = np.where(self.zaxis._scale.val_in_range(Z), Z, np.nan)
+
         rows, cols = Z.shape
 
         has_stride = 'rstride' in kwargs or 'cstride' in kwargs

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2457,7 +2457,7 @@ class Axes3D(Axes):
         val_in_range_X = np.vectorize(self.xaxis._scale.val_in_range, otypes=[bool])
         val_in_range_Y = np.vectorize(self.yaxis._scale.val_in_range, otypes=[bool])
         val_in_range_Z = np.vectorize(self.zaxis._scale.val_in_range, otypes=[bool])
-        
+
         X = np.where(val_in_range_X(X), X, np.nan)
         Y = np.where(val_in_range_Y(Y), Y, np.nan)
         Z = np.where(val_in_range_Z(Z), Z, np.nan)

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2370,6 +2370,17 @@ class Axes3D(Axes):
         self.auto_scale_xyz([x1, x2], [y1, y2], [z1, z2], had_data)
         return polyc
 
+    def _mask_invalid_scale_values(self, X, Y, Z):
+        """Mask out values that are invalid for the current scale."""
+        val_in_range_X = np.vectorize(self.xaxis._scale.val_in_range, otypes=[bool])
+        val_in_range_Y = np.vectorize(self.yaxis._scale.val_in_range, otypes=[bool])
+        val_in_range_Z = np.vectorize(self.zaxis._scale.val_in_range, otypes=[bool])
+        
+        X = np.where(val_in_range_X(X), X, np.nan)
+        Y = np.where(val_in_range_Y(Y), Y, np.nan)
+        Z = np.where(val_in_range_Z(Z), Z, np.nan)
+        return X, Y, Z
+
     def plot_surface(self, X, Y, Z, *, norm=None, vmin=None,
                      vmax=None, lightsource=None, axlim_clip=False, **kwargs):
         """
@@ -2453,14 +2464,7 @@ class Axes3D(Axes):
         Z = cbook._to_unmasked_float_array(Z)
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
 
-        # Mask out values that are invalid for the current scale
-        val_in_range_X = np.vectorize(self.xaxis._scale.val_in_range, otypes=[bool])
-        val_in_range_Y = np.vectorize(self.yaxis._scale.val_in_range, otypes=[bool])
-        val_in_range_Z = np.vectorize(self.zaxis._scale.val_in_range, otypes=[bool])
-
-        X = np.where(val_in_range_X(X), X, np.nan)
-        Y = np.where(val_in_range_Y(Y), Y, np.nan)
-        Z = np.where(val_in_range_Z(Z), Z, np.nan)
+        X, Y, Z = self._mask_invalid_scale_values(X, Y, Z)
 
         rows, cols = Z.shape
 
@@ -2628,6 +2632,9 @@ class Axes3D(Axes):
             raise ValueError("Argument Z must be 2-dimensional.")
         # FIXME: Support masked arrays
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
+        
+        X, Y, Z = self._mask_invalid_scale_values(X, Y, Z)
+        
         rows, cols = Z.shape
 
         has_stride = 'rstride' in kwargs or 'cstride' in kwargs
@@ -2780,10 +2787,12 @@ class Axes3D(Axes):
             z, *args = args
         z = np.asarray(z)
 
+        tx, ty, tz = self._mask_invalid_scale_values(tri.x, tri.y, z)
+
         triangles = tri.get_masked_triangles()
-        xt = tri.x[triangles]
-        yt = tri.y[triangles]
-        zt = z[triangles]
+        xt = tx[triangles]
+        yt = ty[triangles]
+        zt = tz[triangles]
         verts = np.stack((xt, yt, zt), axis=-1)
 
         if cmap:
@@ -2802,7 +2811,7 @@ class Axes3D(Axes):
                 facecolors=color, axlim_clip=axlim_clip, **kwargs)
 
         self.add_collection(polyc, autolim="_datalim_only")
-        self.auto_scale_xyz(tri.x, tri.y, z, had_data)
+        self.auto_scale_xyz(tx, ty, tz, had_data)
 
         return polyc
 

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2375,7 +2375,7 @@ class Axes3D(Axes):
         val_in_range_X = np.vectorize(self.xaxis._scale.val_in_range, otypes=[bool])
         val_in_range_Y = np.vectorize(self.yaxis._scale.val_in_range, otypes=[bool])
         val_in_range_Z = np.vectorize(self.zaxis._scale.val_in_range, otypes=[bool])
-        
+
         X = np.where(val_in_range_X(X), X, np.nan)
         Y = np.where(val_in_range_Y(Y), Y, np.nan)
         Z = np.where(val_in_range_Z(Z), Z, np.nan)
@@ -2632,9 +2632,9 @@ class Axes3D(Axes):
             raise ValueError("Argument Z must be 2-dimensional.")
         # FIXME: Support masked arrays
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
-        
+
         X, Y, Z = self._mask_invalid_scale_values(X, Y, Z)
-        
+
         rows, cols = Z.shape
 
         has_stride = 'rstride' in kwargs or 'cstride' in kwargs

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -2454,9 +2454,13 @@ class Axes3D(Axes):
         X, Y, Z = np.broadcast_arrays(X, Y, Z)
 
         # Mask out values that are invalid for the current scale
-        X = np.where(self.xaxis._scale.val_in_range(X), X, np.nan)
-        Y = np.where(self.yaxis._scale.val_in_range(Y), Y, np.nan)
-        Z = np.where(self.zaxis._scale.val_in_range(Z), Z, np.nan)
+        val_in_range_X = np.vectorize(self.xaxis._scale.val_in_range, otypes=[bool])
+        val_in_range_Y = np.vectorize(self.yaxis._scale.val_in_range, otypes=[bool])
+        val_in_range_Z = np.vectorize(self.zaxis._scale.val_in_range, otypes=[bool])
+        
+        X = np.where(val_in_range_X(X), X, np.nan)
+        Y = np.where(val_in_range_Y(Y), Y, np.nan)
+        Z = np.where(val_in_range_Z(Z), Z, np.nan)
 
         rows, cols = Z.shape
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3192,21 +3192,20 @@ def test_scale3d_calc_coord():
 
 
 def test_3d_log_scale_negative_masking():
-    import matplotlib.pyplot as plt
-    import numpy as np
-
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
-
-    # Create mock arrays with zeroes and negative values
-    X, Y = np.meshgrid(np.linspace(-1, 1, 5), np.linspace(-1, 1, 5))
-    Z = X + Y
-
-    ax.plot_surface(X, Y, Z)
-
-    # Apply non-linear scales
+    
+    # Set scales BEFORE plotting so the masking logic is triggered
     ax.set_xscale('log')
     ax.set_zscale('log')
-
-    # Drawing forces evaluation and confirms the absence of crashes
-    fig.canvas.draw()
+    
+    # A 3x3 grid normally yields 4 polygons total
+    X, Y = np.meshgrid(np.linspace(-1, 1, 3), np.linspace(-1, 1, 3))
+    Z = X + Y
+    
+    surf = ax.plot_surface(X, Y, Z)
+    
+    # On main (broken), no values are masked, so all 4 polygons are generated.
+    # On our branch (fixed), the negative/zero values are masked to NaN,
+    # and plot_surface gracefully drops the invalid polygons.
+    assert len(surf.get_paths()) < 4

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3194,17 +3194,17 @@ def test_scale3d_calc_coord():
 def test_3d_log_scale_negative_masking():
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
-    
+
     # Set scales BEFORE plotting so the masking logic is triggered
     ax.set_xscale('log')
     ax.set_zscale('log')
-    
+
     # A 3x3 grid normally yields 4 polygons total
     X, Y = np.meshgrid(np.linspace(-1, 1, 3), np.linspace(-1, 1, 3))
     Z = X + Y
-    
+
     surf = ax.plot_surface(X, Y, Z)
-    
+
     # On main (broken), no values are masked, so all 4 polygons are generated.
     # On our branch (fixed), the negative/zero values are masked to NaN,
     # and plot_surface gracefully drops the invalid polygons.

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3189,3 +3189,24 @@ def test_scale3d_calc_coord():
     # Pane coordinate should match axis limit (y-pane at max)
     assert pane_idx == 1
     assert point[pane_idx] == pytest.approx(ax.get_ylim()[1])
+
+
+def test_3d_log_scale_negative_masking():
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    fig = plt.figure()
+    ax = fig.add_subplot(111, projection='3d')
+    
+    # Create mock arrays with zeroes and negative values
+    X, Y = np.meshgrid(np.linspace(-1, 1, 5), np.linspace(-1, 1, 5))
+    Z = X + Y
+    
+    ax.plot_surface(X, Y, Z)
+    
+    # Apply non-linear scales
+    ax.set_xscale('log')
+    ax.set_zscale('log')
+    
+    # Drawing forces evaluation and confirms the absence of crashes
+    fig.canvas.draw()

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3197,16 +3197,16 @@ def test_3d_log_scale_negative_masking():
 
     fig = plt.figure()
     ax = fig.add_subplot(111, projection='3d')
-    
+
     # Create mock arrays with zeroes and negative values
     X, Y = np.meshgrid(np.linspace(-1, 1, 5), np.linspace(-1, 1, 5))
     Z = X + Y
-    
+
     ax.plot_surface(X, Y, Z)
-    
+
     # Apply non-linear scales
     ax.set_xscale('log')
     ax.set_zscale('log')
-    
+
     # Drawing forces evaluation and confirms the absence of crashes
     fig.canvas.draw()


### PR DESCRIPTION
## PR summary
Closes #31726

**Why is this change necessary & What problem does it solve?**
Currently, creating a 3D surface plot (`ax.plot_surface`) with a non-linear scale (e.g., `ax.set_zscale('log')`) completely corrupts the surface rendering if the data contains zero or negative values. The new 3D scale transforms (introduced in #30980) were allowing mathematically invalid values to pass through to `Poly3DCollection`, resulting in `NaN`/`-inf` during projection and breaking the renderer.

**What is the reasoning for this implementation?**
Following the guidance of @scottshambaugh, this PR utilizes the new `Scale.val_in_range` method introduced in #31306. 
Immediately after broadcasting `X`, `Y`, and `Z` in `plot_surface`, we use `np.where` to check if the coordinates are valid for their respective axis scales. Any invalid values are replaced with `np.nan`. This elegantly hooks into the existing downstream `NaN` filtering logic inside `plot_surface`, allowing the invalid polygons to be gracefully discarded without corrupting the rest of the valid surface.

## AI Disclosure
I used an AI coding assistant to help analyze the 3D projection pipeline and draft the `val_in_range` masking logic for this PR.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to link the related issue
- [ ] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines