### PR TITLE
DOC: Move errorbar examples to the statistics sections

### DIFF
--- a/galleries/examples/lines_bars_and_markers/gallery_order.txt
+++ b/galleries/examples/lines_bars_and_markers/gallery_order.txt
@@ -51,9 +51,6 @@ span_regions
 stem_plot
 
 # other
-errorbar_limits_simple
-errorbar_subsample
 categorical_variables
 masked_demo
-curve_error_band
 spectrum_demo

--- a/galleries/examples/statistics/curve_error_band.py
+++ b/galleries/examples/statistics/curve_error_band.py
@@ -6,6 +6,8 @@ Curve with error band
 This example illustrates how to draw an error band around a parametrized curve.
 
 A parametrized curve x(t), y(t) can directly be drawn using `~.Axes.plot`.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/curve_error_band
 """
 # sphinx_gallery_thumbnail_number = 2
 

--- a/galleries/examples/statistics/errorbar_limits_simple.py
+++ b/galleries/examples/statistics/errorbar_limits_simple.py
@@ -7,6 +7,8 @@ Illustration of selectively drawing lower and/or upper limit symbols on
 errorbars using the parameters ``uplims``, ``lolims`` of `~.pyplot.errorbar`.
 
 Alternatively, you can use 2xN values to draw errorbars in only one direction.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/errorbar_limits_simple
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/statistics/errorbar_subsample.py
+++ b/galleries/examples/statistics/errorbar_subsample.py
@@ -6,6 +6,8 @@ Errorbar subsampling
 The parameter *errorevery* of `.Axes.errorbar` can be used to draw error bars
 only on a subset of data points. This is particularly useful if there are many
 data points with similar errors.
+
+.. redirect-from:: /gallery/lines_bars_and_markers/errorbar_subsample
 """
 
 import matplotlib.pyplot as plt

--- a/galleries/examples/statistics/gallery_order.txt
+++ b/galleries/examples/statistics/gallery_order.txt
@@ -3,9 +3,12 @@
 # errorbars
 errorbar
 errorbar_features
+errorbar_subsample
+errorbar_limits_simple
 errorbar_limits
 errorbars_and_boxes
 confidence_ellipse
+curve_error_band
 
 # histograms
 hist


### PR DESCRIPTION
Some errorbar examples were in "Lines, bars and markers", others in "Statistics". Let's move everything to "Statistics",

