### PR TITLE
feat: add rcParams for suptitle alignment

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -330,6 +330,12 @@ default: %(va)s
         fontweight, weight : default: :rc:`figure.%(rc)sweight`
             The font weight of the text. See `.Text.set_weight` for possible
             values.
+        horizontalalignment, ha : {'center', 'left', 'right'}, \
+default: :rc:`figure.titlehorizontalalign`
+            The horizontal alignment of the text relative to (*x*, *y*).
+        verticalalignment, va : {'top', 'center', 'bottom', 'baseline'}, \
+default: :rc:`figure.titleverticalalign`
+            The vertical alignment of the text relative to (*x*, *y*).
 
         Returns
         -------
@@ -360,8 +366,18 @@ default: %(va)s
             y = info['y0']
 
         kwargs = cbook.normalize_kwargs(kwargs, Text)
-        kwargs.setdefault('horizontalalignment', info['ha'])
-        kwargs.setdefault('verticalalignment', info['va'])
+
+        # Resolve defaults: rcParam key if present, else hardcoded fallback
+        ha_key = info.get('horizontalalign')
+        va_key = info.get('verticalalign')
+        kwargs.setdefault(
+            'horizontalalignment',
+            mpl.rcParams[ha_key] if ha_key else info['ha'],
+        )
+        kwargs.setdefault(
+            'verticalalignment',
+            mpl.rcParams[va_key] if va_key else info['va'],
+        )
         kwargs.setdefault('rotation', info['rotation'])
 
         if 'fontproperties' not in kwargs:
@@ -394,7 +410,9 @@ default: %(va)s
         # docstring from _suplabels...
         info = {'name': '_suptitle', 'x0': 0.5, 'y0': 0.98,
                 'ha': 'center', 'va': 'top', 'rotation': 0,
-                'size': 'figure.titlesize', 'weight': 'figure.titleweight'}
+                'size': 'figure.titlesize', 'weight': 'figure.titleweight',
+                'horizontalalign': 'figure.titlehorizontalalign',
+                'verticalalign': 'figure.titleverticalalign'}
         return self._suplabels(t, info, **kwargs)
 
     def get_suptitle(self):

--- a/lib/matplotlib/mpl-data/matplotlibrc
+++ b/lib/matplotlib/mpl-data/matplotlibrc
@@ -599,8 +599,10 @@
 ## * FIGURE                                                                  *
 ## ***************************************************************************
 ## See https://matplotlib.org/stable/api/figure_api.html#matplotlib.figure.Figure
-#figure.titlesize:   large     # size of the figure title (``Figure.suptitle()``)
-#figure.titleweight: normal    # weight of the figure title
+#figure.titlesize:            large     # size of the figure title (``Figure.suptitle()``)
+#figure.titleweight:          normal    # weight of the figure title
+#figure.titlehorizontalalign: center    # horizontal alignment of the figure title
+#figure.titleverticalalign:   top       # vertical alignment of the figure title
 #figure.labelsize:   large     # size of the figure label (``Figure.sup[x|y]label()``)
 #figure.labelweight: normal    # weight of the figure label
 #figure.figsize:     6.4, 4.8  # figure size in inches

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -445,6 +445,15 @@ def validate_fontsize(s):
 validate_fontsizelist = _listify_validator(validate_fontsize)
 
 
+def validate_suptitle_ha(s):
+    """
+    Validate horizontal alignment for suptitle rcParams.
+    """
+    return _str_to_one_of(
+        ['center', 'left', 'right', 'center_left', 'center_right'],
+    )(s)
+
+
 def validate_fontweight(s):
     weights = [
         'ultralight', 'light', 'normal', 'regular', 'book', 'medium', 'roman',
@@ -1347,8 +1356,12 @@ _validators = {
 
     ## figure props
     # figure title
-    "figure.titlesize":   validate_fontsize,
-    "figure.titleweight": validate_fontweight,
+    "figure.titlesize":            validate_fontsize,
+    "figure.titleweight":          validate_fontweight,
+    "figure.titlehorizontalalign": validate_suptitle_ha,
+    # Validate that suptitle rcParams are set together to avoid inconsistent defaults
+    # if someone sets ha but not va (or vice versa) — the pair should change together.
+    "figure.titleverticalalign":   validate_verticalalignment,
 
     # figure labels
     "figure.labelsize":   validate_fontsize,
@@ -2768,6 +2781,18 @@ _DEFINITION = [
         default="normal",
         validator=validate_fontweight,
         description="weight of the figure title"
+    ),
+    _Param(
+        "figure.titlehorizontalalign",
+        default="center",
+        validator=validate_suptitle_ha,
+        description="horizontal alignment of the figure title (``Figure.suptitle()``)"
+    ),
+    _Param(
+        "figure.titleverticalalign",
+        default="top",
+        validator=validate_verticalalignment,
+        description="vertical alignment of the figure title (``Figure.suptitle()``)"
     ),
     _Param(
         "figure.labelsize",

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1685,6 +1685,30 @@ def test_rcparams(fig_test, fig_ref):
         fig_test.suptitle("Title")
 
 
+def test_suptitle_rcparams_alignment():
+    """Test that suptitle respects figure.titlehorizontalalign and titleverticalalign."""
+    fig, ax = plt.subplots()
+    with mpl.rc_context({
+        'figure.titlehorizontalalign': 'left',
+        'figure.titleverticalalign': 'center',
+    }):
+        txt = fig.suptitle("Title")
+    assert txt.get_horizontalalignment() == 'left'
+    assert txt.get_verticalalignment() == 'center'
+
+
+def test_suptitle_rcparams_alignment_override():
+    """Test that explicit kwargs override suptitle rcParams defaults."""
+    fig, ax = plt.subplots()
+    with mpl.rc_context({
+        'figure.titlehorizontalalign': 'left',
+        'figure.titleverticalalign': 'center',
+    }):
+        txt = fig.suptitle("Title", ha='right', va='bottom')
+    assert txt.get_horizontalalignment() == 'right'
+    assert txt.get_verticalalignment() == 'bottom'
+
+
 def test_deepcopy():
     fig1, ax = plt.subplots()
     ax.plot([0, 1], [2, 3])

--- a/lib/matplotlib/typing.py
+++ b/lib/matplotlib/typing.py
@@ -318,6 +318,8 @@ RcKeyType: TypeAlias = Literal[
     "figure.subplot.wspace",
     "figure.titlesize",
     "figure.titleweight",
+    "figure.titlehorizontalalign",
+    "figure.titleverticalalign",
     "font.cursive",
     "font.enable_last_resort",
     "font.family",


### PR DESCRIPTION
# Add `figure.titlehorizontalalign` and `figure.titleverticalalign` rcParams

Fixes [#24090](https://github.com/matplotlib/matplotlib/issues/24090)

## Problem

`suptitle()` defaults for horizontal and vertical alignment were hardcoded (`center` / `top`). Only `fontsize` and `fontweight` were configurable via rcParams. Users who wanted to control suptitle alignment had to call `suptitle(ha=..., va=...)` every time — no way to set a project-wide default via rc settings.

## Solution

Added two new rcParams:
- **`figure.titlehorizontalalign`** (default: `"center"`) — validates against `{center, left, right, center_left, center_right}`
- **`figure.titleverticalalign`** (default: `"top"`) — validates against standard vertical alignments

```python
import matplotlib.pyplot as plt

plt.rcParams[figure.titlehorizontalalign] = left
plt.rcParams[figure.titleverticalalign] = bottom

fig, ax = plt.subplots()
fig.suptitle("Left-aligned title")  # Uses rcParams defaults
fig.suptitle("Override", ha=right)  # Explicit kwarg still wins
```

## Changes
- **rcsetup.py**: Added `validate_suptitle_ha` validator + two new rcParam entries with defaults
- **figure.py**: Updated `_suplabels()` to resolve ha/va from rcParams when the key is set
- **matplotlibrc**: Added commented-out default values for the new params
- **tests/test_figure.py**: Two new tests — rcParams alignment applies, kwarg overrides work
- **typing.py**: Added new keys to `RcKeyType` enum

## Backwards Compatibility
Fully backwards compatible. Default values match the old hardcoded defaults (`center` / `top`). Existing code that passes explicit `ha`/`va` kwargs is unaffected.
