### PR TITLE
DOC: Move engineering formatter example from Text to Ticks

### DIFF
--- a/galleries/examples/ticks/engineering_formatter.py
+++ b/galleries/examples/ticks/engineering_formatter.py
@@ -4,6 +4,8 @@ Format ticks using engineering notation
 =======================================
 
 Use of the engineering Formatter.
+
+.. redirect-from:: /gallery/text_labels_and_annotations/engineering_formatter
 """
 
 import matplotlib.pyplot as plt


### PR DESCRIPTION
Ticks is the suitable category because this is about Ticks and their Formatters not about text styling.
