### PR TITLE
Doc/tweak api notes

### DIFF
--- a/doc/api/prev_api_changes/api_changes_3.11.0/behavior.rst
+++ b/doc/api/prev_api_changes/api_changes_3.11.0/behavior.rst
@@ -160,14 +160,6 @@ containing tuples of:
 
 Specifically, the glyph index was added after the character code.
 
-New environment variable to ignore system fonts
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-System fonts may be ignored by setting the :envvar:`MPL_IGNORE_SYSTEM_FONTS`; this
-suppresses searching for system fonts (in known directories or via some
-platform-specific subprocess) as well as limiting the results from
-`.FontManager.findfont`.
-
 SVG links open in new tab or window
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/doc/api/prev_api_changes/api_changes_3.11.0/deprecations.rst
+++ b/doc/api/prev_api_changes/api_changes_3.11.0/deprecations.rst
@@ -282,8 +282,9 @@ It is an internal helper not intended for external use.
 ``image.thumbnail``
 ~~~~~~~~~~~~~~~~~~~
 
-... is deprecated without replacement. Use :external:py:`Pillow's thumbnail method
-<PIL.Image.Image.thumbnail>` instead. See also the `Pillow tutorial
+... is deprecated without replacement. Use :external:py:meth:`Pillow's
+thumbnail method <PIL.Image.Image.thumbnail>` instead. See also the `Pillow
+tutorial
 <https://pillow.readthedocs.io/en/stable/handbook/tutorial.html#create-jpeg-thumbnails>`_.
 
 ``testing.widgets.mock_event`` and ``testing.widgets.do_event``


### PR DESCRIPTION
Two minor tweaks to the API change docs.

 - remove a duplicate with whats_new
 - fix a silently non-rendered link