### PR TITLE
DOC: Move multiple yaxis example from Spines to Subplots, axes and figures

### DIFF
--- a/galleries/examples/axisartist/demo_parasite_axes.py
+++ b/galleries/examples/axisartist/demo_parasite_axes.py
@@ -10,8 +10,8 @@ This approach uses `mpl_toolkits.axes_grid1.parasite_axes.HostAxes` and
 `mpl_toolkits.axes_grid1.parasite_axes.ParasiteAxes`.
 
 The standard and recommended approach is to use instead standard Matplotlib
-axes, as shown in the :doc:`/gallery/spines/multiple_yaxis_with_spines`
-example.
+axes, as shown in the
+:doc:`/gallery/subplots_axes_and_figures/multiple_yaxis_with_spines` example.
 
 An alternative approach using `mpl_toolkits.axes_grid1` and
 `mpl_toolkits.axisartist` is shown in the

--- a/galleries/examples/axisartist/demo_parasite_axes2.py
+++ b/galleries/examples/axisartist/demo_parasite_axes2.py
@@ -15,8 +15,8 @@ This approach uses `mpl_toolkits.axes_grid1.parasite_axes.host_subplot` and
 `mpl_toolkits.axisartist.axislines.Axes`.
 
 The standard and recommended approach is to use instead standard Matplotlib
-axes, as shown in the :doc:`/gallery/spines/multiple_yaxis_with_spines`
-example.
+axes, as shown in the
+:doc:`/gallery/subplots_axes_and_figures/multiple_yaxis_with_spines` example.
 
 An alternative approach using `mpl_toolkits.axes_grid1.parasite_axes.HostAxes`
 and `mpl_toolkits.axes_grid1.parasite_axes.ParasiteAxes` is shown in the

--- a/galleries/examples/subplots_axes_and_figures/multiple_yaxis_with_spines.py
+++ b/galleries/examples/subplots_axes_and_figures/multiple_yaxis_with_spines.py
@@ -11,6 +11,8 @@ Note that this approach uses `matplotlib.axes.Axes` and their
 `~matplotlib.spines.Spine`\s.  Alternative approaches using non-standard Axes
 are shown in the :doc:`/gallery/axisartist/demo_parasite_axes` and
 :doc:`/gallery/axisartist/demo_parasite_axes2` examples.
+
+.. redirect-from:: /gallery/spines/multiple_yaxis_with_spines
 """
 
 import matplotlib.pyplot as plt
@@ -44,3 +46,6 @@ twin2.tick_params(axis='y', colors=p3.get_color())
 ax.legend(handles=[p1, p2, p3])
 
 plt.show()
+
+# %%
+# .. tags:: component: spines


### PR DESCRIPTION
The primary aspect here is the multiple Axis feature. Therefore it should live next to the other `twinx()` examples. The spine aspect is only a technical detail need to move the third y-axis. A user would not look for this in the Spines section.
