### PR TITLE
Drop duplicate 'the the' in two doc comments

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1010,7 +1010,7 @@ class FontConstantsBase:
 
 class ComputerModernFontConstants(FontConstantsBase):
     # Previously, the x-height of Computer Modern was obtained from the font
-    # table. However, that x-height was greater than the the actual (rendered)
+    # table. However, that x-height was greater than the actual (rendered)
     # x-height by a factor of 1.771484375 (at font size 12, DPI 100 and hinting
     # type 32). Now that we're using the rendered x-height, some font constants
     # have been increased by the same factor to compensate.

--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3522,7 +3522,7 @@ class MultiNorm(Norm):
             - If iterable, must be of length `n_components`. Each element can be a
               scalar or array-like and is mapped through the corresponding norm.
             - If structured array, must have `n_components` fields. Each field
-              is mapped through the the corresponding norm.
+              is mapped through the corresponding norm.
 
         """
         values = self._iterable_components_in_data(values, self.n_components)


### PR DESCRIPTION
Two unrelated spots have the same minor typo:

- `lib/matplotlib/_mathtext.py`: "greater than the the actual" in the ComputerModernFontConstants x-height note.
- `lib/matplotlib/colors.py`: "mapped through the the corresponding norm" in the structured-array branch of the to_rgba docstring.