### PR TITLE
MNT: Deprecate Line2D.recache_always()

### DIFF
--- a/doc/api/next_api_changes/deprecations/31818-TH.rst
+++ b/doc/api/next_api_changes/deprecations/31818-TH.rst
@@ -1,0 +1,4 @@
+Line2D.recache_always
+~~~~~~~~~~~~~~~~~~~~~
+
+``recache_always()`` on `.Line2D` is deprecated. Use ``recache(always=True)`` instead.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2652,7 +2652,7 @@ class _AxesBase(martist.Artist):
                 self._unit_change_handler, axis_name, event=object())
         _api.check_in_list(self._axis_map, axis_name=axis_name)
         for line in self.lines:
-            line.recache_always()
+            line.recache(always=True)
         self.relim()
         self._request_autoscale_view(axis_name)
 

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -669,6 +669,7 @@ class Line2D(Artist):
         self.set_xdata(x)
         self.set_ydata(y)
 
+    @_api.deprecated("3.12", alternative="recache(always=True)")
     def recache_always(self):
         self.recache(always=True)
 


### PR DESCRIPTION
`recache(always=True)` is sufficient. There is only one usage in our codebase and I've found none on GitHub.

