### PR TITLE
SVG: simplify large cached collection paths (fix #22803)

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -714,7 +714,11 @@ class RendererSVG(RendererBase):
         path_data = self._convert_path(
             marker_path,
             marker_trans + Affine2D().scale(1.0, -1.0),
-            simplify=False)
+            # Honor path simplification for large reused paths (e.g. the polygon
+            # from fill_between, cached here like a marker). Without this the
+            # full vertex list is written verbatim (see #22803). Ordinary markers
+            # have few vertices and fall below the threshold, so are unaffected.
+            simplify=len(marker_path.vertices) >= 128)
         style = self._get_style_dict(gc, rgbFace)
         dictkey = (path_data, _generate_css(style))
         oid = self._markers.get(dictkey)

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -705,3 +705,27 @@ def test_svgid():
 
     assert plt.rcParams['svg.id'] == svg_id
     assert tree.findall(f'.[@id="{svg_id}"]')
+
+
+def test_fill_between_svg_path_simplified():
+    # Regression test for #22803: the polygon emitted by fill_between is cached
+    # in the SVG backend like a reusable marker and was written without path
+    # simplification, producing very large files. It should be simplified like
+    # any other large path, while remaining vector (not rasterized).
+    import re
+    rng = np.random.default_rng(424242)
+    n = 20000
+    x = np.arange(n)
+    y = rng.normal(size=(10, n))
+    fig, ax = plt.subplots()
+    ax.fill_between(x, y.min(axis=0), y.max(axis=0))
+    ax.set_xlim(0, n)
+    buf = BytesIO()
+    fig.savefig(buf, format="svg")
+    svg = buf.getvalue().decode("utf-8")
+    biggest = max(re.findall(r'\sd="([^"]*)"', svg, re.S), key=len)
+    n_verts = biggest.count("L") + biggest.count("M")
+    # the raw polygon has ~2*n vertices; simplification must reduce it materially
+    assert n_verts < n, f"fill path not simplified ({n_verts} vertices)"
+    # and it must stay vector, not be rasterized as a workaround
+    assert "<image" not in svg


### PR DESCRIPTION
## Summary

Fixes #22803. `fill_between` (and other large filled `PolyCollection`s) produce far larger SVG files than the equivalent line plots, because the SVG backend caches the single reused polygon like a marker (`RendererSVG.draw_markers`) and converts it with `simplify=False`. Every vertex is written verbatim — tens of thousands for dense data — even though path simplification is enabled and already trims equivalent `Line2D` paths.

This honors simplification for large reused paths, mirroring what `draw_path` already does for strokes. Ordinary markers have few vertices and stay below the threshold, so they are unaffected.

## Evidence (issue reproduction, matplotlib 3.10.x)

| | before | after |
|---|---|---|
| SVG size | 1012 KB | **423 KB (2.39×)** |
| fill path vertices | 40,003 | ~16,500 |
| text / axes | vector | vector (unchanged) |
| rasterized? | no | no |
| PNG pixel diff | — | **0 changed pixels** |

Lossless at display resolution and still fully vector — not a `rasterized=True` workaround.

## Test

Adds a regression test asserting the fill path is simplified and the output stays vector (no `<image>`). Separately verified scatter/marker SVG output is byte-identical before/after (no marker regression).

## Open questions for maintainers

- **Threshold:** gated on `len(marker_path.vertices) >= 128` (matplotlib's own simplification minimum). Happy to key it differently — e.g. on `marker_path.should_simplify`, though that is currently `False` for the closed fill polygon.
- Simplifying filled boundaries is conservative elsewhere; output is pixel-identical for the reported case, but I'd welcome guidance on pathological/self-intersecting fills.

Opened as a draft for discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
