### PR TITLE
PERF: Speed up legend best calculations

### DIFF
--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1202,20 +1202,24 @@ class Legend(Artist):
         if offsets:
             pts.append(np.asarray(offsets, dtype=float))
         pts = np.concatenate(pts) if pts else np.empty((0, 2))
-        xL = np.unique([c[1] for c in candidate_boxes])
-        yB = np.unique([c[2] for c in candidate_boxes])
+        x_left = np.unique([c[1] for c in candidate_boxes])
+        y_bottom = np.unique([c[2] for c in candidate_boxes])
         x, y = pts[:, 0], pts[:, 1]
         with np.errstate(invalid='ignore'):
-            in_x = (xL[:, None] < x) & (x < xL[:, None] + width)
-            in_y = (yB[:, None] < y) & (y < yB[:, None] + height)
+            # Broadcast the (n_edges, 1) edge positions against the (n_points,)
+            # coordinates to get (n_edges, n_points) interval membership arrays.
+            in_x = ((x_left[:, np.newaxis] < x)
+                    & (x < x_left[:, np.newaxis] + width))
+            in_y = ((y_bottom[:, np.newaxis] < y)
+                    & (y < y_bottom[:, np.newaxis] + height))
 
         candidates = []
         for idx, l, b, legendBox in candidate_boxes:
-            contained = np.count_nonzero(in_x[np.searchsorted(xL, l)]
-                                         & in_y[np.searchsorted(yB, b)])
+            contained_count = np.count_nonzero(in_x[np.where(x_left == l)[0][0]]
+                                               & in_y[np.where(y_bottom == b)[0][0]])
             # XXX TODO: If markers are present, it would be good to take them
             # into account when checking vertex overlaps in the next line.
-            badness = (contained
+            badness = (contained_count
                        + legendBox.count_overlaps(bboxes)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1188,12 +1188,12 @@ class Legend(Artist):
         bbox = Bbox.from_bounds(0, 0, width, height)
 
         candidate_boxes = []
-        for idx in range(1, len(self.codes)):
-            l, b = self._get_anchored_bbox(idx, bbox,
-                                           self.get_bbox_to_anchor(),
-                                           renderer)
-            candidate_boxes.append(
-                (idx, l, b, Bbox.from_bounds(l, b, width, height)))
+        for loc_code in range(1, len(self.codes)):
+            left, bottom = self._get_anchored_bbox(loc_code, bbox,
+                                                   self.get_bbox_to_anchor(),
+                                                   renderer)
+            candidate_boxes.append((loc_code,
+                                    Bbox.from_bounds(left, bottom, width, height)))
 
         # Every candidate box has the same width and height, with only a handful of
         # distinct left/bottom edges. For speed we compute each point's membership
@@ -1202,8 +1202,8 @@ class Legend(Artist):
         if offsets:
             pts.append(np.asarray(offsets, dtype=float))
         pts = np.concatenate(pts) if pts else np.empty((0, 2))
-        x_left = np.unique([c[1] for c in candidate_boxes])
-        y_bottom = np.unique([c[2] for c in candidate_boxes])
+        x_left = np.unique([box.x0 for _, box in candidate_boxes])
+        y_bottom = np.unique([box.y0 for _, box in candidate_boxes])
         x, y = pts[:, 0], pts[:, 1]
         with np.errstate(invalid='ignore'):
             # Broadcast the (n_edges, 1) edge positions against the (n_points,)
@@ -1214,28 +1214,29 @@ class Legend(Artist):
                     & (y < y_bottom[:, np.newaxis] + height))
 
         candidates = []
-        for idx, l, b, legendBox in candidate_boxes:
-            contained_count = np.count_nonzero(in_x[np.where(x_left == l)[0][0]]
-                                               & in_y[np.where(y_bottom == b)[0][0]])
+        for loc_code, legendBox in candidate_boxes:
+            contained_count = np.count_nonzero(
+                in_x[np.where(x_left == legendBox.x0)[0][0]]
+                & in_y[np.where(y_bottom == legendBox.y0)[0][0]])
             # XXX TODO: If markers are present, it would be good to take them
             # into account when checking vertex overlaps in the next line.
             badness = (contained_count
                        + legendBox.count_overlaps(bboxes)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))
-            # Include the index to favor lower codes in case of a tie.
-            candidates.append((badness, idx, (l, b)))
+            # Include the loc code to favor lower codes in case of a tie.
+            candidates.append((badness, loc_code, (legendBox.x0, legendBox.y0)))
             if badness == 0:
                 break
 
-        _, _, (l, b) = min(candidates)
+        _, _, (left, bottom) = min(candidates)
 
         if self._loc_used_default and time.perf_counter() - start_time > 1:
             _api.warn_external(
                 'Creating legend with loc="best" can be slow with large '
                 'amounts of data.')
 
-        return l, b
+        return left, bottom
 
     def contains(self, mouseevent):
         return self.legendPatch.contains(mouseevent)

--- a/lib/matplotlib/legend.py
+++ b/lib/matplotlib/legend.py
@@ -1187,17 +1187,35 @@ class Legend(Artist):
 
         bbox = Bbox.from_bounds(0, 0, width, height)
 
-        candidates = []
+        candidate_boxes = []
         for idx in range(1, len(self.codes)):
             l, b = self._get_anchored_bbox(idx, bbox,
                                            self.get_bbox_to_anchor(),
                                            renderer)
-            legendBox = Bbox.from_bounds(l, b, width, height)
+            candidate_boxes.append(
+                (idx, l, b, Bbox.from_bounds(l, b, width, height)))
+
+        # Every candidate box has the same width and height, with only a handful of
+        # distinct left/bottom edges. For speed we compute each point's membership
+        # in those intervals once, rather than for all 10 candidate boxes.
+        pts = [line.vertices for line in lines]
+        if offsets:
+            pts.append(np.asarray(offsets, dtype=float))
+        pts = np.concatenate(pts) if pts else np.empty((0, 2))
+        xL = np.unique([c[1] for c in candidate_boxes])
+        yB = np.unique([c[2] for c in candidate_boxes])
+        x, y = pts[:, 0], pts[:, 1]
+        with np.errstate(invalid='ignore'):
+            in_x = (xL[:, None] < x) & (x < xL[:, None] + width)
+            in_y = (yB[:, None] < y) & (y < yB[:, None] + height)
+
+        candidates = []
+        for idx, l, b, legendBox in candidate_boxes:
+            contained = np.count_nonzero(in_x[np.searchsorted(xL, l)]
+                                         & in_y[np.searchsorted(yB, b)])
             # XXX TODO: If markers are present, it would be good to take them
             # into account when checking vertex overlaps in the next line.
-            badness = (sum(legendBox.count_contains(line.vertices)
-                           for line in lines)
-                       + legendBox.count_contains(offsets)
+            badness = (contained
                        + legendBox.count_overlaps(bboxes)
                        + sum(line.intersects_bbox(legendBox, filled=False)
                              for line in lines))

--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -873,6 +873,21 @@ def test_bbox_intersection():
     assert_bbox_eq(inter(r1, r5), bbox_from_ext(1, 1, 1, 1))
 
 
+def test_bbox_count_contains():
+    bbox = mtransforms.Bbox.from_extents(0, 0, 1, 1)
+    assert bbox.count_contains([]) == 0
+    assert bbox.count_contains([
+        [0.5, 0.5],         # inside
+        [0.1, 0.9],         # inside
+        [2.0, 2.0],         # outside
+        [-1.0, 0.5],        # outside
+        [0.0, 0.5],         # on left edge -> excluded
+        [1.0, 1.0],         # on corner -> excluded
+        [np.nan, 0.5],      # non-finite -> ignored
+        [0.5, np.inf],      # non-finite -> ignored
+    ]) == 2
+
+
 def test_bbox_as_strings():
     b = mtransforms.Bbox([[.5, 0], [.75, .75]])
     assert_bbox_eq(b, eval(repr(b), {'Bbox': mtransforms.Bbox}))


### PR DESCRIPTION
## PR summary
Closes https://github.com/matplotlib/matplotlib/issues/8108 (which was partially addressed already in https://github.com/matplotlib/matplotlib/pull/8224)

The 10 candidate legends are the same size and grid aligned, and so share edges. We can speed up the `count_contains` hot path by computing whether each point lies in those candidate intervals once, rather than looping over each location. In my profiling, I see a ~5x speedup for `Legend._find_best_position`, and most of the time there now is spent in other operations.

Did not deprecate `count_contains` since I found some instances of it being used on github, but it's no longer used anywhere internally so could remove. Added a test since it's no longer being exercised otherwise.

Before: 
<img width="2601" height="662" alt="image" src="https://github.com/user-attachments/assets/d12290ec-39b5-4ba5-8016-eb0e0eb26055" />

After:
<img width="2604" height="549" alt="image" src="https://github.com/user-attachments/assets/3ec22d51-8039-4077-9834-2809f58e1e74" />

Should hopefully cut down a lot on the warning `Creating legend with loc="best" can be slow with large amounts of data`, which I seem to run into fairly often.


## AI Disclosure
Claude code used for first cut, manually cleaned up and refactored.

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
