### PR TITLE
bound ft2font stream read to the requested count

### DIFF
--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -203,6 +203,31 @@ def test_ft2font_invalid_args(tmp_path):
         ft2font.FT2Font(file, _kerning_factor=123)
 
 
+def test_ft2font_oversized_read():
+    # A file object whose read() returns *more* bytes than requested is
+    # misbehaving: FreeType only sizes its buffer for the requested count, so
+    # an over-long read must be rejected rather than overflow the buffer or be
+    # silently truncated. Verify that such an object causes construction to
+    # fail loudly instead.
+    data = Path(fm.findfont('DejaVu Sans')).read_bytes()
+
+    class OversizedReader:
+        def __init__(self, data):
+            self._data = data
+
+        def seek(self, offset):
+            pass
+
+        def read(self, size):
+            # Ignore the requested size and hand back the whole file, which is
+            # far more than FreeType ever asks for. The initial read(0) probe
+            # in the constructor still gets an empty bytes object.
+            return self._data if size else b''
+
+    with pytest.raises(RuntimeError):
+        ft2font.FT2Font(OversizedReader(data))
+
+
 @pytest.mark.parametrize('name, size, skippable',
                          [('DejaVu Sans', 1, False), ('WenQuanYi Zen Hei', 3, True)])
 def test_ft2font_face_index(name, size, skippable):

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -453,6 +453,11 @@ read_from_file_callback(FT_Stream stream, unsigned long offset, unsigned char *b
         if (PyBytes_AsStringAndSize(read_result.ptr(), &tmpbuf, &n_read) == -1) {
             throw py::error_already_set();
         }
+        if ((unsigned long)n_read > count) {
+            // A file object's read() is not obliged to honor the requested
+            // size; FreeType only ever sized `buffer` for `count` bytes.
+            n_read = (Py_ssize_t)count;
+        }
         memcpy(buffer, tmpbuf, n_read);
     } catch (py::error_already_set &eas) {
         eas.discard_as_unraisable(__func__);

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -454,9 +454,13 @@ read_from_file_callback(FT_Stream stream, unsigned long offset, unsigned char *b
             throw py::error_already_set();
         }
         if ((unsigned long)n_read > count) {
-            // A file object's read() is not obliged to honor the requested
-            // size; FreeType only ever sized `buffer` for `count` bytes.
-            n_read = (Py_ssize_t)count;
+            // A well-behaved read() never returns more than the requested
+            // number of bytes.  FreeType only ever sized `buffer` for `count`
+            // bytes, so honoring an over-long read would overflow it.  Rather
+            // than silently truncate (which would feed FreeType corrupt data),
+            // signal a failed read so that FT_Open_Face -- and in turn the
+            // FT2Font constructor -- raises.
+            n_read = 0;
         }
         memcpy(buffer, tmpbuf, n_read);
     } catch (py::error_already_set &eas) {


### PR DESCRIPTION
read_from_file_callback copies len(file.read(count)) bytes into the buffer FreeType hands it, but that buffer is only sized for count. When a font is opened from a binary-mode file object (the io.BinaryIO path), nothing obliges the object's read() to honor the requested size, so a read() that returns more than count walks past the end of the FreeType buffer and corrupts the heap.

Cap n_read at count before the memcpy so both the copy and the returned length stay inside the allocated buffer. Before, an over-long read wrote out of bounds; after, the surplus bytes are dropped and FreeType just sees a full-buffer read. The bound sits in the callback because FreeType owns the buffer size, not the caller; the only tradeoff is that a file object returning more than it was asked for loses the bytes past count, which were never going to be used.
