### PR TITLE
Fix add_artist forcing clip path when clip_on is False

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2356,7 +2356,7 @@ class _AxesBase(martist.Artist):
         self._children.append(a)
         a._remove_method = self._children.remove
         self._set_artist_props(a)
-        if a.get_clip_path() is None:
+        if a.get_clip_path() is None and a.get_clip_on():
             a.set_clip_path(self.patch)
         self.stale = True
         return a


### PR DESCRIPTION
### Description
This PR fixes a bug where calling `ax.add_artist()` explicitly overrides and forces a clipping path on an artist, even if that artist was explicitly created with `clip_on=False`. 

### Root Cause
In `lib/matplotlib/axes/_base.py`, the `add_artist` method previously only checked if the artist's clip path was `None`:
```python
if a.get_clip_path() is None:
    a.set_clip_path(self.patch)