### PR TITLE
DOC: Add missing gallery order for Plot types > Gridded data

### DIFF
--- a/galleries/plot_types/arrays/gallery_order.txt
+++ b/galleries/plot_types/arrays/gallery_order.txt
@@ -1,0 +1,8 @@
+# Explicit example order. See https://matplotlib.org/devdocs/devel/document.html#order-examples
+imshow
+pcolormesh
+contour
+contourf
+barbs
+quiver
+streamplot


### PR DESCRIPTION
Forgot to add this file in #31714.

This maintains the order that has been there before.

