### PR TITLE
MNT: Make get_default_filetype a classmethod

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2717,7 +2717,8 @@ class FigureCanvasPdf(FigureCanvasBase):
     fixed_dpi = 72
     filetypes = {'pdf': 'Portable Document Format'}
 
-    def get_default_filetype(self):
+    @classmethod
+    def get_default_filetype(cls):
         return 'pdf'
 
     def print_pdf(self, filename, *,

--- a/lib/matplotlib/backends/backend_pgf.py
+++ b/lib/matplotlib/backends/backend_pgf.py
@@ -761,7 +761,8 @@ class FigureCanvasPgf(FigureCanvasBase):
                  "pdf": "LaTeX compiled PGF picture",
                  "png": "Portable Network Graphics", }
 
-    def get_default_filetype(self):
+    @classmethod
+    def get_default_filetype(cls):
         return 'pdf'
 
     def _print_pgf_to_fh(self, fh, *, bbox_inches_restore=None):

--- a/lib/matplotlib/backends/backend_ps.py
+++ b/lib/matplotlib/backends/backend_ps.py
@@ -967,7 +967,8 @@ class FigureCanvasPS(FigureCanvasBase):
     filetypes = {'ps': 'Postscript',
                  'eps': 'Encapsulated Postscript'}
 
-    def get_default_filetype(self):
+    @classmethod
+    def get_default_filetype(cls):
         return 'ps'
 
     def _print_ps(

--- a/lib/matplotlib/backends/backend_svg.py
+++ b/lib/matplotlib/backends/backend_svg.py
@@ -1371,7 +1371,8 @@ class FigureCanvasSVG(FigureCanvasBase):
               gzip.GzipFile(mode='w', fileobj=fh) as gzipwriter):
             return self.print_svg(gzipwriter, **kwargs)
 
-    def get_default_filetype(self):
+    @classmethod
+    def get_default_filetype(cls):
         return 'svg'
 
     def draw(self):

--- a/lib/matplotlib/backends/backend_template.py
+++ b/lib/matplotlib/backends/backend_template.py
@@ -199,7 +199,8 @@ class FigureCanvasTemplate(FigureCanvasBase):
         """
         self.draw()
 
-    def get_default_filetype(self):
+    @classmethod
+    def get_default_filetype(cls):
         return 'foo'
 
 


### PR DESCRIPTION
FigureCanvasBase defines get_default_filetype as a class method, but all derived implementations overwrite this with an instance method. All implementations could even be static. But let's coerce to a classmethod for consistency and to not change the public API of FigureCanvasBase

https://github.com/matplotlib/matplotlib/blob/8747449ec55780f509b6af0b1b31e4e8032a75cc/lib/matplotlib/backend_bases.py#L2294-L2295
