### PR TITLE
Update mailmap to latest commit

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,7 +1,21 @@
+34j <34j.github@proton.me> <55338215+34j@users.noreply.github.com>
+
+Aasma Gupta <aasmagupta1971@gmail.com> AASMA GUPTA <aasmagupta@Aasmas-Mac.local>
+
+Adam Ormondroyd <Adam.Ormondroyd@gmail.com>
+Adam Ormondroyd <Adam.Ormondroyd@gmail.com> <52655393+AdamOrmondroyd@users.noreply.github.com>
+
 Adam Ortiz <adam.ortiz@utoronto.ca>
+
+Aditi Gautam <agautam@uber.com> <72432016+agautam478@users.noreply.github.com>
+
+Aditya Singh <aditya6060singh@gmail.com>
+Aditya Singh <aditya6060singh@gmail.com> <adityasinghparmar60@gmail.com>
 
 Adrien F. Vincent <vincent.adrien@gmail.com>
 Adrien F. Vincent <vincent.adrien@gmail.com> <adrien.vincent@u-psud.fr>
+
+ALBIN BABU VARGHESE <albinbabuvarghese20@gmail.com>
 
 Aleksey Bilogur <aleksey.bilogur@gmail.com>
 
@@ -11,13 +25,34 @@ Alon Hershenhorn <hershen@gmail.com>
 
 Alvaro Sanchez <sanchezgnzlz.alvaro@gmail.com>
 
+Aman Kushwaha <amankushwaha61709@gmail.com>
+
+Amisha Mehta <amishamehta9900@gmail.com>
+Amisha Mehta <amishamehta9900@gmail.com> <115501608+amishamehta99@users.noreply.github.com>
+
+Ananya Devarakonda <ananya.devarakonda1@gmail.com>
+Ananya Devarakonda <ananya.devarakonda1@gmail.com> <57040724+ananya314@users.noreply.github.com>
+
 Andreas C Mueller <andreasmuellerml@gmail.com> Andreas Mueller <t3kcit@gmail.com>
 
+Andrés Gutierrez <12andresgutierrez04@gmail.com> <andresgutierrezdev@gmail.com>
+
 Andrew Dawson <ajdawson@acm.org> <dawson@atm.ox.ac.uk>
+
+Andrew Fennell <andrew.fennell1999@me.com> <sub+github@afennell.com>
+
+Andrew Kim <110536383+aseriesof-tubes@users.noreply.github.com> dohyun <dohyun@localhost.localdomain>
+
+Anna Mastori <72812754+AnnaMastori@users.noreply.github.com>
+
+Anton <138380708+r3kste@users.noreply.github.com>
 
 anykraus <kraus@mpip-mainz.mpg.de> <anykraus@users.noreply.github.com>
 
 Ariel Hernán Curiale <curiale@gmail.com>
+
+Atharva Kulkarni <kulkarniatharva590@gmail.com> Atharva2012 <kulkarniatharva590@gmail.con>
+Atharva Kulkarni <kulkarniatharva590@gmail.com> <103631956+Atharva2012@users.noreply.github.com>
 
 Ben Cohen <bj.cohen19@gmail.com> <ben@cohen-family.org>
 
@@ -28,19 +63,35 @@ Benedikt Daurer <benedikt.daurer@icm.uu.se>
 Benjamin Congdon <bencongdon96@gmail.com>
 Benjamin Congdon <bencongdon96@gmail.com> bcongdon <bcongdo2@illinois.edu>
 
+Brandon Dusch <brandondusch@gmail.com>
+
+Brian Lau <blau1@terpmail.umd.edu>
+Brian Lau <blau1@terpmail.umd.edu> <103338659+beelauuu@users.noreply.github.com>
+
 Bruno Zohreh <z.shams@bath.ac.uk>
 
 Carsten Schelp <carstenschelp@mp.nl>
 
 Casper van der Wel <caspervdw@gmail.com>
 
+Chahak Mehta <chahakmehta013@gmail.com> Chahak Mehta <201501422@daiict.ac.in>
+
+Chaoyi Hu <chaoyihu.work@gmail.com> <90495101+chaoyihu@users.noreply.github.com>
+
+Charisma Kausar <charisma.kausar@gmail.com> <68203159+ckcherry23@users.noreply.github.com>
+
 CharlesHe16 <c@harl.es>
 
-Chris Holdgraf <choldgraf@gmail.com>
+Chirag Sharma <chiragsharma23082005@gmail.com>
+Chirag Sharma <chiragsharma23082005@gmail.com> <160767827+Chirag3841@users.noreply.github.com>
 
 Cho Yin Yong <choyiny@users.noreply.github.com>
 
 Chris <chrissshe@gmail.com>
+
+Chris Holdgraf <choldgraf@gmail.com>
+
+Christine P. Chai <star1327p@gmail.com>
 
 Christoph Gohlke <cgohlke@uci.edu> cgohlke <cgohlke@uci.edu>
 Christoph Gohlke <cgohlke@uci.edu> C. Gohlke <cgohlke@uci.edu>
@@ -50,14 +101,28 @@ Cimarron Mittelsteadt <cimarronm@gmail.com> Cimarron <cimarronm@gmail.com>
 
 cldssty <huey910@gmail.com>
 
+Constantinos Menelaou <konmenel@gmail.com>
+Constantinos Menelaou <konmenel@gmail.com> <91343054+konmenel@users.noreply.github.com>
+
 Conner R. Phillips <conner.r.phillips@gmail.com> <conner.r.phillips.com>
+
+Dale Dai <ddale1128@gmail.com>
+Dale Dai <ddale1128@gmail.com> <145884899+CouldNot@users.noreply.github.com>
 
 Dan Hickstein <danhickstein@gmail.com>
 
 Daniel Hyams <dhyams@gmail.com>
 Daniel Hyams <dhyams@gmail.com> Daniel Hyams <dhyams@gitdev.(none)>
 
+Daniel Weiss <dkweiss@u.northwestern.edu>
+Daniel Weiss <dkweiss@u.northwestern.edu> <32396142+dkweiss31@users.noreply.github.com>
+
 David Kua <david@kua.io> <david.kua@mail.utoronto.ca>
+
+David Matos <davidmatos06@gmail.com> <david@track32.nl>
+David Matos <davidmatos06@gmail.com> <dmatos2012@users.noreply.github.com>
+
+DerWeh <andreas.weh@web.de> <andreas.weh@uni-a.de>
 
 Devashish Deshpande <ashu.9412@gmail.com>
 
@@ -78,6 +143,9 @@ Eric Ma <ericmajinglong@gmail.com> <ericmjl@users.noreply.github.com>
 
 esvhd <weiliang.zhang@gmail.com>
 
+Eva Sibinga <vegheadeva@gmail.com>
+Eva Sibinga <vegheadeva@gmail.com> <46283995+esibinga@users.noreply.github.com>
+
 Filipe Fernandes <ocefpaf@gmail.com>
 
 Florian Le Bourdais <florian.s.lebourdais@gmail.com>
@@ -85,6 +153,11 @@ Florian Le Bourdais <florian.s.lebourdais@gmail.com>
 Francesco Montesano <franz.bergesund@gmail.com> montefra <franz.bergesund@gmail.com>
 
 Gauravjeet <gauravjeet.kala@mail.utoronto.ca>
+
+G Karthik Koundinya <karthik26092005@gmail.com>
+G Karthik Koundinya <karthik26092005@gmail.com> <144328549+G26karthik@users.noreply.github.com>
+
+Greg Lucas <greg.m.lucas@gmail.com> <greg.lucas@lasp.colorado.edu>
 
 Hajoon Choi <hajoon.choi@mail.utoronto.ca>
 
@@ -94,13 +167,22 @@ Hannes Breytenbach <hannes@saao.ac.za>
 
 Hans Moritz Günther <moritz.guenther@gmx.de>
 
+Haoying Zhang <stevezhang1999@gmail.com>
+Haoying Zhang <stevezhang1999@gmail.com> <38875181+stevezhang1999@users.noreply.github.com>
+Haoying Zhang <stevezhang1999@gmail.com> stevezhang <lilacs@DESKTOP-IO90IQ2.localdomain>
+
 Harshal Prakash Patankar <pharshalp@gmail.com>
 
 Harshit Patni <patniharshit@gmail.com>
 
 Harutaka Kawamura <hkawamura0130@gmail.com>
 
+Hasan Rashid <hasan.j.rashid@gmail.com> <hasanrashid@users.noreply.github.com>
+
 Hood Chatham <roberthoodchatham@gmail.com> Hood <hood@mit.edu>
+
+Husain Gadiwala <hussaingadi.hg@gmail.com>
+Husain Gadiwala <hussaingadi.hg@gmail.com> <69296939+alphanoobie@users.noreply.github.com>
 
 Ian Hunt-Isaak <ianhuntisaak@gmail.com>
 
@@ -119,9 +201,13 @@ Jake Vanderplas <jakevdp@gmail.com>
 Jake Vanderplas <jakevdp@gmail.com> <jakevdp@yahoo.com>
 Jake Vanderplas <jakevdp@gmail.com> <vanderplas@astro.washington.edu>
 
+Jacob Stevens-Haas <37048747+Jacob-Stevens-Haas@users.noreply.github.com>
+
 James R. Evans <jrevans1@earthlink.net>
 
 Jan-Hendrik Müller <44469195+kolibril13@users.noreply.github.com>
+
+jaya prajapati <jayaprajapati8755@gmail.com>
 
 Jeff Lutgen <jlutgen@gmail.com> <jlutgen@users.noreply.github.com>
 
@@ -131,6 +217,8 @@ Jens Hedegaard Nielsen <jenshnielsen@gmail.com>
 Jens Hedegaard Nielsen <jenshnielsen@gmail.com> <jens.nielsen@ucl.ac.uk>
 
 Jerome F. Villegas <jeromefvillegas@gmail.com>
+
+JOD <joddeepesh@gmail.com>
 
 Joel Frederico <458871+joelfrederico@users.noreply.github.com>
 
@@ -147,12 +235,19 @@ Joseph Fox-Rabinovitz <jfoxrabinovitz@gmail.com> Joseph Fox-Rabinovitz <joseph.r
 
 Jouni K. Seppänen <jks@iki.fi>
 
+Juanita Gomez <juanitagomezr2112@gmail.com>
+
 Julien Lhermitte <ordirules@gmail.com>
 
 Julien Schueller <julien.schueller@gmail.com> <schueller@porsche-l64.phimeca.lan>
 Julien Schueller <julien.schueller@gmail.com> <schueller@bx-l64.phimeca.lan>
 
+Kaustubh Desale <desalekaustubh3@gmail.com>
+Kaustubh Desale <desalekaustubh3@gmail.com> <97254178+Kaustbh@users.noreply.github.com>
+
 Kevin Davies <kdavies4@gmail.com> <daviesk24@yahoo.com>
+
+Khushikela29 <Khushikela29@gmail.com> <121342846+Khushikela29@users.noreply.github.com>
 
 kikocorreoso <kikocorreoso@gmail.com> <kikocorreoso@users.noreply.github.com>
 
@@ -163,6 +258,8 @@ Kristen M. Thyng <kthyng@gmail.com>
 
 Kyle Sunden <sunden@wisc.edu>
 
+Kyra Cho <kyra.c@columbia.edu> <wsc2119@columbia.edu>
+
 Leeonadoh <leo.sunpeng.li@gmail.com>
 
 Lennart Fricke <lennart@die-frickes.eu> <lennart.fricke@kabelmail.de>
@@ -172,6 +269,13 @@ Levi Kilcher <levi.kilcher@nrel.gov>
 Leon Yin <hello.leonyin@gmail.com>
 
 Lion Krischer <lion.krischer@gmail.com> <krischer@geophysik.uni-muenchen.de>
+
+Logan Pageler <pagelerlogan@gmail.com>
+Logan Pageler <pagelerlogan@gmail.com> <48865621+Logan-Pageler@users.noreply.github.com>
+
+Lukas Hergt <lthergt@posteo.de> <lthergt@phas.ubc.ca>
+
+Lumberbot (aka Jack) <39504233+meeseeksmachine@users.noreply.github.com>
 
 luz paz <luzpaz@users.noreply.github.com>
 
@@ -187,12 +291,21 @@ Marco Gorelli <m.e.gorelli@gmail.com> <33491632+MarcoGorelli@users.noreply.githu
 
 Marek Rudnicki <marekrud@gmail.com>
 
+Marten Henric van Kerkwijk <mhvk@astro.utoronto.ca>
+
 Martin Fitzpatrick <martin.fitzpatrick@gmail.com> <mfitzp@abl.es>
+
+Marvin <marvin.krawutschke@outlook.de>
+Marvin <marvin.krawutschke@outlook.de> <101656586+Marvvxi@users.noreply.github.com>
+
+Mathias Hauser <mathias.hauser@env.ethz.ch> <mathause@users.noreply.github.com>
 
 Matt Newville <newville@cars.uchicago.edu>
 
 Matthew Emmett <memmett@gmail.com>
 Matthew Emmett <memmett@gmail.com> <memmett@unc.edu>
+
+Matthew Morrison <msm8275@rit.edu> <120498834+mattymo30@users.noreply.github.com>
 
 Matthias Bussonnier <bussonniermatthias@gmail.com>
 Matthias Bussonnier <bussonniermatthias@gmail.com> <mbussonnier@ucmerced.edu>
@@ -201,6 +314,9 @@ Matthias Lüthi <maluethi@protonmail.ch>
 Matthias Lüthi <maluethi@protonmail.ch> <matthias.luethi@lhep.unibe.ch>
 
 Matti Picus <matti.picus@gmail.com>
+
+Melissa Weber Mendonça <melissawm@gmail.com>
+Melissa Weber Mendonça <melissawm@gmail.com> <melissawm.github@gmail.com>
 
 Michael Droettboom <mdboom@gmail.com> <mdroe@stsci.edu>
 Michael Droettboom <mdboom@gmail.com> Michael Droettboom <mdboom@debian-vm>
@@ -211,8 +327,13 @@ Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@michiel-de-hoons-
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@Michiels-MacBook-Pro.local>
 Michiel de Hoon <mjldehoon@yahoo.com> Michiel de Hoon <mdehoon@tkx294.genome.gsc.riken.jp>
 
+Milan Gittler <gittlermilan@seznam.cz>
+Milan Gittler <gittlermilan@seznam.cz> <55838375+Cemonix@users.noreply.github.com>
+
 MinRK <benjaminrk@gmail.com>
 MinRK <benjaminrk@gmail.com> Min RK <minrk@kerbin.local>
+
+Miriam Simone <miriam.rose.simone@gmail.com>
 
 Nelle Varoquaux <nelle.varoquaux@gmail.com>
 
@@ -221,7 +342,11 @@ Nic Eggert <nic.eggert@gmail.com> Nic Eggert <nse23@cornell.edu>
 
 Nicolas P. Rougier <Nicolas.Rougier@inria.fr>
 
+N R Navaneet <navaneetnr@gmail.com> <156576749+nrnavaneet@users.noreply.github.com>
+
 OceanWolf <juichenieder-tigger@yahoo.co.uk>
+
+odile <odilevidrine@gatech.edu> OdileVidrine <65249488+OdileVidrine@users.noreply.github.com>
 
 Olivier Castany <1868182+ocastany@users.noreply.github.com>
 Olivier Castany <1868182+ocastany@users.noreply.github.com> <Olivier@home>
@@ -241,6 +366,10 @@ Paul Ivanov <pivanov314@gmail.com>
 Paul Ivanov <pivanov314@gmail.com> <pi@berkeley.edu>
 Paul Ivanov <pivanov314@gmail.com> <pivanov5@bloomberg.net>
 
+Pedro Marques <pedrom02.dev@gmail.com>
+
+Pedro Peçanha <pedrompecanha27@gmail.com> <60028123+pedrompecanha@users.noreply.github.com>
+
 Per Parker <wisalam@live.com>
 
 Péter Leéh <leeh123peter@gmail.com>
@@ -254,9 +383,31 @@ Phil Elson <pelson.pub@gmail.com> <philipelson@gmail.com>
 
 Philipp Nagel <phil.nagel@bolton-menk.com>
 
+Pirzada Ahmad Faraz <ahmadacer2006@gmail.com>
+Pirzada Ahmad Faraz <ahmadacer2006@gmail.com> <136244856+pirzada-ahmadfaraz@users.noreply.github.com>
+
+photoniker <johannkrauter@googlemail.com> <17592823+photoniker@users.noreply.github.com>
+
+Pranav Raghu <kingprawn5000@gmail.com>
+Pranav Raghu <kingprawn5000@gmail.com> <73378019+Impaler343@users.noreply.github.com>
+
 productivememberofsociety666 <productivememberofsociety666@sol.fr.am> none <none@example.net>
 
+Quentin Peter <qaep2@cam.ac.uk> <impact27@users.noreply.github.com>
+
+Rahul Monani <rahulmonani2004@gmail.com>
+
+Raphael Quast <raphael.quast@geo.tuwien.ac.at>
+
+Ratnabali Dutta <ratnabalidutta26@gmail.com>
+
+Richard Penney <rwp@rwpenney.uk> <rwpenney@users.noreply.github.com>
+
 Rishikesh <rishikksh20@gmail.com>
+
+Roman <121314722+GameRoMan@users.noreply.github.com>
+
+Ruth Comer <ruth.comer@metoffice.gov.uk> <10599679+rcomer@users.noreply.github.com>
 
 Ruth Nainggolan <nainggolan.ruthg@gmail.com> Ruth G. N <32371319+ruthgn@users.noreply.github.com>
 
@@ -267,12 +418,21 @@ Richard Sheridan <richard.sheridan@gmail.com>
 Samesh Lakhotia <samesh.lakhotia@gmail.com>
 Samesh Lakhotia <43701530+sameshl@users.noreply.github.com> <samesh.lakhotia@gmail.com>'
 
+Saumya Agrawal <145997182+saumyacoder1709@users.noreply.github.com> Saumya <you@example.com>
+
 Scott Lasley <selasley@me.com>
+
+Scott Shambaugh <scottshambaugh@users.noreply.github.com> <14363975+scottshambaugh@users.noreply.github.com>
 
 Sebastian Raschka <mail@sebastianraschka.com>
 Sebastian Raschka <mail@sebastianraschka.com> <se.raschka@me.com>
 
 ShawnChen1996 <shawnchen1996@outlook.com>
+
+Shriya Kalakata <shriyakalakata123@gmail.com>
+Shriya Kalakata <shriyakalakata123@gmail.com> <87483933+shriyakalakata@users.noreply.github.com>
+Shriya Kalakata <shriyakalakata123@gmail.com> Shriya Kalakata <shriyakalakata@10-18-248-97.dynapool.wireless.nyu.edu>
+Shriya Kalakata <shriyakalakata123@gmail.com> Shriya Kalakata <shriyakalakata@Shriyas-MacBook-Pro.local>
 
 Sidharth Bansal <bansal.sidharth2996@gmail.com>
 Sidharth Bansal <20972099+SidharthBansal@users.noreply.github.com> <bansal.sidharth2996@gmail.com>
@@ -289,6 +449,8 @@ switham <github@mac-guyver.com> switham <switham_github@mac-guyver.com>
 
 Taehoon Lee <taehoonlee@snu.ac.kr>
 
+Takumasa Nakamura <n.takumasa@gmail.com>
+
 Ted Drain <ted.drain@gmail.com>
 
 Taras Kuzyo <kuzyo.taras@gmail.com>
@@ -303,17 +465,33 @@ Thomas A Caswell <tcaswell@gmail.com> Thomas A Caswell <tcaswell@localhost.local
 
 Till Stensitzki <mail.till@gmx.de>
 
+Tim Hoffmann <2836374+timhoffm@users.noreply.github.com> <tim.hoffmann@zeiss.com>
+
+Tine Zivic <tine.zivic@gmail.com> <43860297+tinezivic@users.noreply.github.com>
+
+Tobias Thrien <thrien@umich.edu> tobias <tobias@freedom.localdomain>
+
+Tom Sarantis <tsarantis@proton.me>
+
 Trish Gillett-Kawamoto <trish.gillett@shopify.com> <discardthree@gmail.com>
 
 Tuan Dung Tran <tuan.d.tran@hotmail.com>
+
+tybeller <ty.c.beller@gmail.com> <73607363+tybeller@users.noreply.github.com>
+
+Valentin Bruch <valentin.bruch@dwd.de>
+Valentin Bruch <valentin.bruch@dwd.de> <46252273+stiglers-eponym@users.noreply.github.com>
 
 Víctor Zabalza <vzabalza@gmail.com>
 
 Vidur Satija <vidursatija@gmail.com>
 
-WANG Aiyong <gepcelway@gmail.com>
+Vishal Pankaj Chandratreya <19171016+tfpf@users.noreply.github.com>
+Vishal Pankaj Chandratreya <19171016+tfpf@users.noreply.github.com> <vpaijc@gmail.com>
 
-Zhili (Jerry) Pan <sasori.pan.jerry@gmail.com>
+vittoboa <boarinivittorio@gmail.com> <38300176+vittoboa@users.noreply.github.com>
+
+WANG Aiyong <gepcelway@gmail.com>
 
 Werner F Bruhin <wernerfbd@gmx.ch>
 
@@ -321,3 +499,7 @@ Yunfei Yang <yangyunf@iits-b473-20053.(none)> Yunfei Yang <yangyunf@iits-b473-20
 Yunfei Yang <yangyunf@iits-b473-20053.(none)> Yunfei Yang <yangyunf@iits-b473-20061.(none)>
 
 Zac Hatfield-Dodds <zac.hatfield.dodds@gmail.com>
+
+Zhili (Jerry) Pan <sasori.pan.jerry@gmail.com>
+
+ZPyrolink <38cz74@gmail.com> <73246085+ZPyrolink@users.noreply.github.com>

--- a/doc/release/prev_whats_new/github_stats_3.10.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.0.rst
@@ -2,17 +2,17 @@
 
 .. _github-stats-3_10_0:
 
-GitHub statistics for 3.10.0 (Dec 13, 2024)
+GitHub statistics for 3.10.0 (Dec 14, 2024)
 ===========================================
 
-GitHub statistics for 2024/05/15 (tag: v3.9.0) - 2024/12/13
+GitHub statistics for 2024/05/15 (tag: v3.9.0) - 2024/12/14
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 100 issues and merged 337 pull requests.
+We closed 106 issues and merged 346 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/84?closed=1>`__
 
-The following 128 authors contributed 1932 commits.
+The following 120 authors contributed 1323 commits.
 
 * abhi-jha
 * Adam J. Stewart
@@ -28,7 +28,7 @@ The following 128 authors contributed 1932 commits.
 * anpaulan
 * Anson0028
 * Anthony Lee
-* anTon
+* Anton
 * Antony Lee
 * Ayoub Gouasmi
 * Brigitta Sipőcz
@@ -44,7 +44,6 @@ The following 128 authors contributed 1932 commits.
 * dale
 * Dani Pinyol
 * Daniel Weiss
-* Danny
 * David Bakaj
 * David Lowry-Duda
 * David Meyer
@@ -73,12 +72,10 @@ The following 128 authors contributed 1932 commits.
 * john
 * Jonas Eschle
 * Jouni K. Seppänen
-* juanis2112
 * Juanita Gomez
 * Justin Hendrick
 * K900
-* Kaustbh
-* Kaustubh
+* Kaustubh Desale
 * Kherim Willems
 * Kyle Sunden
 * Kyra Cho
@@ -103,7 +100,6 @@ The following 128 authors contributed 1932 commits.
 * Nabil
 * nakamura yuki
 * odile
-* OdileVidrine
 * Oscar Gustafsson
 * Panicks28
 * Paul An
@@ -111,11 +107,9 @@ The following 128 authors contributed 1932 commits.
 * PedroBittarBarao
 * Peter Talley
 * Pierre-antoine Comby
-* Pranav
 * Pranav Raghu
 * pre-commit-ci[bot]
 * proximalf
-* r3kste
 * Randolf Scholz
 * Refael Ackermann
 * RickyP24
@@ -123,20 +117,18 @@ The following 128 authors contributed 1932 commits.
 * Ruth Comer
 * Ryan May
 * Sai Chaitanya, Sanivada
-* saranti
 * scaccol
 * Scott Shambaugh
 * Sean Smith
 * Simon May
 * simond07
 * smcgrawDotNet
-* Takumasa N
-* Takumasa N.
 * Takumasa Nakamura
 * thiagoluisbecker
 * Thomas A Caswell
 * Tiago Lubiana
 * Tim Hoffmann
+* Tom Sarantis
 * trananso
 * Trygve Magnus Ræder
 * Victor Liu
@@ -145,8 +137,10 @@ The following 128 authors contributed 1932 commits.
 
 GitHub issues and pull requests:
 
-Pull Requests (337):
+Pull Requests (346):
 
+* :ghpull:`29306`: Backport PR #29242 on branch v3.10.x (DOC: Add kwdoc list to scatter() docstring)
+* :ghpull:`29242`: DOC: Add kwdoc list to scatter() docstring
 * :ghpull:`29299`: Merge v3.9.x into v3.10.x
 * :ghpull:`29296`: Backport PR #29295 on branch v3.10.x (BLD: Pin meson-python to <0.17.0)
 * :ghpull:`29290`: Backport PR #29254 on branch v3.10.x (DOC: Add note to align_labels())
@@ -225,6 +219,7 @@ Pull Requests (337):
 * :ghpull:`29097`: ENH: add back/forward buttons to osx backend move
 * :ghpull:`29095`: Backport PR #29071 on branch v3.10.x (Bump pypa/gh-action-pypi-publish from 1.10.3 to 1.11.0 in the actions group)
 * :ghpull:`29096`: Backport PR #29094 on branch v3.10.x (DOC: fix link in See Also section of axes.violin)
+* :ghpull:`29071`: Bump pypa/gh-action-pypi-publish from 1.10.3 to 1.11.0 in the actions group
 * :ghpull:`29092`: Backport PR #29088 on branch v3.10.x (DOC: Format aliases in kwargs tables)
 * :ghpull:`29094`: DOC: fix link in See Also section of axes.violin
 * :ghpull:`29091`: Backport PR #29085 on branch v3.10.x (FIX: Update GTK3Agg backend export name for consistency)
@@ -269,6 +264,7 @@ Pull Requests (337):
 * :ghpull:`29007`: MNT: Deprecate changing Figure.number
 * :ghpull:`28861`: Break Artist._remove_method reference cycle
 * :ghpull:`28478`: bugfix for ``PathSimplifier``
+* :ghpull:`29001`: Cycler signature code format fix
 * :ghpull:`28992`: DOC: Refresh transform tree example
 * :ghpull:`28890`: MNT: Add missing dependency to environment.yml
 * :ghpull:`28354`: Add Quiverkey zorder option
@@ -304,6 +300,7 @@ Pull Requests (337):
 * :ghpull:`27349`: [ENH] Implement dynamic clipping to axes limits for 3D plots
 * :ghpull:`28913`: DOC: Fix Axis.set_label reference
 * :ghpull:`28911`: MNT: Fix double evaluation of _LazyTickList
+* :ghpull:`28910`: Bump the actions group across 1 directory with 5 updates
 * :ghpull:`28584`: MNT: Prevent users from erroneously using legend label API on Axis
 * :ghpull:`28853`: MNT: Check the input sizes of regular X,Y in pcolorfast
 * :ghpull:`28838`: TST: Fix minor issues in interactive backend test
@@ -314,6 +311,7 @@ Pull Requests (337):
 * :ghpull:`28896`: doc: specify non-python dependencies in dev install docs
 * :ghpull:`28843`: MNT: Cleanup FontProperties __init__ API
 * :ghpull:`28683`: MNT: Warn if fixed aspect overwrites explicitly set data limits
+* :ghpull:`28879`: doc: add pandas and xarray fixtures to testing API docs
 * :ghpull:`25645`: Fix issue with sketch not working on PathCollection in Agg
 * :ghpull:`28886`: DOC: Cross-link Axes attributes
 * :ghpull:`28880`: Remove 'in' from removal substitution for deprecation messages
@@ -342,6 +340,7 @@ Pull Requests (337):
 * :ghpull:`27938`: feat: add dunder method for math operations on Axes Size divider
 * :ghpull:`28569`: Adding tags to many examples
 * :ghpull:`28183`: Expire deprecations
+* :ghpull:`28796`: Add example of petroff10 in the style sheets to show how to use the color sequence.
 * :ghpull:`28801`: DOC: Clarify AxLine.set_xy2 / AxLine.set_slope
 * :ghpull:`28788`: TST: Skip webp tests if it isn't available
 * :ghpull:`28550`: Remove internal use of ``Artist.figure``
@@ -377,6 +376,7 @@ Pull Requests (337):
 * :ghpull:`28709`: Bump actions/attest-build-provenance from 1.4.0 to 1.4.1 in the actions group
 * :ghpull:`28707`: Avoid division-by-zero in Sketch::Sketch
 * :ghpull:`28610`: CI: Add CI to test matplotlib against free-threaded Python
+* :ghpull:`28677`: Doc: add axes titles to axhspan/axvspan
 * :ghpull:`28262`: Fix PolygonSelector cursor to temporarily hide during active zoom/pan
 * :ghpull:`28670`: API: deprecate unused helper in patch._Styles
 * :ghpull:`28589`: Qt embedding example: Separate drawing and data retrieval timers
@@ -411,6 +411,7 @@ Pull Requests (337):
 * :ghpull:`28073`: Add support for multiple hatches, edgecolors and linewidths in histograms
 * :ghpull:`28594`: MNT: Raise on GeoAxes limits manipulation
 * :ghpull:`28312`: Remove one indirection layer in ToolSetCursor.
+* :ghpull:`28566`: MNT: Update label for Tag proposal issue template
 * :ghpull:`28573`: ENH: include property name in artist AttributeError
 * :ghpull:`28503`: Bump minimum Python to 3.10
 * :ghpull:`28525`: FIX: colorbar pad for ``ImageGrid``
@@ -485,8 +486,13 @@ Pull Requests (337):
 * :ghpull:`28037`: DOC: Fix inconsistent spacing in some docstrings in _axes.py
 * :ghpull:`28031`: Be more specific in findobj return type
 
-Issues (100):
+Issues (106):
 
+* :ghissue:`28463`: [ENH]: ticker.EngFormatter: allow offset
+* :ghissue:`23490`: [ENH]: Add buttons (plural) attribute to mouseevents
+* :ghissue:`28209`: [Doc]: quiver ‘scale_units’ description is not very not clear
+* :ghissue:`22651`: [ENH]: rgb_to_hsv/hsv_to_rgb could check that the inputs are of floating point dtype
+* :ghissue:`9056`: default filename does not strip invalid characters on windows
 * :ghissue:`29298`: [Doc]: The link at "see also" is incorrect. (Axes.violin)
 * :ghissue:`29248`: [Bug]: Figure.align_labels() confused by GridSpecFromSubplotSpec
 * :ghissue:`26738`: Improve LineCollection docstring further
@@ -504,6 +510,7 @@ Issues (100):
 * :ghissue:`19229`: Add public API for setting an axis unit converter
 * :ghissue:`21108`: [Bug]: Hatch linewidths cannot be modified in an  rcParam context
 * :ghissue:`27784`: [Bug]: Polar plot error bars don't rotate with angle for ``set_theta_direction`` and ``set_theta_offset``
+* :ghissue:`28944`: [Bug]: calling title before making polar plot
 * :ghissue:`29011`: [Bug]: Figure.autofmt_xdate() not working in presence of colorbar with constrained layout
 * :ghissue:`29020`: AIX internal CI build break #Matplotlib
 * :ghissue:`28726`: feature request: support passing DataFrames to table.table

--- a/doc/release/prev_whats_new/github_stats_3.10.1.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.1.rst
@@ -7,10 +7,10 @@ GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/02/27
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 14 issues and merged 107 pull requests.
+We closed 15 issues and merged 107 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/98?closed=1>`__
 
-The following 28 authors contributed 241 commits.
+The following 27 authors contributed 172 commits.
 
 * Anselm Hahn
 * Antony Lee
@@ -23,7 +23,6 @@ The following 28 authors contributed 241 commits.
 * Greg Lucas
 * hannah
 * hu-xiaonan
-* Khushi_29
 * Khushikela29
 * KIU Shueng Chuan
 * Kyle Martin
@@ -153,8 +152,9 @@ Pull Requests (107):
 * :ghpull:`29310`: Backport PR #29292 on branch v3.10.x (Update dependencies.rst)
 * :ghpull:`29308`: Update cibuildwheel workflow
 
-Issues (14):
+Issues (15):
 
+* :ghissue:`29595`: [Bug]: Setting alpha with an array is ignored with jupyterlab %inline backend
 * :ghissue:`28382`: [Bug]: interpolation_stage="rgba" does not respect array-alpha
 * :ghissue:`28780`: Doc build fails with numpy>=2.1.0
 * :ghissue:`29603`: [Bug]: Setting ``text.usetex=True`` in ``pyplot.rcParams`` Raises FIPS Compliance Errors

--- a/doc/release/prev_whats_new/github_stats_3.10.3.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.3.rst
@@ -7,10 +7,10 @@ GitHub statistics for 2025/02/27 (tag: v3.10.1) - 2025/05/08
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 16 issues and merged 78 pull requests.
+We closed 17 issues and merged 78 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/101?closed=1>`__
 
-The following 28 authors contributed 128 commits.
+The following 26 authors contributed 96 commits.
 
 * Alexandra Khoo
 * Antony Lee
@@ -26,7 +26,6 @@ The following 28 authors contributed 128 commits.
 * James Addison
 * Jody Klymak
 * Kyle Sunden
-* Marten H. van Kerkwijk
 * Marten Henric van Kerkwijk
 * martincornejo
 * Mateusz Sokół
@@ -39,7 +38,6 @@ The following 28 authors contributed 128 commits.
 * Ruth Comer
 * Thomas A Caswell
 * Tim Hoffmann
-* Weh Andreas
 
 GitHub issues and pull requests:
 
@@ -124,8 +122,9 @@ Pull Requests (78):
 * :ghpull:`29584`: DOC: Recommend constrained_layout over tight_layout
 * :ghpull:`29552`: Bug Fix: Normalize kwargs for Histogram
 
-Issues (16):
+Issues (17):
 
+* :ghissue:`29959`: [MNT]: Python 3.14.0a7 test failures
 * :ghissue:`29183`: [Bug]: I give an RGB image to imsave but I don't have the right color map!
 * :ghissue:`29797`: [MNT]: Flaky Windows_py31x tests on Azure Pipelines
 * :ghissue:`26827`: [Bug]: ImportError when using Matplotlib v3.8.0 in Python package tests

--- a/doc/release/prev_whats_new/github_stats_3.10.5.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.5.rst
@@ -3,27 +3,22 @@
 GitHub statistics for 3.10.5 (Jul 31, 2025)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/07/31
+GitHub statistics for 2025/05/08 (tag: v3.10.3) - 2025/07/31
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 18 issues and merged 67 pull requests.
+We closed 18 issues and merged 66 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/102?closed=1>`__
 
-The following 36 authors contributed 371 commits.
+The following 21 authors contributed 81 commits.
 
 * Antony Lee
 * Brian Christian
 * chrisjbillington
-* Christine P. Chai
 * Clément Robert
 * David Stansby
-* dependabot[bot]
 * Elliott Sales de Andrade
-* G.D. McBain
-* Greg Lucas
 * hannah
-* hu-xiaonan
 * Ian Thomas
 * ianlv
 * IdiotCoffee
@@ -31,27 +26,17 @@ The following 36 authors contributed 371 commits.
 * Inês Cachola
 * Jody Klymak
 * Jouni K. Seppänen
-* Khushi_29
 * Kyle Sunden
 * Lumberbot (aka Jack)
 * N R Navaneet
-* Nathan G. Wiseman
-* Oscar Gustafsson
-* Praful Gulani
-* Qian Zhang
-* Raphael Erik Hviding
 * Roman
-* Roman A
 * Ruth Comer
-* saikarna913
-* Scott Shambaugh
 * Thomas A Caswell
 * Tim Hoffmann
-* Trygve Magnus Ræder
 
 GitHub issues and pull requests:
 
-Pull Requests (67):
+Pull Requests (66):
 
 * :ghpull:`30357`: CIBW updates: fix pypy sections, update cibw version
 * :ghpull:`30356`: Manual Backport PR #30195 on branch v3.10.x (ci: Enable wheel builds on Python 3.14)

--- a/doc/release/prev_whats_new/github_stats_3.10.6.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.6.rst
@@ -3,51 +3,33 @@
 GitHub statistics for 3.10.6 (Aug 29, 2025)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/08/29
+GitHub statistics for 2025/07/31 (tag: v3.10.5) - 2025/08/29
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 4 issues and merged 19 pull requests.
+We closed 5 issues and merged 20 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/103?closed=1>`__
 
-The following 31 authors contributed 380 commits.
+The following 12 authors contributed 47 commits.
 
 * Alan Burlot
 * Antony Lee
-* Christine P. Chai
 * David Stansby
-* dependabot[bot]
 * Doron Behar
 * Elliott Sales de Andrade
-* G.D. McBain
-* Greg Lucas
 * hannah
-* hu-xiaonan
 * Ian Thomas
-* Inês Cachola
 * Jody Klymak
-* Jouni K. Seppänen
-* Khushi_29
 * Kyle Sunden
-* Lumberbot (aka Jack)
-* N R Navaneet
-* Nathan G. Wiseman
-* Oscar Gustafsson
-* Praful Gulani
-* Qian Zhang
-* Raphael Erik Hviding
-* Roman
 * Ruth Comer
-* saikarna913
-* Scott Shambaugh
 * Thomas A Caswell
 * Tim Hoffmann
-* Trygve Magnus Ræder
 
 GitHub issues and pull requests:
 
-Pull Requests (19):
+Pull Requests (20):
 
+* :ghpull:`30488`: Backport PR #30486 on branch v3.10.x (doc: Update warnings about python-build-standalone)
 * :ghpull:`30487`: Backport PR #30484 on branch v3.10.x (FIX: be more cautious about checking widget size)
 * :ghpull:`30484`: FIX: be more cautious about checking widget size
 * :ghpull:`30481`: Backport PR #30394 on branch v3.10.x (ENH: Gracefully handle python-build-standalone ImportError with Tk)
@@ -68,8 +50,9 @@ Pull Requests (19):
 * :ghpull:`30415`: Backport PR #30414 on branch v3.10.x (DOC: update Cartopy url)
 * :ghpull:`30414`: DOC: update Cartopy url
 
-Issues (4):
+Issues (5):
 
+* :ghissue:`30409`: [Doc]: Update note on uv/python-build-standalone incompatibility
 * :ghissue:`29618`: [Bug]: FigureCanvasQT is seemingly prematurely freed under certain conditions
 * :ghissue:`30390`: [ENH]: Gracefully handle python-build-standalone ImportError
 * :ghissue:`30420`: [ENH]: Support parallel plotting

--- a/doc/release/prev_whats_new/github_stats_3.10.7.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.7.rst
@@ -3,47 +3,23 @@
 GitHub statistics for 3.10.7 (Oct 08, 2025)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/10/08
+GitHub statistics for 2025/08/29 (tag: v3.10.6) - 2025/10/08
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 4 issues and merged 16 pull requests.
+We closed 5 issues and merged 16 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/105?closed=1>`__
 
-The following 32 authors contributed 422 commits.
+The following 8 authors contributed 25 commits.
 
 * Aasma Gupta
-* AASMA GUPTA
-* Antony Lee
-* Christine P. Chai
 * David Stansby
-* dependabot[bot]
 * Elliott Sales de Andrade
-* G.D. McBain
-* Greg Lucas
-* hannah
-* hu-xiaonan
-* Ian Thomas
-* Inês Cachola
-* Jody Klymak
-* Jouni K. Seppänen
-* Khushi_29
 * Kyle Sunden
-* Lumberbot (aka Jack)
-* N R Navaneet
-* Nathan G. Wiseman
-* Oscar Gustafsson
-* Praful Gulani
-* Qian Zhang
-* Raphael Erik Hviding
-* Roman
 * Ruth Comer
-* saikarna913
-* Scott Shambaugh
 * Thomas A Caswell
 * Tim Heap
 * Tim Hoffmann
-* Trygve Magnus Ræder
 
 GitHub issues and pull requests:
 
@@ -66,8 +42,9 @@ Pull Requests (16):
 * :ghpull:`30490`: Fix SVG rendering error in def update_background
 * :ghpull:`30494`: Backport PR #30492 on branch v3.10.x (DOC: pytz link should be from PyPI)
 
-Issues (4):
+Issues (5):
 
+* :ghissue:`30617`: [ENH]: pyparsing 3.3.0a1 deprecation warnings
 * :ghissue:`30611`: [MNT]: black version
 * :ghissue:`30551`: [Bug]: Mypy stubtest failure on disjoint_base
 * :ghissue:`30493`: [Bug]: test_save_figure_return seems flaky

--- a/doc/release/prev_whats_new/github_stats_3.10.8.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.8.rst
@@ -3,58 +3,31 @@
 GitHub statistics for 3.10.8 (Nov 12, 2025)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2025/11/12
+GitHub statistics for 2025/10/08 (tag: v3.10.7) - 2025/11/12
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 4 issues and merged 16 pull requests.
+We closed 4 issues and merged 15 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/106?closed=1>`__
 
-The following 35 authors contributed 445 commits.
+The following 9 authors contributed 26 commits.
 
-* Aasma Gupta
-* Antony Lee
-* Christine P. Chai
-* David Stansby
-* dependabot[bot]
 * Elliott Sales de Andrade
-* G.D. McBain
 * Greg Lucas
 * hannah
 * heinrich5991
-* hu-xiaonan
-* Ian Thomas
-* Inês Cachola
-* Jody Klymak
-* Jouni K. Seppänen
-* Khushi_29
 * Kyle Sunden
-* Lucas Gruwez
-* Lumberbot (aka Jack)
-* N R Navaneet
-* Nathan G. Wiseman
 * Nathan Goldbaum
 * Nick Coish
-* Oscar Gustafsson
-* Praful Gulani
-* Qian Zhang
 * Rafael Katri
-* Raphael Erik Hviding
-* Roman
-* Ruth Comer
-* saikarna913
-* Scott Shambaugh
-* Thomas A Caswell
 * Tim Hoffmann
-* Trygve Magnus Ræder
 
 GitHub issues and pull requests:
 
-Pull Requests (16):
+Pull Requests (15):
 
 * :ghpull:`30717`: Backport PR #30714 on branch v3.10.x (FIX: Gracefully handle numpy arrays as input to check_in_list())
 * :ghpull:`30714`: FIX: Gracefully handle numpy arrays as input to check_in_list()
-* :ghpull:`30560`: Consistent zoom boxes
 * :ghpull:`30711`: Backport PR #30697 on branch v3.10.x (BUG: raise when creating a MacOS FigureManager outside the main thread)
 * :ghpull:`30697`: BUG: raise when creating a MacOS FigureManager outside the main thread
 * :ghpull:`30656`: Backport PR #29810 on branch v3.10.x (Declare free-threaded support in MacOS backend extension)

--- a/doc/release/prev_whats_new/github_stats_3.10.9.rst
+++ b/doc/release/prev_whats_new/github_stats_3.10.9.rst
@@ -3,57 +3,35 @@
 GitHub statistics for 3.10.9 (Apr 23, 2026)
 ===========================================
 
-GitHub statistics for 2024/12/14 (tag: v3.10.0) - 2026/04/23
+GitHub statistics for 2025/11/13 (tag: v3.10.8) - 2026/04/23
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 10 issues and merged 34 pull requests.
+We closed 10 issues and merged 35 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/107?closed=1>`__
 
-The following 37 authors contributed 519 commits.
+The following 14 authors contributed 65 commits.
 
-* Aasma Gupta
 * Aman Srivastava
-* Antony Lee
-* beelauuu
 * Ben Root
-* Christine P. Chai
-* David Stansby
-* dependabot[bot]
+* Brian Lau
 * Elliott Sales de Andrade
-* G.D. McBain
-* Greg Lucas
-* hannah
-* hu-xiaonan
-* Ian Thomas
-* Inês Cachola
-* Jody Klymak
-* Jouni K. Seppänen
-* Khushi_29
 * Kyle Sunden
 * Lumberbot (aka Jack)
 * m-sahare
-* N R Navaneet
-* Nathan G. Wiseman
-* Oscar Gustafsson
-* Praful Gulani
-* Qian Zhang
-* Raphael Erik Hviding
 * Raphael Quast
-* Roman
 * Ruth Comer
-* saikarna913
 * Scott Shambaugh
 * Steve Berardi
 * Thomas A Caswell
 * Tim Hoffmann
-* Trygve Magnus Ræder
 * Vikash Kumar
 
 GitHub issues and pull requests:
 
-Pull Requests (34):
+Pull Requests (35):
 
+* :ghpull:`31558`: Backport PR #31556 on branch v3.10.x (FIX: Inverted PyErr_Occurred check in enum type caster (_enums.h))
 * :ghpull:`31556`: FIX: Inverted PyErr_Occurred check in enum type caster (_enums.h)
 * :ghpull:`31078`: Backport PR #31075 on branch v3.10.x (Fix remove method for figure title and xy-labels)
 * :ghpull:`31280`: Backport PR #31278 on branch v3.10.x (Fix ``clabel`` manual argument not accepting unit-typed coordinates)

--- a/doc/release/prev_whats_new/github_stats_3.5.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.5.0.rst
@@ -452,7 +452,6 @@ Pull Requests (939):
 * :ghpull:`21089`: Update sticky_edges docstring to new behavior.
 * :ghpull:`21084`: Backport PR #20988 on branch v3.5.x (Add HiDPI support in GTK.)
 * :ghpull:`21085`: Backport PR #21082 on branch v3.5.x (Fix layout of sidebar entries)
-* :ghpull:`20345`: ENH: call update_ticks before we return them to the user
 * :ghpull:`21082`: Fix layout of sidebar entries
 * :ghpull:`20988`: Add HiDPI support in GTK.
 * :ghpull:`21080`: Backport PR #19619 on branch v3.5.x (Fix bug in shape assignment)

--- a/doc/release/prev_whats_new/github_stats_3.6.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.6.0.rst
@@ -2,17 +2,17 @@
 
 .. _github-stats-3-6-0:
 
-GitHub statistics for 3.6.0 (Sep 15, 2022)
+GitHub statistics for 3.6.0 (Sep 16, 2022)
 ==========================================
 
-GitHub statistics for 2021/11/16 (tag: v3.5.0) - 2022/09/15
+GitHub statistics for 2021/11/16 (tag: v3.5.0) - 2022/09/16
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 202 issues and merged 894 pull requests.
+We closed 223 issues and merged 900 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/65?closed=1>`__
 
-The following 174 authors contributed 4425 commits.
+The following 167 authors contributed 3677 commits.
 
 * Abhishek K M
 * Adeel Hassan
@@ -25,7 +25,6 @@ The following 174 authors contributed 4425 commits.
 * andrzejnovak
 * Andrés Martínez
 * Anna Mastori
-* AnnaMastori
 * Ante Sikic
 * Antony Lee
 * arndRemy
@@ -73,7 +72,6 @@ The following 174 authors contributed 4425 commits.
 * Haziq Khurshid
 * Henry
 * henrybeUM
-* Hood
 * Hood Chatham
 * Ian Hunt-Isaak
 * Ian Thomas
@@ -103,14 +101,13 @@ The following 174 authors contributed 4425 commits.
 * kislovskiy
 * KIU Shueng Chuan
 * kjain
-* kolibril13
 * krassowski
 * Krish-sysadmin
-* Leeh Peter
 * lgfunderburk
 * Liam Toney
 * Lucas Ricci
 * Luke Davis
+* Lumberbot (aka Jack)
 * luz paz
 * mackopes
 * MAKOMO
@@ -122,8 +119,7 @@ The following 174 authors contributed 4425 commits.
 * Matthew Feickert
 * Matthias Bussonnier
 * Mauricio Collares
-* MeeseeksMachine
-* melissawm
+* Melissa Weber Mendonça
 * Mr-Milk
 * Navid C. Constantinou
 * Nickolaos Giannatos
@@ -143,13 +139,12 @@ The following 174 authors contributed 4425 commits.
 * Raphael Quast
 * rditlar9
 * Richard Penney
-* richardsheridan
+* Richard Sheridan
 * Rike-Benjamin Schuppner
 * Robert Cimrman
 * Roberto Toro
 * root
 * Ruth Comer
-* Ruth G. N
 * Ruth Nainggolan
 * Ryan May
 * Rémi Achard
@@ -165,7 +160,6 @@ The following 174 authors contributed 4425 commits.
 * Sven Eschlbeck
 * sveneschlbeck
 * takimata
-* tfpf
 * Thomas A Caswell
 * Tim Hoffmann
 * Tobias Megies
@@ -175,7 +169,6 @@ The following 174 authors contributed 4425 commits.
 * unknown
 * Uwe Hubert
 * vfdev-5
-* Vishal Chandratreya
 * Vishal Pankaj Chandratreya
 * Vishnu V K
 * vk0812
@@ -191,7 +184,7 @@ The following 174 authors contributed 4425 commits.
 
 GitHub issues and pull requests:
 
-Pull Requests (894):
+Pull Requests (900):
 
 * :ghpull:`23814`: Consolidate release notes for 3.6
 * :ghpull:`23899`: Backport PR #23885 on branch v3.6.x (DOC: Rearrange navbar-end elements)
@@ -1042,10 +1035,12 @@ Pull Requests (894):
 * :ghpull:`21379`: Simplify filename tracking in FT2Font.
 * :ghpull:`21278`: Clear findfont cache when calling addfont().
 * :ghpull:`21400`: Use bbox.{size,bounds,width,height,p0,...} where appropriate.
+* :ghpull:`21402`: Do not use mutables as default parameters
 * :ghpull:`21408`: Reword annotations tutorial section titles.
 * :ghpull:`21371`: Rename default branch
 * :ghpull:`21389`: Log pixel coordinates in event_handling coords_demo example on terminal/console
 * :ghpull:`21376`: Factor common parts of saving to different formats using pillow.
+* :ghpull:`21385`: Document what indexing a GridSpec returns
 * :ghpull:`21377`: Enable tests for text path based markers
 * :ghpull:`21283`: Demonstrate inset_axes in scatter_hist example.
 * :ghpull:`21356`: Raise an exception when find_tex_file fails to find a file.
@@ -1066,10 +1061,13 @@ Pull Requests (894):
 * :ghpull:`21213`: Compress comments in make_image.
 * :ghpull:`21187`: Deprecate error_msg_foo helpers.
 * :ghpull:`21190`: Deprecate mlab.stride_windows.
+* :ghpull:`17096`: Add conda environment.yml for developers
 * :ghpull:`21152`: Rename ``**kw`` to ``**kwargs``.
 * :ghpull:`21087`: Move colormap examples from userdemo to images_contours_and_fields.
 * :ghpull:`21074`: Deprecate MarkerStyle(None).
+* :ghpull:`20345`: ENH: call update_ticks before we return them to the user
 * :ghpull:`20990`: Explicit registration of canvas-specific tool subclasses.
+* :ghpull:`21055`: Support marker="none" to mean "no marker".
 * :ghpull:`21049`: Simplify setting Legend attributes
 * :ghpull:`21056`: Deprecate support for no-args MarkerStyle().
 * :ghpull:`21059`: Remove dummy test command from setup.py
@@ -1087,9 +1085,31 @@ Pull Requests (894):
 * :ghpull:`20957`: legend_handler_map cleanups.
 * :ghpull:`20955`: Remove unused HostAxes._get_legend_handles.
 * :ghpull:`20851`: Try to install the Noto Sans CJK font
+* :ghpull:`20898`: Reword BoundaryNorm docs.
 
-Issues (202):
+Issues (223):
 
+* :ghissue:`22262`: [ENH]: Support for custom/special ticks without complex workarounds
+* :ghissue:`20746`: autoinfer norms from scale names in the "norm" kwarg of imshow() and friends.
+* :ghissue:`16935`: Unable to append to array.array after using it in a plot
+* :ghissue:`19080`: deprecation of validCap, validJoin makes pydoc spam out many, many warnings
+* :ghissue:`7556`: document when derived values (ex tick locations and labels) are computed
+* :ghissue:`16217`: pcolormesh with shading=gouraud gives error when saved as eps
+* :ghissue:`22690`: [Bug]: supports_blit is True with MacOSX backend
+* :ghissue:`7089`: matplotlibrc reader cannot handle rcparams with a hash
+* :ghissue:`4058`: regularize ``get_window_extent``
+* :ghissue:`16747`: Incosistent keyword arguments
+* :ghissue:`21285`: legend.get_window_extent() fails
+* :ghissue:`21802`: [Bug]: Pickled figure artists can no longer be picked
+* :ghissue:`25038`: [Bug]: Saving eps figure with usetex and no text in the plot fails
+* :ghissue:`21722`: [MNT]: Is the macosx backend (very slowly) leaking strings?
+* :ghissue:`6800`: Calling savefig() changes the return value of ax.get_xticklabels()
+* :ghissue:`21259`: [Bug]: Memory leak in 3.4.3
+* :ghissue:`20055`: new "layout" class
+* :ghissue:`6418`: Update virtualenv + OSX + conda guide
+* :ghissue:`14055`: Purpose of Scatter plot with pie-chart markers example
+* :ghissue:`23230`: [Doc]: How to turn off markers in stem plot
+* :ghissue:`23845`: [Doc]: Rearrange nav bar icons
 * :ghissue:`23827`: backend_gtk3agg.py calls set_device_scale
 * :ghissue:`23560`: [Doc]: mpl_toolkits.axes_grid still mentioned as maintained
 * :ghissue:`23794`: [Doc]: Version switcher broken in devdocs
@@ -1150,6 +1170,7 @@ Issues (202):
 * :ghissue:`23172`: [Bug]: Calling matplotlib.pyplot.show() outside of matplotlib.pyplot.rc_context no longer works
 * :ghissue:`23019`: [Bug]: ``UnicodeDecodeError`` when using some special and accented characters in TeX
 * :ghissue:`23334`: [Doc]: Tk embedding example crashes Spyder
+* :ghissue:`23339`: MultiCursor should be able to bind to axes in more than one figure...
 * :ghissue:`23298`: [Bug]: get_backend() clears figures from Gcf.figs if they were created under rc_context
 * :ghissue:`21942`: [ENH]: add width/height_ratios to subplots and friends
 * :ghissue:`23028`: [ENH]: contour kwarg for negative_linestyle
@@ -1207,7 +1228,6 @@ Issues (202):
 * :ghissue:`22726`: [Bug]: tripcolor ignores clim
 * :ghissue:`21635`: [ENH]: Add a nightly wheel build
 * :ghissue:`9994`: document where nightly wheels are published
-* :ghissue:`22350`: [Bug]: text.usetex Vs. DateFormatter
 * :ghissue:`4976`: missing imshow() subplots when using tight_layout()
 * :ghissue:`22150`: [ENH]: Tool icons are hardly visible in Tk when using a dark theme
 * :ghissue:`22662`: Leave color parameter empty should be fine[ENH]:
@@ -1243,7 +1263,6 @@ Issues (202):
 * :ghissue:`22369`: [Doc]: Incorrect comment in example code for creating adjacent subplots
 * :ghissue:`19174`: connectionstyle arc3 with high rad value pushes up data interval of x-axis and y-axis.
 * :ghissue:`8351`: seaborn styles make "+", "x" markers invisible; proposed workaround for shipped styles
-* :ghissue:`22278`: Deprecate/remove maxdict
 * :ghissue:`19276`: imshow with very large arrays not working as expected
 * :ghissue:`22035`: [ENH]: Specify a custom focal length / FOV for the 3d camera
 * :ghissue:`22264`: [Bug]: new constrained_layout causes axes to go invisible(?)
@@ -1292,3 +1311,4 @@ Issues (202):
 * :ghissue:`17986`: MEP22 per-backend tool registration
 * :ghissue:`4938`: Feature request: add option to disable mathtext parsing
 * :ghissue:`11435`: plt.subplot eats my subplots
+* :ghissue:`6103`: ticklabels empty when not interactive

--- a/doc/release/prev_whats_new/github_stats_3.6.1.rst
+++ b/doc/release/prev_whats_new/github_stats_3.6.1.rst
@@ -12,7 +12,7 @@ These lists are automatically generated, and may be incomplete or contain duplic
 We closed 22 issues and merged 80 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/73?closed=1>`__
 
-The following 19 authors contributed 129 commits.
+The following 19 authors contributed 112 commits.
 
 * Antony Lee
 * baharev
@@ -25,7 +25,7 @@ The following 19 authors contributed 129 commits.
 * hannah
 * Ian Hunt-Isaak
 * Jody Klymak
-* melissawm
+* Melissa Weber Mendonça
 * Oscar Gustafsson
 * Ruth Comer
 * slackline
@@ -55,7 +55,7 @@ Pull Requests (80):
 * :ghpull:`24078`: Backport PR #24047 on branch v3.6.x (Revert #22360: Let TeX handle multiline strings itself)
 * :ghpull:`24047`: Revert #22360: Let TeX handle multiline strings itself
 * :ghpull:`24077`: Backport PR #24054 on branch v3.6.x ( DOC: Move OO-examples from pyplot section)
-* :ghpull:`24054`:  DOC: Move OO-examples from pyplot section
+* :ghpull:`24054`: DOC: Move OO-examples from pyplot section
 * :ghpull:`24072`: Backport PR #24069 on branch v3.6.x (Clarification of marker size in scatter)
 * :ghpull:`24073`: Backport PR #24070 on branch v3.6.x (DOC: colorbar may steal from array of axes)
 * :ghpull:`24070`: DOC: colorbar may steal from array of axes

--- a/doc/release/prev_whats_new/github_stats_3.6.2.rst
+++ b/doc/release/prev_whats_new/github_stats_3.6.2.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2022/10/08 (tag: v3.6.1) - 2022/11/02
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 21 issues and merged 86 pull requests.
+We closed 25 issues and merged 86 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/75?closed=1>`__
 
-The following 22 authors contributed 27 commits.
+The following 23 authors contributed 89 commits.
 
 * Antony Lee
 * Carsten Schnober
@@ -28,6 +28,7 @@ The following 22 authors contributed 27 commits.
 * Jody Klymak
 * Kostya Farber
 * Kyle Sunden
+* Lumberbot (aka Jack)
 * Martok
 * Muhammad Abdur Rakib
 * Oscar Gustafsson
@@ -128,8 +129,12 @@ Pull Requests (86):
 * :ghpull:`24130`: DOC: align contour parameter doc with implementation
 * :ghpull:`24081`: TST: force test with shared test image to run in serial
 
-Issues (21):
+Issues (25):
 
+* :ghissue:`28161`: [Bug]: Pyplot internal bug
+* :ghissue:`24150`: [Doc]: Improve animation.FuncAnimation.save - link parent methods in child's method documentation
+* :ghissue:`24389`: [Bug]: LayoutEngine rect not respected when saving figure with ``rcParams['figure.constrained_layout.use'] = True``
+* :ghissue:`24374`: TypeError: int() argument must be a string, a bytes-like object or a number, not 'KeyboardModifier'[Bug]:
 * :ghissue:`20326`: FuncAnimation Named Arguments
 * :ghissue:`24332`: [Bug]: backend bug in matplotlib==3.6.1 with python3.11 and PySide6==6.4.0.1
 * :ghissue:`24296`: [Doc]:  Axes limits not updated in animate decay

--- a/doc/release/prev_whats_new/github_stats_3.6.3.rst
+++ b/doc/release/prev_whats_new/github_stats_3.6.3.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2022/11/02 (tag: v3.6.2) - 2023/01/11
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 16 issues and merged 107 pull requests.
+We closed 17 issues and merged 107 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/76?closed=1>`__
 
-The following 20 authors contributed 198 commits.
+The following 20 authors contributed 194 commits.
 
 * Antony Lee
 * Chahak Mehta
@@ -147,8 +147,9 @@ Pull Requests (107):
 * :ghpull:`24344`: Add test for colorbar extend alpha
 * :ghpull:`23974`: Fix repeated word typos
 
-Issues (16):
+Issues (17):
 
+* :ghissue:`9960`: Wrong path in the html file when running save function in FuncAnimation
 * :ghissue:`23389`: [Bug]: Colorbar with log scales wrong format
 * :ghissue:`24589`: [Bug]: inset_locator is broken when used with subfigures
 * :ghissue:`10160`: Low resolution (dpi problem) with Qt5 backend on new iMac Pro Retina

--- a/doc/release/prev_whats_new/github_stats_3.7.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.7.0.rst
@@ -9,14 +9,13 @@ GitHub statistics for 2022/09/16 (tag: v3.6.0) - 2023/02/13
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 120 issues and merged 427 pull requests.
+We closed 136 issues and merged 427 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/70?closed=1>`__
 
-The following 112 authors contributed 1962 commits.
+The following 109 authors contributed 1769 commits.
 
 * Abhijnan Bajpai
 * Adrien F. Vincent
-* Ahoy Ahoy
 * Akshit Tyagi
 * Ali Meshkat
 * Almar Klein
@@ -50,6 +49,7 @@ The following 112 authors contributed 1962 commits.
 * Jae-Joon Lee
 * Jakub Klus
 * James Braza
+* Jan-Hendrik Müller
 * Jay Stanley
 * Jef Myers
 * jeffreypaul15
@@ -65,20 +65,19 @@ The following 112 authors contributed 1962 commits.
 * Kanza
 * Karan
 * Kian Eliasi
-* kolibril13
 * Kostya Farber
 * Krutarth Patel
 * Kyle Sunden
 * Leo Singer
 * Lucas Ricci
 * luke
+* Lumberbot (aka Jack)
 * Marc Van den Bossche
 * Martok
-* Marvvxi
+* Marvin
 * Matthew Feickert
 * Mauricio Collares
-* MeeseeksMachine
-* melissawm
+* Melissa Weber Mendonça
 * Mikhail Ryazanov
 * Muhammad Abdur Rakib
 * noatamir
@@ -93,10 +92,9 @@ The following 112 authors contributed 1962 commits.
 * Pratim Ugale
 * pre-commit-ci[bot]
 * ramvikrams
-* richardsheridan
+* Richard Sheridan
 * Ruth Comer
 * Ryan May
-* saranti
 * Scott Shambaugh
 * Shabnam Sadegh
 * Shawn Zhong
@@ -111,11 +109,10 @@ The following 112 authors contributed 1962 commits.
 * Sven Eschlbeck
 * sveneschlbeck
 * takimata
-* tfpf
 * Thomas A Caswell
 * Tiger Nie
 * Tim Hoffmann
-* Tom
+* Tom Sarantis
 * Tortar
 * tsumli
 * tybeller
@@ -131,6 +128,7 @@ GitHub issues and pull requests:
 
 Pull Requests (427):
 
+* :ghpull:`25194`: 370 final
 * :ghpull:`25201`: Backport PR #25196 on branch v3.7.x (Add deprecation for setting data with non sequence type in ``Line2D``)
 * :ghpull:`25196`: Add deprecation for setting data with non sequence type in ``Line2D``
 * :ghpull:`25197`: Backport PR #25193 on branch v3.7.x (Fix displacement of colorbar for eps with bbox_inches='tight')
@@ -167,7 +165,6 @@ Pull Requests (427):
 * :ghpull:`25106`: Fix cursor_demo wrt. Line2D.set_x/ydata not accepting scalars anymore.
 * :ghpull:`25103`: Backport PR #25098 on branch v3.7.x (Correctly pass valinit as keyword in SliderTool.)
 * :ghpull:`25098`: Correctly pass valinit as keyword in SliderTool.
-* :ghpull:`23442`: Remove need to detect math mode in pgf strings
 * :ghpull:`25093`: Backport PR #25092 on branch v3.7.x (Fix distribution of test data)
 * :ghpull:`24893`: STY: make allowed line length 9 longer to 88 from 79
 * :ghpull:`25092`: Fix distribution of test data
@@ -431,7 +428,6 @@ Pull Requests (427):
 * :ghpull:`24441`: DOC: Fix example for what's new imshow so it isn't cut off or crowded.
 * :ghpull:`24443`: Add valid values to ``get_*axis_transform`` docstring
 * :ghpull:`24440`: DOC: Fix colorbar what's new entry so it isn't cut off.
-* :ghpull:`23787`: Use pybind11 for C/C++ extensions
 * :ghpull:`24247`: Split toolkit tests into their toolkits
 * :ghpull:`24432`: DOC: Fix What's New entry for bar_label() formatting.
 * :ghpull:`23101`: Move show() to somewhere naturally inheritable / document what pyplot expects from a backend.
@@ -457,6 +453,7 @@ Pull Requests (427):
 * :ghpull:`24322`: GOV: change security reporting to use tidelift
 * :ghpull:`24305`: Unify logic of ConnectionStyle._Base.{_clip,_shrink}.
 * :ghpull:`24303`: Simplify generate_fontconfig_pattern.
+* :ghpull:`23119`: Small cleanups to QuiverKey.
 * :ghpull:`24319`: Bump mamba-org/provision-with-micromamba from 13 to 14
 * :ghpull:`24239`: Fix mathtext rendering of ``\|`` and sizing of ``|`` and ``\|``
 * :ghpull:`23606`: added offset section & restructured annotations tutorial
@@ -468,7 +465,7 @@ Pull Requests (427):
 * :ghpull:`24298`: List all the places to update when adding a dependency.
 * :ghpull:`24289`: Cleanup image_zcoord example.
 * :ghpull:`23865`: Add test and example for VBoxDivider
-* :ghpull:`24287`:  Simplifying glyph stream logic in ps backend
+* :ghpull:`24287`: Simplifying glyph stream logic in ps backend
 * :ghpull:`24291`: Rely on builtin round() instead of manual rounding.
 * :ghpull:`24062`: Replaced std::random_shuffle with std::shuffle in tri
 * :ghpull:`24278`: Use oldest-supported-numpy for build
@@ -532,7 +529,7 @@ Pull Requests (427):
 * :ghpull:`23579`: Remove direct manipulation of HostAxes.parasites by end users.
 * :ghpull:`23553`: Add tests for ImageGrid
 * :ghpull:`23918`: Merge v3.6.x branch to main
-* :ghpull:`23902`:  Add test and improve examples for mpl_toolkits
+* :ghpull:`23902`: Add test and improve examples for mpl_toolkits
 * :ghpull:`23950`: DOC: Don't import doctest because we're not using it
 * :ghpull:`21006`: Rotate errorbar caps in polar plots
 * :ghpull:`23870`: Implement Sphinx-Gallery's ``make html-noplot``
@@ -559,12 +556,29 @@ Pull Requests (427):
 * :ghpull:`22614`: ENH: Add pan and zoom toolbar handling to 3D Axes
 * :ghpull:`21562`: Add a test for Hexbin Linear
 
-Issues (120):
+Issues (136):
 
+* :ghissue:`19021`: Need a way to check if an axis minor or major grid is on
+* :ghissue:`24387`: [Bug]: plt.tight_layout() after layout='constrained' should at least warn
+* :ghissue:`7751`: Setting logarithmic yscale in Radar chart broken
+* :ghissue:`23465`: [Doc]: Update multiple category bar chart gallery examples
+* :ghissue:`14432`: tight_layout() messes up bbox_to_anchor in legend().
+* :ghissue:`22374`: Animation docs should include a simple "save as gif with pillow" example
+* :ghissue:`24836`: [Bug]: findSystemFonts should not look in subdirectories of C:\Users\Admin\AppData\Local\Microsoft\Windows\Fonts
+* :ghissue:`20841`: [ENH]: matplotlib.pyplot.bar_label - add parameter to skip 0 length labels
+* :ghissue:`3857`: New 'outside' locations for legend
+* :ghissue:`7073`: Legend cut of if using pgf backend
+* :ghissue:`25523`: Using CenterNorm in imshow with a given halfrange does display data when not displaying the colorbar
+* :ghissue:`3745`: Feature Request: Automatic Legend Placement Outside of Figures and Axes
+* :ghissue:`24789`: [ENH]: Ability to Swap autopct and label positions
 * :ghissue:`25176`: [Bug]: Colorbar is displaced when saving as .eps with bbox_inches='tight'
 * :ghissue:`25075`: [Bug]: Widget blitting broken when saving as PDF
 * :ghissue:`25181`: unavoidable warnings in nbagg on ``plt.close``
+* :ghissue:`25164`: [Bug]: LA image mode not working anymore for custom toolbar buttons
+* :ghissue:`25048`: [Doc]: matplotlib.axes.Axes.table bbox parameter
+* :ghissue:`24820`: FigureCanvasTkAgg memory leak
 * :ghissue:`25134`: [Doc]: pyplot.boxplot whisker length wrong docs
+* :ghissue:`24821`: [Bug]: Windows correction is not correct in ``mlab._spectral_helper``
 * :ghissue:`24395`: Any resizing of the plot after plt.show results in an error when closing the window
 * :ghissue:`25107`: [Doc]: annotated_cursor example seems broken
 * :ghissue:`25124`: [Bug]: ax.plot(x,y) disappears after changing y_scale
@@ -635,13 +649,12 @@ Issues (120):
 * :ghissue:`24386`: [Bug]: ``align`` in ``HPacker`` is reversed
 * :ghissue:`23803`: Static code analysis
 * :ghissue:`8990`: Surprising behaviour of mutating input arrays to Axes.plot vs Axes3D.plot
-* :ghissue:`24550`: [ENH]: Warn when a SymLogScale receives values that are all in the linear regime
-* :ghissue:`23416`: [Bug]: Inconsistent y-axis unit label with plot/scatter
 * :ghissue:`23603`: [MNT]: Only a subset of attributes set via ``Axes.tick_params()`` are accessible via public methods and attributes
 * :ghissue:`13858`: matplotlib.sphinxext.plot_directive generates incorrect links when using dirhtml builder
 * :ghissue:`19376`: eventplot: allow a list of alpha channels as in the case with colors
 * :ghissue:`24508`: [Bug]: Re-organization of mpl_toolkits tests broke tools/triage_tests.py
 * :ghissue:`19040`: v3.3.0 Regression, Animation draws artists multiple times.
+* :ghissue:`24228`: [Doc]: Create Animation Tutorial
 * :ghissue:`12324`: DOC: Write a unified backend doc
 * :ghissue:`24464`: Issue with legend labelcolor='linecolor' for errorbar plots
 * :ghissue:`24273`: [ENH]: Axes.set_xticks/Axis.set_ticks only validates kwargs if ticklabels are set, but they should

--- a/doc/release/prev_whats_new/github_stats_3.7.1.rst
+++ b/doc/release/prev_whats_new/github_stats_3.7.1.rst
@@ -2,21 +2,20 @@
 
 .. _github-stats-3-7-1:
 
-GitHub statistics for 3.7.1 (Mar 03, 2023)
+GitHub statistics for 3.7.1 (Mar 04, 2023)
 ==========================================
 
-GitHub statistics for 2023/02/13 (tag: v3.7.0) - 2023/03/03
+GitHub statistics for 2023/02/13 (tag: v3.7.0) - 2023/03/04
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 14 issues and merged 62 pull requests.
+We closed 18 issues and merged 62 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/80?closed=1>`__
 
-The following 16 authors contributed 129 commits.
+The following 15 authors contributed 85 commits.
 
 * Albert Y. Shih
 * Antony Lee
-* devRD
 * Elliott Sales de Andrade
 * Fabian Joswig
 * Greg Lucas
@@ -98,8 +97,9 @@ Pull Requests (62):
 * :ghpull:`25215`: Backport PR #25198 - DOC: remove constrained_layout kwarg from examples
 * :ghpull:`25198`: DOC: remove constrained_layout kwarg from examples
 
-Issues (14):
+Issues (18):
 
+* :ghissue:`25602`: [Bug]: Any operation on matplotlib fails due to gtk4 backend error
 * :ghissue:`25361`: [Doc]: matplotlib.patches.ArrowStyle
 * :ghissue:`25365`: [Bug]: Inconsistent size/padx for spacers in NavigationToolbar2Tk._rescale and _Spacer
 * :ghissue:`25212`: [Bug]: LICENSE_QHULL is included in wheel only the second time
@@ -108,9 +108,12 @@ Issues (14):
 * :ghissue:`25338`: [Bug]: set_val of rangeslider sets incorrect value
 * :ghissue:`25300`: [Bug]: Unable to pickle figure with draggable legend
 * :ghissue:`25223`: [Doc]: ``layout="none"`` for figure constructor?
+* :ghissue:`24844`: [Doc]: Add alt-text to images in 3.6 release notes
 * :ghissue:`25219`: [Bug]: axes.set_xlim with string dates raises when plotting with datetimes
 * :ghissue:`21666`: [Doc]: Sidebar not always very helpful
 * :ghissue:`25298`: [Bug]: ``axes.labelsize`` is ignored
 * :ghissue:`25233`: [MNT]: FFMpegWriter does not check if out path exists when initialized.
+* :ghissue:`25269`: [Bug]: backend error when in use on Windows
 * :ghissue:`25242`: [Bug]: Relative paths in ``plt.style.use()`` no longer work in 3.7
 * :ghissue:`25251`: [CI]: eslint failure
+* :ghissue:`25227`: [Bug]: errors using pycharm backend

--- a/doc/release/prev_whats_new/github_stats_3.7.2.rst
+++ b/doc/release/prev_whats_new/github_stats_3.7.2.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2023/03/04 (tag: v3.7.1) - 2023/07/05
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 36 issues and merged 156 pull requests.
+We closed 37 issues and merged 155 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/81?closed=1>`__
 
-The following 25 authors contributed 248 commits.
+The following 25 authors contributed 244 commits.
 
 * Adam J. Stewart
 * Antony Lee
@@ -24,7 +24,7 @@ The following 25 authors contributed 248 commits.
 * Greg Lucas
 * Jody Klymak
 * Kyle Sunden
-* MeeseeksMachine
+* Lumberbot (aka Jack)
 * Melissa Weber Mendonça
 * Mubin Manasia
 * NISHANT KUMAR
@@ -42,7 +42,7 @@ The following 25 authors contributed 248 commits.
 
 GitHub issues and pull requests:
 
-Pull Requests (156):
+Pull Requests (155):
 
 * :ghpull:`26260`: Backport PR #25960 on branch v3.7.x (FIX: wspace and hspace in subfigures without layout engine)
 * :ghpull:`25960`: FIX: wspace and hspace in subfigures without layout engine
@@ -86,7 +86,6 @@ Pull Requests (156):
 * :ghpull:`26021`: Backport PR #26005 on branch v3.7.x (Fix backend tests on CI)
 * :ghpull:`25985`: Drop metadata table when subsetting fonts
 * :ghpull:`25978`: Fix subslice optimization for long, fully nan lines.
-* :ghpull:`26002`: Bump pypa/cibuildwheel from 2.12.3 to 2.13.0
 * :ghpull:`26005`: Fix backend tests on CI
 * :ghpull:`26001`: Backport PR #25954 on branch v3.7.x (Add note that subfigure is still provisional to docstring)
 * :ghpull:`25954`: Add note that subfigure is still provisional to docstring
@@ -201,13 +200,14 @@ Pull Requests (156):
 * :ghpull:`25384`: FIX: Remove some numpy function overrides from pylab
 * :ghpull:`25392`: Backport PR #25388 on branch v3.7.x (Better axis labels for examples)
 
-Issues (36):
+Issues (37):
 
+* :ghissue:`19682`: pgf baseline images are OS-dependent
+* :ghissue:`19530`: AnnotationBbox returns weird window_extent?
 * :ghissue:`25511`: [Bug]: wspace and hspace in subfigures not working
 * :ghissue:`26230`: [Bug]: pcolor writing to read-only input mask
 * :ghissue:`26093`: [Bug]: pcolormesh writing to input mask
-* :ghissue:`24453`: [Bug]:  AnnotationBbox does not return correct window_extent before first draw
-* :ghissue:`26161`: [MNT]: install on Python 3.12.0b3
+* :ghissue:`24453`: [Bug]: AnnotationBbox does not return correct window_extent before first draw
 * :ghissue:`26146`: Impossible to get the z value of a line in 3D
 * :ghissue:`26118`: [Bug]: symlog scale generates false warning when mouse is moved
 * :ghissue:`25806`: [Bug]: pdf export for large image sizes results in wrong colors

--- a/doc/release/prev_whats_new/github_stats_3.7.3.rst
+++ b/doc/release/prev_whats_new/github_stats_3.7.3.rst
@@ -12,7 +12,7 @@ These lists are automatically generated, and may be incomplete or contain duplic
 We closed 14 issues and merged 48 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/82?closed=1>`__
 
-The following 17 authors contributed 130 commits.
+The following 17 authors contributed 80 commits.
 
 * amiraflak
 * Amirreza Aflakparast

--- a/doc/release/prev_whats_new/github_stats_3.8.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.8.0.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2023/02/13 (tag: v3.7.0) - 2023/09/14
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 185 issues and merged 649 pull requests.
+We closed 189 issues and merged 648 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/77?closed=1>`__
 
-The following 146 authors contributed 2914 commits.
+The following 138 authors contributed 2269 commits.
 
 * 0xedl
 * Aalok Chhetri
@@ -39,8 +39,6 @@ The following 146 authors contributed 2914 commits.
 * David Stansby
 * dependabot[bot]
 * Devilsaint
-* devRD
-* Dusch4593
 * DWesl
 * Eero Vaher
 * Elliott Sales de Andrade
@@ -58,6 +56,7 @@ The following 146 authors contributed 2914 commits.
 * Hai Zhu
 * hannah
 * Haojun Song
+* Haoying Zhang
 * Hasan Rashid
 * haval0
 * Higgs32584
@@ -74,7 +73,6 @@ The following 146 authors contributed 2914 commits.
 * Jonathan Wheeler
 * jsdodge
 * Julian Chen
-* kolibril13
 * krooijers
 * Kyle Sunden
 * Larry Bradley
@@ -82,6 +80,7 @@ The following 146 authors contributed 2914 commits.
 * lganic
 * Lukas Schrangl
 * luke
+* Lumberbot (aka Jack)
 * marbled-toast
 * mariamalykh
 * Marisa Wong
@@ -91,9 +90,7 @@ The following 146 authors contributed 2914 commits.
 * Matthew Feickert
 * Matthew Morrison
 * Matthias Bussonnier
-* MeeseeksMachine
 * Melissa Weber Mendonça
-* melissawm
 * Michael Dittrich
 * Michael Higgins
 * Mubin Manasia
@@ -106,7 +103,6 @@ The following 146 authors contributed 2914 commits.
 * Pavel Zwerschke
 * Peter Cock
 * Petros Tzathas
-* Photoniker
 * photoniker
 * Pierre Haessig
 * Pieter Eendebak
@@ -119,14 +115,13 @@ The following 146 authors contributed 2914 commits.
 * Ratnabali Dutta
 * rbt94
 * Richard Barnes
-* richardsheridan
+* Richard Sheridan
 * RishabhSpark
 * Rob Righter
 * roberto.bodo
 * root
 * Ruth Comer
 * Sam
-* saranti
 * Scott Shambaugh
 * Shreeya Ramesh
 * Sia Ghelichkhan
@@ -135,14 +130,11 @@ The following 146 authors contributed 2914 commits.
 * SnorfYang
 * Stefanie Molin
 * Steffen Rehberg
-* stevezhang
-* stevezhang1999
 * Talha Irfan
 * Thomas A Caswell
 * Thomas J. Fan
 * Tigran Khachatryan
 * Tim Hoffmann
-* Tom
 * Tom Sarantis
 * Tunç Başar Köse
 * Utkarsh Verma
@@ -163,7 +155,7 @@ The following 146 authors contributed 2914 commits.
 
 GitHub issues and pull requests:
 
-Pull Requests (649):
+Pull Requests (648):
 
 * :ghpull:`26777`: Backport PR #26702 on branch v3.8.x (converted coc to rst and put links in code_of_conduct.md)
 * :ghpull:`26775`: Backport PR #26767 on branch v3.8.x (Trim Gouraud triangles that contain NaN)
@@ -200,7 +192,6 @@ Pull Requests (649):
 * :ghpull:`26695`: Bump actions/checkout from 3 to 4
 * :ghpull:`26694`: Backport PR #26689 on branch v3.8.x (Fix error generation for missing pgf.texsystem.)
 * :ghpull:`26522`: TST: Add failing test
-* :ghpull:`26689`: Fix error generation for missing pgf.texsystem.
 * :ghpull:`26688`: Backport PR #26680 on branch v3.8.x (Fix flaky CI tests)
 * :ghpull:`26680`: Fix flaky CI tests
 * :ghpull:`26675`: Backport PR #26665 on branch v3.8.x (Clarify loading of backend FigureCanvas and show().)
@@ -815,8 +806,12 @@ Pull Requests (649):
 * :ghpull:`24913`: Deprecate Bbox.anchored() with no container.
 * :ghpull:`24905`: Remove some long-obsolete commented code in grid_helper_curvelinear.
 
-Issues (185):
+Issues (189):
 
+* :ghissue:`22389`: [MNT]: gtk4 backends are not tested on GHA
+* :ghissue:`20877`: Possible issue in hexbin using weights
+* :ghissue:`24104`: [Bug]: fig.tight_layout when quiver collection is clipped produces AttributeError
+* :ghissue:`26736`: [ENH]: matplotlib 3.12 prelease wheels
 * :ghissue:`26765`: [Bug]: Crash in Windows 10 if polar axis lim is lower than lowest data point.
 * :ghissue:`26674`: [Doc]: Line3DCollection segments
 * :ghissue:`26531`: [Bug]: ValueError thrown when ``levels`` is set to a lower value than ``vmin`` when using ``contours`` method of Axes
@@ -1002,4 +997,3 @@ Issues (185):
 * :ghissue:`17583`: Linter complains about unexpected data-type, however, docs say this is possible
 * :ghissue:`15926`: Support for Python Type Hints (PEP 484)
 * :ghissue:`13798`: Add PEP484 type hints to the code (For IDE autocompletion / hints)
-

--- a/doc/release/prev_whats_new/github_stats_3.8.1.rst
+++ b/doc/release/prev_whats_new/github_stats_3.8.1.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2023/09/15 (tag: v3.8.0) - 2023/10/31
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 24 issues and merged 95 pull requests.
+We closed 25 issues and merged 95 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/85?closed=1>`__
 
-The following 27 authors contributed 165 commits.
+The following 27 authors contributed 146 commits.
 
 * 0taj
 * Antony Lee
@@ -142,8 +142,9 @@ Pull Requests (95):
 * :ghpull:`26699`: Improve naming of cibuildwheel jobs
 * :ghpull:`26605`: ci: Install GTK4 from brew on macOS
 
-Issues (24):
+Issues (25):
 
+* :ghissue:`27144`: [Doc]: the matplotlib notebook magic requires ``notebook<7``
 * :ghissue:`27120`: [Bug]: macosx backend pause() cannot be ctrl-c'd
 * :ghissue:`27070`: [Bug]: find_nearest_contour deprecated with no replacement?
 * :ghissue:`26913`: Should ``ContourSet.allsegs`` and ``.allkinds`` be deprecated?

--- a/doc/release/prev_whats_new/github_stats_3.8.2.rst
+++ b/doc/release/prev_whats_new/github_stats_3.8.2.rst
@@ -9,13 +9,13 @@ GitHub statistics for 2023/10/31 (tag: v3.8.1) - 2023/11/17
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 3 issues and merged 27 pull requests.
+We closed 2 issues and merged 27 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/86?closed=1>`__
 
-The following 10 authors contributed 39 commits.
+The following 10 authors contributed 53 commits.
 
+* Andrew Kim
 * Antony Lee
-* dohyun
 * Elliott Sales de Andrade
 * hannah
 * Jody Klymak
@@ -57,8 +57,7 @@ Pull Requests (27):
 * :ghpull:`27246`: Backport PR #27244 on branch v3.8.x (Clarify semantics of plt.matshow(..., fignum=...).)
 * :ghpull:`27244`: Clarify semantics of plt.matshow(..., fignum=...).
 
-Issues (3):
+Issues (2):
 
 * :ghissue:`27333`: [Bug]: Spurious lines added with some manually add contour labels
 * :ghissue:`27274`: [Bug]: prune parameter of MaxNLocator has no effect
-* :ghissue:`27262`: [Bug]: Segmentation fault when resizing on Python 3.12 and MacOS 14

--- a/doc/release/prev_whats_new/github_stats_3.8.3.rst
+++ b/doc/release/prev_whats_new/github_stats_3.8.3.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2023/11/17 (tag: v3.8.2) - 2024/02/14
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 18 issues and merged 74 pull requests.
+We closed 19 issues and merged 71 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/88?closed=1>`__
 
-The following 25 authors contributed 133 commits.
+The following 25 authors contributed 114 commits.
 
 * Allan Haldane
 * Antony Lee
@@ -22,6 +22,7 @@ The following 25 authors contributed 133 commits.
 * Elliott Sales de Andrade
 * Greg Lucas
 * hannah
+* Haoying Zhang
 * James Salsman
 * Jody Klymak
 * Joshua Stevenson
@@ -31,22 +32,20 @@ The following 25 authors contributed 133 commits.
 * Oscar Gustafsson
 * Ruth Comer
 * Samuel Diebolt
-* saranti
 * sdiebolt
 * Shriya Kalakata
 * Stefan
 * Steffen Rehberg
-* stevezhang1999
 * Thomas A Caswell
 * Tim Hoffmann
+* Tom Sarantis
 
 GitHub issues and pull requests:
 
-Pull Requests (74):
+Pull Requests (71):
 
 * :ghpull:`27790`: Backport PR #27785 on branch v3.8.x (FIX: be careful about communicating with subprocess)
 * :ghpull:`27789`: Backport PR #27756 on branch v3.8.x (Add protections against infinite loop in bezier calculations)
-* :ghpull:`27785`: FIX: be careful about communicating with subprocess
 * :ghpull:`27756`: Add protections against infinite loop in bezier calculations
 * :ghpull:`27779`: Manual backport of dependabot cibw upgrades
 * :ghpull:`27778`: Backport PR #27773 on branch v3.8.x (MNT: pcolormesh robust underflow)
@@ -54,7 +53,6 @@ Pull Requests (74):
 * :ghpull:`27777`: Backport PR #27776 on branch v3.8.x (Better document the relation between figure and manager)
 * :ghpull:`27776`: Better document the relation between figure and manager
 * :ghpull:`27759`: Backport PR #27755 on branch v3.8.x (Allow threads during macos event loop)
-* :ghpull:`27755`: Allow threads during macos event loop
 * :ghpull:`27742`: Backport PR #27708 on branch v3.8.x (DOC: update colors from colormaps example)
 * :ghpull:`27718`: Backport PR #27716 on branch v3.8.x (fix default image format in gtk4 savefig dialog)
 * :ghpull:`27716`: fix default image format in gtk4 savefig dialog
@@ -71,7 +69,6 @@ Pull Requests (74):
 * :ghpull:`27657`: Fix Numpy 2.0 related test failures
 * :ghpull:`27647`: Fix error that occurs when minorticks are on multi-Axes Figure with more than one boxplot
 * :ghpull:`27660`: Backport PR #27624 on branch v3.8.x (Prepare for Pytest v8)
-* :ghpull:`27624`: Prepare for Pytest v8
 * :ghpull:`27636`: Backport PR #27634 on branch v3.8.x (circle: Make deploy stage into a normal step)
 * :ghpull:`27622`: Backport PR #27620 on branch v3.8.x (DOC: simplify histogram animation example)
 * :ghpull:`27612`: Backport PR #27606 on branch v3.8.x (Pin black version)
@@ -119,8 +116,9 @@ Pull Requests (74):
 * :ghpull:`27365`: [DOC]: Fix menu example
 * :ghpull:`27354`: Backport PR #27348 on branch v3.8.x (updated api/animation documentation as per standards)
 
-Issues (18):
+Issues (19):
 
+* :ghissue:`27627`: Optional Dependencies Link not working on Installing user's page
 * :ghissue:`27437`: [Bug]: PGF backend crashes at program exit after creating a plot
 * :ghissue:`27770`: [Bug]: pcolormesh issue with np.seterr(under='raise')
 * :ghissue:`27720`: [Bug]: pyplot hangs at pause in sonoma 14.3 with backend MacOSX

--- a/doc/release/prev_whats_new/github_stats_3.8.4.rst
+++ b/doc/release/prev_whats_new/github_stats_3.8.4.rst
@@ -5,41 +5,27 @@
 GitHub statistics for 3.8.4 (Apr 03, 2024)
 ==========================================
 
-GitHub statistics for 2023/09/15 (tag: v3.8.0) - 2024/04/03
+GitHub statistics for 2024/02/15 (tag: v3.8.3) - 2024/04/03
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 3 issues and merged 27 pull requests.
+We closed 5 issues and merged 27 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/89?closed=1>`__
 
-The following 26 authors contributed 351 commits.
+The following 12 authors contributed 38 commits.
 
-* 0taj
 * Alec Vercruysse
 * Alexander Volkov
-* Antony Lee
-* Anvi Verma
-* Chiraag Balu
 * David Gilbertson
 * David Stansby
-* dependabot[bot]
 * Elliott Sales de Andrade
-* Eric Firing
-* Greg Lucas
-* Gurudatta Shanbhag
-* hannah
-* James Salsman
 * Jody Klymak
 * Kyle Sunden
 * lkkmpn
-* Lucia Korpas
-* Matthew Morrison
 * Oscar Gustafsson
 * Ruth Comer
-* Samuel Diebolt
 * Thomas A Caswell
 * Tim Hoffmann
-* wemi3
 
 GitHub issues and pull requests:
 
@@ -73,8 +59,10 @@ Pull Requests (27):
 * :ghpull:`27802`: Backport PR #27794 on branch v3.8.x (Remove old reference to 72 DPI in figure_size_units.py)
 * :ghpull:`27794`: Remove old reference to 72 DPI in figure_size_units.py
 
-Issues (3):
+Issues (5):
 
+* :ghissue:`3382`: colormap support for 3d quiver
+* :ghissue:`8484`: a more user-friendly way to specify color for each arrow in 3D quiver?
 * :ghissue:`27953`: [Bug]: Pyplot can no longer set axes properties
 * :ghissue:`11759`: The color of the 3D arrow head does not match that of the arrow body
 * :ghissue:`27826`: [Bug]: Unexpected behavior of scatter.legend_elements

--- a/doc/release/prev_whats_new/github_stats_3.9.0.rst
+++ b/doc/release/prev_whats_new/github_stats_3.9.0.rst
@@ -9,17 +9,16 @@ GitHub statistics for 2023/09/15 (tag: v3.8.0) - 2024/05/15
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 97 issues and merged 450 pull requests.
+We closed 103 issues and merged 456 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/78?closed=1>`__
 
-The following 175 authors contributed 2584 commits.
+The following 163 authors contributed 1906 commits.
 
 * 0taj
 * Abdul Razak Taha
 * Adam J. Stewart
 * Adam Turner
 * Aditi Gautam
-* agautam478
 * Alan Lau
 * Albert Y. Shih
 * Alec Vercruysse
@@ -28,7 +27,7 @@ The following 175 authors contributed 2584 commits.
 * Allan Haldane
 * Amirreza Aflakparast
 * Ananya Devarakonda
-* ananya314
+* Andrew Kim
 * Anja Beck
 * Anjini2004
 * Ant Lockyer
@@ -42,7 +41,6 @@ The following 175 authors contributed 2584 commits.
 * Binaya Sharma
 * Cameron
 * Chaoyi Hu
-* chaoyihu
 * Chiraag Balu
 * Christoph Hasse
 * ConstableCatnip
@@ -54,10 +52,8 @@ The following 175 authors contributed 2584 commits.
 * danielcobej
 * David Gilbertson
 * David Stansby
-* ddale1128@gmail.com
 * dependabot[bot]
 * Devilsaint
-* dohyun
 * Drew Kinneer
 * DWesl
 * Elisa Heckelmann
@@ -65,7 +61,6 @@ The following 175 authors contributed 2584 commits.
 * Elliott Sales de Andrade
 * Eric Firing
 * Eric Prestat
-* esibinga
 * Eva Sibinga
 * Evgenii Radchenko
 * Faisal Fawad
@@ -89,8 +84,6 @@ The following 175 authors contributed 2584 commits.
 * Issam Arabi
 * Jacob Stevens-Haas
 * Jacob Tomlinson
-* Jake
-* Jake Stevens-Haas
 * James Salsman
 * Jaroza727
 * Jeremy Farrell
@@ -123,7 +116,6 @@ The following 175 authors contributed 2584 commits.
 * Matthew Morrison
 * Matthias Bussonnier
 * Melissa Weber Mendonça
-* melissawm
 * mliu08
 * Mostafa Noah
 * MostafaNouh0011
@@ -146,7 +138,6 @@ The following 175 authors contributed 2584 commits.
 * QuadroTec
 * Rafael Tsuha
 * Raghuram Sirigiri
-* Raphael
 * Raphael Quast
 * Ratnabali Dutta
 * rawwash
@@ -157,24 +148,21 @@ The following 175 authors contributed 2584 commits.
 * Ruth Comer
 * samGreer
 * Samuel Diebolt
-* saranti
 * Scott Shambaugh
 * Sebastian Berg
 * Seohyeon Lee
 * Sheepfan0828
 * ShivamPathak99
 * Shriya Kalakata
-* shriyakalakata
 * Stefan
 * Steffen Rehberg
-* stevezhang1999
 * Sudhanshu Pandey
 * Talha Irfan
 * thehappycheese
 * Thomas A Caswell
 * Tiago Lubiana
 * Tim Hoffmann
-* tobias
+* Tobias Thrien
 * Tom Sarantis
 * trananso
 * turnipseason
@@ -192,7 +180,7 @@ The following 175 authors contributed 2584 commits.
 
 GitHub issues and pull requests:
 
-Pull Requests (450):
+Pull Requests (456):
 
 * :ghpull:`28206`: Backport PR #28205 on branch v3.9.x (TST: Fix tests with older versions of ipython)
 * :ghpull:`28207`: TST: Followup corrections to #28205
@@ -270,6 +258,7 @@ Pull Requests (450):
 * :ghpull:`23597`: Always use PyQT/PySide6 for GitHub CI
 * :ghpull:`28013`: Avoid plt.xticks/plt.yticks in gallery examples.
 * :ghpull:`28006`: Fix deprecation warnings in ft2font extension
+* :ghpull:`28003`: [pre-commit.ci] pre-commit autoupdate
 * :ghpull:`27723`: ci: Enable testing on M1 macOS
 * :ghpull:`26375`: Add ``widths``, ``heights`` and ``angles`` setter to ``EllipseCollection``
 * :ghpull:`27999`: Remove documentation that some backends don't support hatching.
@@ -380,6 +369,7 @@ Pull Requests (450):
 * :ghpull:`25815`: [TST] Make jpl units instantiated with datetimes consistent with mpl converters
 * :ghpull:`27729`: DOC: Improve colormap normalization example
 * :ghpull:`27732`: TST: Remove memory leak test
+* :ghpull:`27631`: DOC: update doc/readme.txt & remove devel/readme
 * :ghpull:`27733`: ci: Simplify CodeQL setup
 * :ghpull:`27692`: Add method to update position of arrow patch
 * :ghpull:`27736`: Fix incorrect API reference in docs
@@ -465,6 +455,8 @@ Pull Requests (450):
 * :ghpull:`27013`: Add test_contour under test_datetime.py
 * :ghpull:`27497`: Clarify that set_axisbelow doesn't move grids below images.
 * :ghpull:`27498`: Remove unnecessary del local variables at end of Gcf.destroy.
+* :ghpull:`27476`: Added smoke test for Axes.imshow to test_datetime.py
+* :ghpull:`27282`: DOC: add collection-fontsrecommended to dependencies
 * :ghpull:`27466`: Add test_eventplot to test_datetime.py
 * :ghpull:`25905`: Use annotate coordinate systems to simplify label_subplots.
 * :ghpull:`27471`: Doc: visualizing_tests and ``triage_tests`` tools
@@ -499,6 +491,7 @@ Pull Requests (450):
 * :ghpull:`27387`: Revert "MNT: add _version.py to .gitignore"
 * :ghpull:`27347`: FIX: scale norm of collections when first array is set
 * :ghpull:`27374`: MNT: add _version.py to .gitignore
+* :ghpull:`27335`: DOC: clarify stackplot limits
 * :ghpull:`19011`: Simplify tk tooltip setup.
 * :ghpull:`27367`: Fix _find_fonts_by_props docstring
 * :ghpull:`27359`: Fix build on PyPy
@@ -567,6 +560,7 @@ Pull Requests (450):
 * :ghpull:`27086`: Rename py namespace to mpl in extension code
 * :ghpull:`27082`: MAINT: Update environment.yml to match requirements files
 * :ghpull:`27072`: Remove datetime test stubs for spectral methods/table
+* :ghpull:`26954`: add a mypy pre-commit hook
 * :ghpull:`26830`: Update stix table with Unicode names
 * :ghpull:`26969`: DOC: add units to user/explain [ci doc]
 * :ghpull:`27028`: Added test_hist in test_datetime.py
@@ -633,20 +627,27 @@ Pull Requests (450):
 * :ghpull:`26787`: Remove unused Axis private init helpers.
 * :ghpull:`26629`: DOC: organize figure API
 * :ghpull:`26690`: Make generated pgf code more robust against later changes of tex engine.
-* :ghpull:`26577`: Bugfix: data sanitizing for barh
 * :ghpull:`26684`: Update PR template doc links
 * :ghpull:`26686`: PR template: shorten comment and pull up top
 * :ghpull:`26670`: Added sanitize_sequence to kwargs in _preprocess_data
 * :ghpull:`26634`: [MNT] Move SubplotParams from figure to gridspec
 * :ghpull:`26609`: Cleanup AutoMinorLocator implementation.
 * :ghpull:`26293`: Added get_xmargin(), get_ymargin() and get_zmargin() and tests.
+* :ghpull:`26505`: ci: Don't install recommended packages on Ubuntu
 * :ghpull:`26516`: Replace reference to %pylab by %matplotlib.
 * :ghpull:`26483`: Improve legend(loc='best') warning and test
 * :ghpull:`26482`: [DOC]: print pydata sphinx/mpl theme versions
 * :ghpull:`23787`: Use pybind11 for C/C++ extensions
 
-Issues (97):
+Issues (103):
 
+* :ghissue:`18107`: More strict handling of legend(labels)
+* :ghissue:`22324`: [Bug]: zoom on overlapping axes triggers all axes
+* :ghissue:`1502`: twin axis panning / zooming should be toggleable
+* :ghissue:`17786`: Pyplot methods should link to their parents
+* :ghissue:`28959`: [Bug]: Broken functionality: Qt5/PySide2, using interactive mode, fig.canvas.draw() then fig.canvas.flush_events() leaves plot in non-interactive state.
+* :ghissue:`23815`: [MNT]: Slowly move towards pyproject.toml?
+* :ghissue:`7869`: Take text objects into account in legend autopositioning.
 * :ghissue:`28202`: [Bug]: Qt test_ipython fails on older ipython
 * :ghissue:`28145`: [TST] Upcoming dependency test failures
 * :ghissue:`28034`: [TST] Upcoming dependency test failures
@@ -733,7 +734,6 @@ Issues (97):
 * :ghissue:`26990`: [Doc]: Histogram path example renders poorly in HTML
 * :ghissue:`25738`: [MNT]: Improve readability of _mathtext_data.stix_virtual_fonts table
 * :ghissue:`11129`: Highlight past winners for JDH plotting contest in docs
-* :ghissue:`24050`: No error message in matplotlib.axes.Axes.legend() if there are more labels than handles
 * :ghissue:`10922`: ENH: clear() method for widgets.RadioButtons
 * :ghissue:`18295`: How to modify ticklabels in axisartist?
 * :ghissue:`24996`: [Bug]: for non-rectilinear axes, axvline/axhline should behave as "draw a gridline at that x/y"

--- a/doc/release/prev_whats_new/github_stats_3.9.1.rst
+++ b/doc/release/prev_whats_new/github_stats_3.9.1.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2024/05/15 (tag: v3.9.0) - 2024/07/04
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 30 issues and merged 111 pull requests.
+We closed 33 issues and merged 111 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/91?closed=1>`__
 
-The following 29 authors contributed 184 commits.
+The following 27 authors contributed 114 commits.
 
 * Antony Lee
 * Brigitta Sipőcz
@@ -38,8 +38,6 @@ The following 29 authors contributed 184 commits.
 * Scott Shambaugh
 * simond07
 * SjoerdB93
-* Takumasa N
-* Takumasa N.
 * Takumasa Nakamura
 * Thomas A Caswell
 * Tim Hoffmann
@@ -160,8 +158,11 @@ Pull Requests (111):
 * :ghpull:`28233`: CI: Fix font install on macOS/Homebrew
 * :ghpull:`28231`: DOC: we do not need the blit call in on_draw
 
-Issues (30):
+Issues (33):
 
+* :ghissue:`27025`: [MNT]: Any type hint in subplots
+* :ghissue:`28045`: [ENH]: Improve typing of Figure.subplots
+* :ghissue:`27827`: [Bug]: color=("Cn", alpha) does not work
 * :ghissue:`22482`: [ENH]: pickle (or save) matplotlib figure with insteractive slider
 * :ghissue:`25847`: [Bug]: Graph gets cut off with scaled resolution using gtk4cairo backend
 * :ghissue:`28341`: [Bug]: Incorrect X-axis scaling with date values
@@ -189,6 +190,6 @@ Issues (30):
 * :ghissue:`28221`: [Doc]: drawedges attribute described twice in matplotlib.colorbar documentation
 * :ghissue:`28296`: [Doc]: Missing comma
 * :ghissue:`28256`: [Bug]: axes3d.py's _on_move() converts the roll angle to radians, but then passes it to view_init() as if it were still in degrees
-* :ghissue:`28267`: [Bug]: for Python 3.11.9 gor ValueError: PyCapsule_New called with null pointer
+* :ghissue:`28267`: [Bug]: for Python 3.11.9 got ValueError: PyCapsule_New called with null pointer
 * :ghissue:`28022`: [Bug]: Type of Axes is unknown pyright
 * :ghissue:`28002`: Segfault from path editor example with QtAgg

--- a/doc/release/prev_whats_new/github_stats_3.9.2.rst
+++ b/doc/release/prev_whats_new/github_stats_3.9.2.rst
@@ -12,7 +12,7 @@ These lists are automatically generated, and may be incomplete or contain duplic
 We closed 9 issues and merged 45 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/93?closed=1>`__
 
-The following 20 authors contributed 67 commits.
+The following 20 authors contributed 59 commits.
 
 * Adam J. Stewart
 * Anthony Lee

--- a/doc/release/prev_whats_new/github_stats_3.9.3.rst
+++ b/doc/release/prev_whats_new/github_stats_3.9.3.rst
@@ -9,10 +9,10 @@ GitHub statistics for 2024/08/12 (tag: v3.9.2) - 2024/11/30
 
 These lists are automatically generated, and may be incomplete or contain duplicates.
 
-We closed 6 issues and merged 62 pull requests.
+We closed 7 issues and merged 62 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/95?closed=1>`__
 
-The following 18 authors contributed 90 commits.
+The following 17 authors contributed 90 commits.
 
 * Andresporcruz
 * Antony Lee
@@ -24,7 +24,6 @@ The following 18 authors contributed 90 commits.
 * hannah
 * Kyle Sunden
 * Kyra Cho
-* kyracho
 * Lumberbot (aka Jack)
 * Michael Hinton
 * Oscar Gustafsson
@@ -45,7 +44,6 @@ Pull Requests (62):
 * :ghpull:`29153`: Bump codecov/codecov-action from 4 to 5 in the actions group
 * :ghpull:`29149`: Backport CI config updates to v3.9.x
 * :ghpull:`29121`: Backport PR #29120 on branch v3.9.x (DOC: Switch nested pie example from cmaps to color_sequences)
-* :ghpull:`29071`: Bump pypa/gh-action-pypi-publish from 1.10.3 to 1.11.0 in the actions group
 * :ghpull:`29046`: Backport PR #28981 on branch v3.9.x (FIX: macos: Use standard NSApp run loop in our input hook)
 * :ghpull:`28981`: FIX: macos: Use standard NSApp run loop in our input hook
 * :ghpull:`29041`: Backport PR #29035 on branch v3.9.x (FIX: Don't set_wmclass on GTK3)
@@ -58,6 +56,7 @@ Pull Requests (62):
 * :ghpull:`29014`: FIX: fake out setuptools scm in tox on ci
 * :ghpull:`29010`: Backport PR #29005 on branch v3.9.x (DOC: Update meson-python intersphinx link)
 * :ghpull:`29006`: Backport PR #28993 on branch v3.9.x (FIX: contourf hatches use multiple edgecolors)
+* :ghpull:`29005`: DOC: Update meson-python intersphinx link
 * :ghpull:`28993`: FIX: contourf hatches use multiple edgecolors
 * :ghpull:`28988`: Backport PR #28987 on branch v3.9.x (Fix: Do not use numeric tolerances for axline special cases)
 * :ghpull:`28947`: Backport PR #28925 on branch v3.9.x (TST: handle change in pytest.importorskip behavior)
@@ -100,9 +99,10 @@ Pull Requests (62):
 * :ghpull:`28689`: ci: Enable testing on Python 3.13
 * :ghpull:`28724`: Backport fixes from #28711
 
-Issues (6):
+Issues (7):
 
 * :ghissue:`28960`: [Bug]: High CPU utilization of the macosx backend
+* :ghissue:`29008`: [Bug]: intersphinx on meson-python is broken
 * :ghissue:`28990`: [Bug]: no longer able to set multiple hatch colors
 * :ghissue:`28870`: [Bug]: axline doesn't work with some axes scales
 * :ghissue:`28386`: [Bug]: Minor issue - Drawing an axline sets slopes less than 1E-8 to 0

--- a/doc/release/prev_whats_new/github_stats_3.9.4.rst
+++ b/doc/release/prev_whats_new/github_stats_3.9.4.rst
@@ -12,7 +12,7 @@ These lists are automatically generated, and may be incomplete or contain duplic
 We closed 2 issues and merged 3 pull requests.
 The full list can be seen `on GitHub <https://github.com/matplotlib/matplotlib/milestone/100?closed=1>`__
 
-The following 3 authors contributed 15 commits.
+The following 3 authors contributed 10 commits.
 
 * Elliott Sales de Andrade
 * Scott Shambaugh

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -18,7 +18,7 @@ from subprocess import check_output
 
 from gh_api import (
     get_paged_request, make_auth_header, get_pull_request, is_pull_request,
-    get_milestone_id, get_issues_list, get_authors,
+    get_milestones, get_issues_list, get_authors,
 )
 # -----------------------------------------------------------------------------
 # Globals
@@ -207,6 +207,7 @@ if __name__ == "__main__":
             since -= td
 
     since = round_hour(since)
+    end_date = datetime.today()
 
     milestone = opts.milestone
     project = opts.project
@@ -214,8 +215,15 @@ if __name__ == "__main__":
     print(f'fetching GitHub stats since {since} (tag: {tag}, milestone: {milestone})',
           file=sys.stderr)
     if milestone:
-        milestone_id = get_milestone_id(project=project, milestone=milestone,
-                                        auth=True)
+        all_milestones = get_milestones(project=project, auth=True)
+        for ms in all_milestones:
+            if ms['title'] == milestone:
+                milestone_id = ms['number']
+                if ms.get('closed_at') is not None:
+                    end_date = datetime.fromisoformat(ms['closed_at'])
+                break
+        else:
+            raise ValueError(f"milestone {milestone} not found")
         issues_and_pulls = get_issues_list(project=project, milestone=milestone_id,
                                            state='closed', auth=True)
         issues, pulls = split_pulls(issues_and_pulls, project=project)
@@ -230,16 +238,18 @@ if __name__ == "__main__":
     n_issues, n_pulls = map(len, (issues, pulls))
     n_total = n_issues + n_pulls
     since_day = since.strftime("%Y/%m/%d")
-    today = datetime.today()
 
     title = (f'GitHub statistics for {milestone.lstrip("v")} '
-             f'{today.strftime("(%b %d, %Y)")}')
+             f'{end_date.strftime("(%b %d, %Y)")}')
 
     ncommits = 0
     all_authors = []
     if tag:
         # print git info, in addition to GitHub info:
         since_tag = f'{tag}..'
+        if milestone:
+            if check_output(['git', 'tag', '-l', milestone]).strip():
+                since_tag += milestone
         cmd = ['git', 'log', '--oneline', since_tag]
         ncommits += len(check_output(cmd).splitlines())
 
@@ -250,7 +260,8 @@ if __name__ == "__main__":
     pr_authors = []
     for pr in pulls:
         pr_authors.extend(get_authors(pr))
-    ncommits = len(pr_authors) + ncommits - len(pulls)
+    if not tag:
+        ncommits = len(pr_authors) + ncommits - len(pulls)
     author_cmd = ['git', 'check-mailmap'] + pr_authors
     with_email = check_output(author_cmd,
                               encoding='utf-8', errors='replace').splitlines()
@@ -274,7 +285,7 @@ if __name__ == "__main__":
     # Print summary report we can directly include into release notes.
     print(REPORT_TEMPLATE.format(title=title, title_underline='=' * len(title),
                                  since_day=since_day, tag=tag,
-                                 today=today.strftime('%Y/%m/%d'),
+                                 today=end_date.strftime('%Y/%m/%d'),
                                  n_issues=n_issues, n_pulls=n_pulls,
                                  milestone=milestone_str,
                                  nauthors=len(unique_authors), ncommits=ncommits,

--- a/tools/github_stats.py
+++ b/tools/github_stats.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
             since -= td
 
     since = round_hour(since)
-    end_date = datetime.today()
+    end_date = datetime.today()  # will be overwritten for closed milestones
 
     milestone = opts.milestone
     project = opts.project


### PR DESCRIPTION
## PR summary

This was last updated in cee7684917ce4991bcefa8b02da5825b6ca649cd, which added new contributors up to 0b61e32fedf1190ba2af97c79d92980897077408. This PR handles everything up to 99ae86bc6d52ac429fc1eba40978261a2465905f.

While going through the GitHub stats pages, I found out some annoyances with how GitHub does things. Specifically, _anything_ a contributor "does" online uses the information from the public profile. I put "does" in quotes, because while it does cover explicit actions like committing in the web browser, it also includes one action not initiated directly by a user, but instead by a maintainer: squash merging a PR. In addition, when the script asks GitHub for the authors of a PR, it returns all the authors of the _original_ commits. This means for every PR that is squash merged, we have the chance to count it as (at least) two authors instead of one.

This means that our author count on the GitHub stats pages can sometimes be highly inflated. I have updated the script so that it works better post-release, and regenerated those pages for releases after 0b61e32fedf1190ba2af97c79d92980897077408. Note that in the extreme case, some of the `v3.10.x` pages were generated with `--since v3.10.0` instead of the previous release, so there are quite a few extra not even due to duplicate authors.

<details>
<summary>All changes and reasons why</summary>

I am putting accounts in a code block so to not ping ~75 people on one PR:

- `@34j`: Initial commit in #29954 with proton email, followups committed on GitHub, using masked email. Canonicalized to proton email.
- `@AMAN194701`: commits locally had Title Case name, on GitHub used UPPER CASE.
- `@AasmaGupta`: Some invalid email from local config. Canonicalized to gmail.
- `@AdamOrmondroyd`: commits locally were gmail, on GitHub used the masked email.
- `@AndrGutierrez`: there were two emails and two names (but I think one was a misspelling). Canonicalized on the one that was known to GitHub last (i.e., used for the squash merge.)
- `@AnnaMastori`: Just a minor spacing error, went with the name as in profile.
- `@Atharva2012`: this was a typo: https://github.com/matplotlib/matplotlib/pull/31720#issuecomment-4577527427
- `@Cemonix`: all the name, email, and masked email came in via #29545.
- `@Chirag3841`: the squash merge appears to have used the masked email, but all the commits used gmail.
- `@CouldNot`: commits locally were gmail, on GitHub used the masked email.
- `@DerWeh`: the latter email is the second commit of #29545 (along with a full name), but it is not linked to the GitHub account, so I assume the former is preferred now (and recent activity has not used the full name either, nor does the profile show one, so I won't add it here.)
- `@Dusch4593`: Two names for same email. Canonicalized on GitHub profile name.
- `@GameRoMan`: Used the name as given in the profile.
- `@Impaler343`: commits locally were gmail, on GitHub used the masked email.
- `@Jacob-Stevens-Haas`: Two names for same email. Canonicalized on GitHub profile name.
- `@Kaustbh`: commits locally were gmail, on GitHub used the masked email.
- `@Khushikela29`: commits locally were gmail, on GitHub used the masked email.
- `@Logan-Pageler`: commits locally were gmail, on GitHub used the masked email.
- `@OdileVidrine`: commits locally were gatech, on GitHub used the masked email.
- `@ZPyrolink`: commits locally were gmail, on GitHub used the masked email.
- `@aditya-singh597`: One email used locally, but a different one for the profile. Canonicalized on the profile one?
- `@agautam478`: commits locally were uber, on GitHub used the masked email.
- `@albus-droid`: commits had a mix of name/username for name. Canonicalized on GitHub name in profile.
- `@alphanoobie`: commits locally were gmail, on GitHub used the masked email.
- `@amishamehta99`: #31231 and #31252 are Name <email>; not sure where the masked email came from, but it is linked to the email on GitHub.
- `@ananya314`: commits locally were gmail, on GitHub used the masked email.
- `@andrew-fennell`: two emails, but both are linked to GitHub. Canonicalized on the one used in all commits but one.
- `@aseriesof-tubes`: The email is invalid, and I can't find any other commits here, so I used the GitHub masked email for the user from the PR that introduced it.
- `@beelauuu`: commits locally were .edu, on GitHub used the masked email.
- `@buddy0452004`: Used the name as given in the profile.
- `@chahak13`: both emails are linked to GitHub, but went with the one used more often.
- `@chaoyihu`: commits locally were gmail, on GitHub used the masked email.
- `@ckcherry23`: commits locally were gmail, on GitHub used the masked email.
- `@devRD`: Two names for same email. Canonicalized on GitHub profile name.
- `@dkweiss31`: Original commit in #29073 uses the .edu email and all subsequent commits were using GitHub suggestions, so used the masked email.
- `@dmatos2012`: commits locally used two emails used, on GitHub used the masked email. Canonicalized on the most used email.
- `@esibinga`: commits locally were gmail, on GitHub used the masked email.
- `@greglucas`: Canonicalized on the more recent email.
- `@hasanrashid`: commits locally were gmail, on GitHub used the masked email.
- `@impact27`: commits locally were ac.uk, on GitHub used the masked email.
- `@jayaprajapatii`: Just a minor spacing error, went with name as in profile.
- `@joddeepesh-cloud`: Two names for same email. Canonicalized on the GitHub profile name.
- `@juanis2112`: Two names for same email. Canonicalized on GitHub profile name.
- `@konmenel`: commits locally were gmail (with a mix of full name or username as name), on GitHub used the masked email.
- `@kyracho`: both emails are linked to the GitHub account, but the one I used here is the one in the profile.
- `@lukashergt`: both emails are linked to the GitHub account, but the one I used here is the one in the profile.
- `@mathause`: commits locally were ethz, on GitHub used the masked email.
- `@meeseeksmachine`: Renamed, so set to new name.
- `@melissawm`: A few mixed names/emails, so canonicalize on the current one.
- `@mhvk`: Went with the name in the latest commit, though the GitHub profile doesn't have a middle name at all, so unsure about this one.
- `@miriamsimone`: Multiple names for the single email; went with the full name.
- `@mkrake`: commits locally were gmail, on GitHub used the masked email; also the username changed.
- `@n-takumasa`: Three names for same email. Canonicalized on latest name.
- `@nrnavaneet`: commits locally were gmail, on GitHub (either suggestions or squash merges) used the masked email.
- `@pedrom2002`: Canonicalized on name from profile.
- `@pedrompecanha`: commits locally were gmail, on GitHub used the masked email.
- `@photoniker`: commits locally were gmail, on GitHub used the masked email, I think.
- `@pirzada-ahmadfaraz`: commits locally were gmail, on GitHub used the masked email.
- `@r3kste`: Appears sometimes as Anton, sometimes as anTon, sometimes as r3kste, but the name on the profile is Anton now, so go with that.
- `@raphaelquast`: Two names for same email. Canonicalized on GitHub profile name.
- `@rcomer`: Probably masked email came in from changes made directly on GitHub; went with the Met email.
- `@rwpenney`: commits locally were personal domain, on GitHub used the masked email.
- `@saranti`: name appears 4 different ways with the same email, went with the name in the profile.
- `@saumyacoder1709`: the email address is invalid, and I can't find any other commits with a valid one, so use the masked GitHub email from #30843.
- `@scottshambaugh`: Not sure why there are two masked emails, and neither appears to be more recent, so I went with the more frequent one (125 vs 69 commits.)
- `@shriyakalakata`: commits locally were gmail, on GitHub used the masked email; there was also a couple invalid emails that I canonicalized to this account.
- `@star1327p`: full name is mostly used; not sure why the username snuck in a few places.
- `@stevezhang1999`: first commit had an invalid email, and the rest were a mix of gmail and masked email. Canonicalized on the gmail.
- `@stiglers-eponym`: commits locally were gmail, on GitHub used the masked email.
- `@tfpf`: Replace `tfpf` with full name, as in profile. The username appears in older commits, but full name added later. There's also a gmail, but that seems to not be used any more.
- `@thrien`: the email on the commit from #27440 was invalid, so I took the name/email from the GitHub profile.
- `@timhoffm`: I've never seen the non-masked email before, and though they're in PRs you've made, the commits are no longer linked to your account. So I think those few commits were a mistake or an old email.
- `@tinezivic`: all commits use gmail, except the one squash merged PR, which used the masked email, so go with the first one.
- `@tybeller`: commits locally were gmail, on GitHub used the masked email.
- `@vittoboa`: commits locally were gmail, on GitHub used the masked email.
</details>

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines