### PR TITLE
Improve MaxNLocator, AutoLocator signatures.

### DIFF
--- a/doc/api/next_api_changes/deprecations/31788-AL.rst
+++ b/doc/api/next_api_changes/deprecations/31788-AL.rst
@@ -1,0 +1,4 @@
+``MaxNLocator.default_params``
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+... is deprecated.  The default parameter values are now directly given in the
+class' constructor signature.

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -41,7 +41,7 @@ class TestMaxNLocator:
 
     @pytest.mark.parametrize('kwargs, errortype, match', [
         ({'foo': 0}, TypeError,
-         re.escape("set_params() got an unexpected keyword argument 'foo'")),
+         re.escape("__init__() got an unexpected keyword argument 'foo'")),
         ({'steps': [2, 1]}, ValueError, "steps argument must be an increasing"),
         ({'steps': 2}, ValueError, "steps argument must be an increasing"),
         ({'steps': [2, 11]}, ValueError, "steps argument must be an increasing"),

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -2115,14 +2115,26 @@ class MaxNLocator(Locator):
     Finds nice tick locations with no more than :math:`nbins + 1` ticks being within the
     view limits. Locations beyond the limits are added to support autoscaling.
     """
-    default_params = dict(nbins=10,
-                          steps=None,
-                          integer=False,
-                          symmetric=False,
-                          prune=None,
-                          min_n_ticks=2)
 
-    def __init__(self, nbins=None, **kwargs):
+    default_params = _api.deprecated("3.12")(property(lambda self: dict(
+        nbins=10,
+        steps=None,
+        integer=False,
+        symmetric=False,
+        prune=None,
+        min_n_ticks=2,
+    )))
+
+    def __init__(
+        self,
+        nbins=10,
+        *,
+        steps=None,
+        integer=False,
+        symmetric=False,
+        prune=None,
+        min_n_ticks=2,
+    ):
         """
         Parameters
         ----------
@@ -2157,9 +2169,14 @@ class MaxNLocator(Locator):
             Relax *nbins* and *integer* constraints if necessary to obtain
             this minimum number of ticks.
         """
-        if nbins is not None:
-            kwargs['nbins'] = nbins
-        self.set_params(**{**self.default_params, **kwargs})
+        self.set_params(
+            nbins=nbins,
+            steps=steps,
+            integer=integer,
+            symmetric=symmetric,
+            prune=prune,
+            min_n_ticks=min_n_ticks,
+        )
 
     @staticmethod
     def _validate_steps(steps):
@@ -3033,7 +3050,8 @@ class AutoLocator(MaxNLocator):
     This is a subclass of `~matplotlib.ticker.MaxNLocator`, with parameters
     *nbins = 'auto'* and *steps = [1, 2, 2.5, 5, 10]*.
     """
-    def __init__(self):
+
+    def __init__(self, **kwargs):
         """
         To know the values of the non-public parameters, please have a
         look to the defaults of `~matplotlib.ticker.MaxNLocator`.
@@ -3044,7 +3062,7 @@ class AutoLocator(MaxNLocator):
         else:
             nbins = 'auto'
             steps = [1, 2, 2.5, 5, 10]
-        super().__init__(nbins=nbins, steps=steps)
+        super().__init__(nbins=nbins, steps=steps, **kwargs)
 
 
 class AutoMinorLocator(Locator):

--- a/lib/matplotlib/ticker.pyi
+++ b/lib/matplotlib/ticker.pyi
@@ -225,8 +225,18 @@ class _Edge_integer:
     def ge(self, x: float) -> float: ...
 
 class MaxNLocator(Locator):
-    default_params: dict[str, Any]
-    def __init__(self, nbins: int | Literal["auto"] | None = ..., **kwargs) -> None: ...
+    @property
+    def default_params(self) -> dict[str, Any]: ...
+    def __init__(
+        self,
+        nbins: int | Literal["auto"] | None = ...,
+        *,
+        steps: Sequence[float] | None = None,
+        integer: bool = False,
+        symmetric: bool = False,
+        prune: bool | None = None,
+        min_n_ticks: int = 2,
+    ) -> None: ...
     def set_params(self, **kwargs) -> None: ...
     def view_limits(self, dmin: float, dmax: float) -> tuple[float, float]: ...
 
@@ -293,7 +303,7 @@ class LogitLocator(MaxNLocator):
     def minor(self, value: bool) -> None: ...
 
 class AutoLocator(MaxNLocator):
-    def __init__(self) -> None: ...
+    def __init__(self, **kwargs) -> None: ...
 
 class AutoMinorLocator(Locator):
     ndivs: int


### PR DESCRIPTION
Directly set the defaults of MaxNLocator in the constructor signature (with a cutout for `nbins=None`), rather than in a separate variable.

Support passing kwargs to AutoLocator as well (they're already supported by MaxNLocator).

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
