### PR TITLE
Make plot directive errors fail Sphinx builds

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -203,6 +203,7 @@ import jinja2  # Sphinx dependency.
 
 from sphinx.environment.collectors import EnvironmentCollector
 from sphinx.errors import ExtensionError
+from sphinx.util import logging
 
 import matplotlib
 from matplotlib.backend_bases import FigureManagerBase
@@ -212,6 +213,8 @@ from matplotlib import _pylab_helpers, cbook
 matplotlib.use("agg")
 
 __version__ = 2
+
+_log = logging.getLogger(__name__)
 
 
 # -----------------------------------------------------------------------------
@@ -947,11 +950,11 @@ def run(arguments, content, options, state_machine, state, lineno):
                                      code_includes=source_file_includes)
         errors = []
     except PlotError as err:
+        message = "Exception occurred in plotting {}\n from {}:\n{}".format(
+            output_base, source_file_name, err)
+        _log.warning(message, location=(source_file_name, lineno))
         reporter = state.memo.reporter
-        sm = reporter.system_message(
-            2, "Exception occurred in plotting {}\n from {}:\n{}".format(
-                output_base, source_file_name, err),
-            line=lineno)
+        sm = reporter.system_message(2, message, line=lineno)
         results = [(code, [])]
         errors = [sm]
 

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -16,8 +16,9 @@ pytest.importorskip('sphinx', minversion='4.1.3')
 tinypages = Path(__file__).parent / 'data/tinypages'
 
 
-def build_sphinx_html(source_dir, doctree_dir, html_dir, extra_args=None):
-    # Build the pages with warnings turned into errors
+def build_sphinx_html(
+        source_dir, doctree_dir, html_dir, extra_args=None, expected_returncode=0):
+    # Build the pages with warnings turned into errors.
     extra_args = [] if extra_args is None else extra_args
     cmd = [sys.executable, '-msphinx', '-W', '-b', 'html',
            '-d', str(doctree_dir), str(source_dir), str(html_dir), *extra_args]
@@ -31,12 +32,31 @@ def build_sphinx_html(source_dir, doctree_dir, html_dir, extra_args=None):
     out = proc.stdout
     err = proc.stderr
 
-    assert proc.returncode == 0, \
+    assert proc.returncode == expected_returncode, \
         f"sphinx build failed with stdout:\n{out}\nstderr:\n{err}\n"
-    if err:
+    if expected_returncode == 0 and err:
         pytest.fail(f"sphinx build emitted the following warnings:\n{err}")
 
-    assert html_dir.is_dir()
+    if expected_returncode == 0:
+        assert html_dir.is_dir()
+    return proc
+
+
+def test_plot_directive_exception_fails_build(tmp_path):
+    shutil.copyfile(tinypages / 'conf.py', tmp_path / 'conf.py')
+    shutil.copytree(tinypages / '_static', tmp_path / '_static')
+    (tmp_path / 'index.rst').write_text("""
+.. plot::
+
+    raise RuntimeError("plot directive failure")
+""")
+
+    proc = build_sphinx_html(
+        tmp_path, tmp_path / 'doctrees', tmp_path / '_build' / 'html',
+        expected_returncode=1)
+
+    assert "Exception occurred in plotting index-1" in proc.stderr
+    assert "RuntimeError: plot directive failure" in proc.stderr
 
 
 def test_tinypages(tmp_path):


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Plot execution exceptions are currently converted into Docutils system messages,
so Sphinx does not treat them as warnings and `sphinx-build -W` can still exit
successfully.

Log `PlotError` exceptions through Sphinx while preserving the existing Docutils
system message. This makes warning-as-error builds fail when a plot directive
raises an exception.

Add a regression test that builds a page containing a failing plot directive and
checks that the Sphinx build exits unsuccessfully with the exception details.

closes #30899
## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
OpenAI Codex was used to analyze the issue, implement the change, and draft the
regression test and pull request description. The resulting changes were reviewed
and validated with the available local checks.
## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
