### PR TITLE
Fix invalid format string in set_xticklabels error message.

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -2227,11 +2227,10 @@ class Axis(martist.Artist):
             labels = [t.get_text() if hasattr(t, 'get_text') else t
                       for t in labels]
         except TypeError:
-            raise TypeError(f"{labels:=} must be a sequence") from None
+            raise TypeError(f"{labels=!r} must be a sequence") from None
         locator = (self.get_minor_locator() if minor
                    else self.get_major_locator())
         if not labels:
-            # eg labels=[]:
             formatter = mticker.NullFormatter()
         elif (isinstance(locator, mticker.FixedLocator) or
               (hasattr(locator, 'base') and

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7032,6 +7032,8 @@ def test_xticks_bad_args():
     ax = plt.figure().add_subplot()
     with pytest.raises(TypeError, match='must be a sequence'):
         ax.set_xticks([2, 9], 3.1)
+    with pytest.raises(TypeError, match='must be a sequence'):
+        ax.set_xticks([2, 9], ax)
     with pytest.raises(ValueError, match='must be 1D'):
         plt.xticks(np.arange(4).reshape((-1, 1)))
     with pytest.raises(ValueError, match='must be 1D'):


### PR DESCRIPTION
"=" happens to be a valid format string for numeric values, but not for arbitrary objects, so an error
(`TypeError: unsupported format string passed to <objecttype>.__format__`) would previously occur *while formatting the error message* for something like `set_xticklabels(object())`.

(The actual case where I saw this happen is when I wrongly passed a Formatter to set_xticklabels.)

Also remove a fairly pointless comment.

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
