### PR TITLE
BLD/DOC: uv install instructions

### DIFF
--- a/doc/devel/development_setup.rst
+++ b/doc/devel/development_setup.rst
@@ -141,6 +141,7 @@ setup.
 
 .. _venv: https://docs.python.org/3/library/venv.html
 .. _conda: https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-environments.html
+.. _uv: https://docs.astral.sh/uv/
 
 .. tab-set::
 
@@ -181,6 +182,59 @@ setup.
         pip install --group dev
 
       Remember to activate the environment whenever you start working on Matplotlib!
+
+   .. tab-item:: uv environment
+
+      `uv`_ is a fast drop-in replacement for ``pip`` and ``venv``. After
+      `installing uv <https://docs.astral.sh/uv/getting-started/installation/>`_,
+      create a new environment and install the Python dependencies with ::
+
+        uv venv
+        uv pip install --group dev
+
+      and activate it with one of the following :
+
+      .. tab-set::
+
+         .. tab-item:: Linux and macOS
+
+            .. code-block:: bash
+
+               source .venv/bin/activate
+
+         .. tab-item:: Windows cmd.exe
+
+            .. code-block:: bat
+
+               .venv\Scripts\activate.bat
+
+         .. tab-item:: Windows PowerShell
+
+            .. code-block:: ps1con
+
+               .venv\Scripts\Activate.ps1
+
+      Remember to activate the environment whenever you start working on Matplotlib!
+
+      .. note::
+
+         When using uv, prefix the remaining ``pip`` commands in this guide with
+         ``uv``. For example, the :ref:`editable install <development-install>`
+         below becomes ::
+
+            uv pip install --verbose --no-build-isolation --group dev --editable .
+
+         You can also manage the environment from a lockfile with ``uv sync``.
+         Because Matplotlib has a compiled (meson-python) build, install the
+         dependencies and the editable build in separate steps ::
+
+            uv sync --group dev --no-install-project
+            uv pip install --no-build-isolation --no-deps --editable .
+
+         Then activate the environment as above. Avoid ``uv run``, because it
+         re-syncs the project and rebuilds the editable install with build
+         isolation, which is incompatible with the meson-python editable rebuild.
+         ``uv run --no-sync`` will work around this.
 
    .. tab-item:: conda environment
 


### PR DESCRIPTION
## PR summary

Towards https://github.com/matplotlib/matplotlib/issues/30877.

This documents how to install matplotlib using `uv`. I've omitted adding `uv.lock` for now.

Pixi is handled in https://github.com/matplotlib/matplotlib/pull/31384, though note that uv is easier since it needs no additional configuration to work out of the box.

## AI Disclosure
Claude code did a bad job, so I wrote the docs manually.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

