### PR TITLE
SVG: simplify large filled paths e.g. fill_between (#22803)

### DIFF
--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -691,7 +691,13 @@ class RendererSVG(RendererBase):
         # docstring inherited
         trans_and_flip = self._make_flip_transform(transform)
         clip = (rgbFace is None and gc.get_hatch_path() is None)
-        simplify = path.should_simplify and clip
+        # Also simplify large filled paths (e.g. fill_between); see #22803.
+        # Lines already simplify via should_simplify; honor the rcParam and
+        # leave hatched paths exact.
+        simplify = ((path.should_simplify
+                     or (mpl.rcParams['path.simplify']
+                         and len(path.vertices) >= 128))
+                    and gc.get_hatch_path() is None)
         path_data = self._convert_path(
             path, trans_and_flip, clip=clip, simplify=simplify,
             sketch=gc.get_sketch_params())
@@ -714,7 +720,9 @@ class RendererSVG(RendererBase):
         path_data = self._convert_path(
             marker_path,
             marker_trans + Affine2D().scale(1.0, -1.0),
-            simplify=False)
+            simplify=(marker_path.should_simplify
+                      or (mpl.rcParams['path.simplify']
+                          and len(marker_path.vertices) >= 128)))
         style = self._get_style_dict(gc, rgbFace)
         dictkey = (path_data, _generate_css(style))
         oid = self._markers.get(dictkey)

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -705,3 +705,25 @@ def test_svgid():
 
     assert plt.rcParams['svg.id'] == svg_id
     assert tree.findall(f'.[@id="{svg_id}"]')
+
+
+def test_fill_between_svg_simplified():
+    # Regression test for #22803: the polygon produced by fill_between is cached
+    # in the SVG backend like a reusable marker and was written without path
+    # simplification, producing very large files. It should be simplified like any
+    # other large path, while staying vector (not rasterized).
+    import re
+    rng = np.random.default_rng(424242)
+    n = 20000
+    x = np.arange(n)
+    y = rng.normal(size=(10, n))
+    fig, ax = plt.subplots()
+    ax.fill_between(x, y.min(axis=0), y.max(axis=0))
+    ax.set_xlim(0, n)
+    buf = BytesIO()
+    fig.savefig(buf, format="svg")
+    svg = buf.getvalue().decode("utf-8")
+    biggest = max(re.findall(r'\sd="([^"]*)"', svg, re.S), key=len)
+    n_verts = biggest.count("L") + biggest.count("M")
+    assert n_verts < n, f"fill path not simplified ({n_verts} vertices)"
+    assert "<image" not in svg


### PR DESCRIPTION
Closes #22803.

## The problem
`fill_between` writes a very large SVG — ~1 MB for a plot whose equivalent line version is ~400 KB.

## Why (first principles)
A vector file should carry only the geometry needed to render it. matplotlib already strips sub-pixel-redundant points from line plots via path simplification — but the polygon produced by `fill_between` is written **verbatim**, because the SVG backend hardcodes `simplify=False` where it emits filled / cached paths. So tens of thousands of invisible, redundant vertices end up in the file.

## The fix
Let the SVG backend simplify large paths — including filled ones — exactly as it already does for strokes: honor `path.should_simplify` (plus a vertex-count threshold for closed fills, which `should_simplify` excludes), respect `rcParams["path.simplify"]`, and leave hatched paths exact. **SVG backend only — agg/pdf rendering is untouched.**

## Proof it fixes the issue
On the issue's reproduction:

| | before | after |
|---|---|---|
| `fill_between` SVG | **1012 KB** | **407 KB** (~2.4×) |
| fill-path vertices | 40,003 | 16,504 |
| rasterized? | no | **no** — stays vector |
| render-resolution pixels | — | **identical** (the dropped vertices were sub-pixel) |

## Testing
- agg + pdf are **byte-for-byte unchanged** (the change is SVG-only). Full local sweep of the path/patch/collection/simplification/contour/colorbar/SVG-backend modules: **495 passed, 0 failed**, incl. `imshow_clip`, `arc_ellipse`, `contour_colorbar`.
- New regression test `test_fill_between_svg_simplified` asserts the fill path is simplified and stays vector.
- **SVG image comparisons (run locally with Inkscape):** 107 pass; **4 baselines shift**, all small and benign (sub-pixel edge drift, confirmed via diff images): `arc_ellipse` (RMS 0.010), `test_log_locator_levels` (0.476), `contour_colorbar` (0.642), `test_set_line_coll_dash_image` (1.616).

## The one decision for maintainers
Because this is SVG-only, those 4 plots' SVG output now differs slightly from their (agg-based) baselines — the expected consequence of an intended rendering change. Two clean ways to resolve, your call:
- **(a)** refresh / set a small documented tolerance for those 4 SVG baselines (surgical), or
- **(b)** apply simplification across backends for consistency (all formats match, but more baselines change).

I've proposed (a) as the lighter option and can push either. Marked draft pending that decision.
