### PR TITLE
Qt: Silence an exception at interpreter exit

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -195,7 +195,13 @@ class TimerQT(TimerBase):
         super().__init__(*args, **kwargs)
 
     def __del__(self):
-        self._timer_stop()
+        try:
+            self._timer_stop()
+        except RuntimeError as e:
+            # Silence warning on shutdown.
+            ignore_msg = "wrapped C/C++ object of type QTimer has been deleted"
+            if str(e) != ignore_msg:
+                raise
 
     def _timer_set_single_shot(self):
         self._timer.setSingleShot(self._single)


### PR DESCRIPTION
## PR summary

This silences the following warning about an ignored exception:
```
Exception ignored while calling deallocator <function TimerQT.__del__ at 0x...>:
Traceback (most recent call last):
  File ".../lib/matplotlib/backends/backend_qt.py", line 198, in __del__
    self._timer_stop()
  File ".../lib/matplotlib/backends/backend_qt.py", line 210, in _timer_stop
    self._timer.stop()
RuntimeError: wrapped C/C++ object of type QTimer has been deleted
```

I noticed this in passing while looking at [some CI logs](https://github.com/matplotlib/matplotlib/actions/runs/26654149606/job/78559927469?pr=31769#step:13:334).

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines