### PR TITLE
Preserve legend loc and mode when regenerating via figure options dialog

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -248,11 +248,15 @@ def figure_edit(axes, parent=None):
         if generate_legend:
             draggable = None
             ncols = 1
+            loc = "best"
+            mode = None
             if axes.legend_ is not None:
                 old_legend = axes.get_legend()
                 draggable = old_legend._draggable is not None
                 ncols = old_legend._ncols
-            new_legend = axes.legend(ncols=ncols)
+                loc = old_legend._loc
+                mode = old_legend._mode
+            new_legend = axes.legend(ncols=ncols, loc=loc, mode=mode)
             if new_legend:
                 new_legend.set_draggable(draggable)
 

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -219,6 +219,49 @@ def test_figureoptions():
 
 
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)
+def test_figureoptions_preserve_legend_settings():
+    # Regenerating the legend from the figure options dialog must preserve
+    # the existing legend's loc and mode, not reset them to defaults.
+    from matplotlib.backends.qt_editor import _formlayout
+
+    fig, ax = plt.subplots()
+    ax.plot([1, 2, 3], label="data")
+    ax.legend(loc="lower right", mode="expand", ncols=1)
+    old_loc = ax.get_legend()._loc
+    old_mode = ax.get_legend()._mode
+
+    def reconstruct(content):
+        # Mirror FormWidget.get(): a multi-page form is a list of
+        # (widgets, title, comment) triples; a flat form is a list of
+        # (label, value) pairs with separators/static text using label=None.
+        if content and all(
+            isinstance(it, (list, tuple)) and len(it) == 3
+            and isinstance(it[0], list)
+            for it in content
+        ):
+            return [reconstruct(it[0]) for it in content]
+        values = []
+        for label, value in content:
+            if label is None:
+                continue
+            if isinstance(value, list):  # combo box -> current selection
+                value = value[0]
+            values.append(value)
+        return values
+
+    def fake_fedit(datalist, title="", parent=None, icon=None, apply=None):
+        data = [reconstruct(page[0]) for page in datalist]
+        data[0][-1] = True  # tick "(Re-)Generate automatic legend"
+        apply(data)
+
+    with mock.patch.object(_formlayout, "fedit", fake_fedit):
+        fig.canvas.manager.toolbar.edit_parameters()
+
+    assert ax.get_legend()._loc == old_loc
+    assert ax.get_legend()._mode == old_mode
+
+
+@pytest.mark.backend('QtAgg', skip_on_importerror=True)
 def test_save_figure_return(tmp_path):
     fig, ax = plt.subplots()
     ax.imshow([[1]])


### PR DESCRIPTION
## PR summary

Fixes #17775.

When regenerating a legend from the Qt figure options dialog
("(Re-)Generate automatic legend"), the previous code only preserved
`ncols` and the draggable state. The legend's position (`loc`) and `mode`
were reset to defaults, discarding the user's settings. This reads `loc`
and `mode` from the existing legend and passes them into the regenerated
`axes.legend(...)` call.

## Note on bbox_to_anchor

The issue also mentions `bbox_to_anchor`. I left it out for now because
`Legend._bbox_to_anchor` is stored already transformed into display
coordinates, so passing it straight back into `legend(bbox_to_anchor=...)`
double-transforms it. Happy to handle that in a follow-up with the proper
transform if maintainers would like it here.

## PR checklist

- [x] Added a regression test (`test_figureoptions_preserve_legend_settings`)
      that fails on `main` and passes with this change.