### PR TITLE
FIX: disable pixel snap in eventplot for large event counts

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1517,6 +1517,8 @@ class Axes(_AxesBase):
                                          linestyle=linestyle)
             self.add_collection(coll, autolim=False)
             coll._internal_update(kwargs)
+            if 'snap' not in kwargs and len(positions) > 100:
+                coll.set_snap(False)
             colls.append(coll)
 
         if len(positions) > 0:

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8190,6 +8190,27 @@ def test_eventplot_errors(err, args, kwargs, match):
         plt.eventplot(*args, **kwargs)
 
 
+def test_eventplot_snap_threshold():
+    """Snap is disabled when there are more than 100 event groups."""
+    fig, ax = plt.subplots()
+    positions = [np.random.rand(5) for _ in range(150)]
+    colls = ax.eventplot(positions)
+    for coll in colls:
+        assert coll.get_snap() is False
+
+    fig2, ax2 = plt.subplots()
+    positions_small = [np.random.rand(5) for _ in range(50)]
+    colls_small = ax2.eventplot(positions_small)
+    for coll in colls_small:
+        assert coll.get_snap() is not False
+
+    fig3, ax3 = plt.subplots()
+    positions_explicit = [np.random.rand(5) for _ in range(150)]
+    colls_explicit = ax3.eventplot(positions_explicit, snap=True)
+    for coll in colls_explicit:
+        assert coll.get_snap() is True
+
+
 def test_bar_broadcast_args():
     fig, ax = plt.subplots()
     # Check that a bar chart with a single height for all bars works.


### PR DESCRIPTION
When more than 100 event groups are plotted, the Agg renderer snaps thin lines to the nearest pixel. With many closely spaced rows the rounding can collapse distinct events onto the same pixel, making them invisible.

This disables snap automatically above 100 groups unless the caller passes `snap` explicitly.

A previous attempt (#30053) was closed.

Closes #20243