### PR TITLE
DOC: Fix gallery order

### DIFF
--- a/doc/sphinxext/gallery_order.py
+++ b/doc/sphinxext/gallery_order.py
@@ -134,8 +134,6 @@ class MplFileExplicitOrder(ExplicitOrder):
 
         non_existing_examples = listed_examples - existing_examples
         missing_examples = existing_examples - listed_examples
-        print(f"non_existing_examples: {non_existing_examples}")
-        print(f"missing_examples: {missing_examples}")
 
         if non_existing_examples:
             raise ValueError(

--- a/galleries/examples/spines/gallery_order.txt
+++ b/galleries/examples/spines/gallery_order.txt
@@ -2,5 +2,4 @@
 spines
 spine_placement_demo
 spines_dropped
-multiple_yaxis_with_spines
 centered_spines_with_arrows


### PR DESCRIPTION
- Remove unnecessary prints.
- Remove an example that was moved in #31765 (crossed PRs)
