### PR TITLE
FIX: use data values in bar_label

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2908,10 +2908,8 @@ class Axes(_AxesBase):
 
             if orientation == "vertical":
                 extrema = max(y0, y1) if dat >= 0 else min(y0, y1)
-                length = abs(y0 - y1)
             else:  # horizontal
                 extrema = max(x0, x1) if dat >= 0 else min(x0, x1)
-                length = abs(x0 - x1)
 
             if err is None or np.size(err) == 0:
                 endpt = extrema
@@ -2919,11 +2917,6 @@ class Axes(_AxesBase):
                 endpt = err[:, 1].max() if dat >= 0 else err[:, 1].min()
             else:  # horizontal
                 endpt = err[:, 0].max() if dat >= 0 else err[:, 0].min()
-
-            if label_type == "center":
-                value = sign(dat) * length
-            else:  # edge
-                value = extrema
 
             if label_type == "center":
                 xy = (0.5, 0.5)
@@ -2967,9 +2960,9 @@ class Axes(_AxesBase):
 
             if lbl is None:
                 if isinstance(fmt, str):
-                    lbl = cbook._auto_format_str(fmt, value)
+                    lbl = cbook._auto_format_str(fmt, dat)
                 elif callable(fmt):
-                    lbl = fmt(value)
+                    lbl = fmt(dat)
                 else:
                     raise TypeError("fmt must be a str or callable")
             annotation = self.annotate(lbl,

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -13,7 +13,7 @@ import sys
 from types import SimpleNamespace
 import unittest.mock
 
-import dateutil.tz
+import dateutil
 
 import numpy as np
 from numpy import ma
@@ -9501,6 +9501,13 @@ def test_nan_barlabels():
     labels = ax.bar_label(bars)
     assert [l.get_text() for l in labels] == ['', '1', '2']
     assert np.allclose(ax.get_ylim(), (0.0, 3.0))
+
+
+def test_int_fmt_bar_label():
+    fig, ax = plt.subplots()
+    bars = ax.bar(['foo', 'bar'], [5, 7])
+    labels = ax.bar_label(bars, fmt='{:d}')
+    assert [l.get_text() for l in labels] == ['5', '7']
 
 
 def test_patch_bounds():  # PR 19078


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
This is a minor issue, but...

Currently it is not possible to format bar labels as integers, even if the original data are ints:

```python
import matplotlib.pyplot as plt

fig, ax = plt.subplots()
bars = ax.bar(['foo', 'bar'], [5, 7])
labels = ax.bar_label(bars, fmt='N={:d}')

plt.show()
```
```
Traceback (most recent call last):
  File "/[path-to-git-repo]/matplotlib/lib/matplotlib/cbook.py", line 2546, in _auto_format_str
    return fmt % (value,)
           ~~~~^~~~~~~~~~
TypeError: not all arguments converted during string formatting

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/[path-to-script]/bar_label_example.py", line 5, in <module>
    labels = ax.bar_label(bars, fmt='N={:d}')
  File "/[path-to-git-repo]/matplotlib/lib/matplotlib/axes/_axes.py", line 2970, in bar_label
    lbl = cbook._auto_format_str(fmt, value)
  File "/[path-to-git-repo]/matplotlib/lib/matplotlib/cbook.py", line 2548, in _auto_format_str
    return fmt.format(value)
           ~~~~~~~~~~^^^^^^^
ValueError: Unknown format code 'd' for object of type 'float'
```
The values used are derived from the size of the rectangle, and are therefore always floats.  However, the actual data values are also available in this loop, so I'm not clear why we don't directly use them.   I wondered if it had to do with unit handling, but the data values on the container have already been processed as `height` or `width` within `bar` 

https://github.com/matplotlib/matplotlib/blob/b825c6dd7670504904854b46770670d8f7790a8c/lib/matplotlib/axes/_axes.py#L2517
https://github.com/matplotlib/matplotlib/blob/b825c6dd7670504904854b46770670d8f7790a8c/lib/matplotlib/axes/_axes.py#L2523
https://github.com/matplotlib/matplotlib/blob/b825c6dd7670504904854b46770670d8f7790a8c/lib/matplotlib/axes/_axes.py#L2644-L2647

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
No AI used.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
