### PR TITLE
Partially revert "Fix test_RcParams_class on Python 3.15"

### DIFF
--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -79,19 +79,12 @@ def test_RcParams_class():
                        'font.size': 12})
 
     expected_repr = """
-RcParams({
-          'font.cursive': ['Zapf Chancery', 'cursive'],
+RcParams({'font.cursive': ['Zapf Chancery', 'cursive'],
           'font.family': ['sans-serif'],
           'font.size': 12.0,
-          'font.weight': 'normal',
-         })""".lstrip()
+          'font.weight': 'normal'})""".lstrip()
 
     actual_repr = repr(rc)
-    if sys.version_info[:2] < (3, 15):
-        actual_repr = (actual_repr
-                       .replace("{'", "{\n          '")
-                       .replace("'}", "',\n         }"))
-
     assert actual_repr == expected_repr
 
     expected_str = """


### PR DESCRIPTION
## PR summary

This partially reverts commit 43b79764d5a4668d4cce7ccc32b1e047568f8815, as the change has been [reverted in Python 3.15 b2](https://github.com/python/cpython/pull/150249).

I have left in the shortening of the lists, so that lines are shorter and have less chance of being wrapped in the future.

## AI Disclosure
None

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines