### PR TITLE
Fix title font property precedence

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -214,15 +214,7 @@ class Axes(_AxesBase):
         title.update(default)
         if fontdict is not None:
             title.update(fontdict)
-        # Apply complete font properties before individual font properties so
-        # the latter take precedence regardless of keyword argument order.
-        fontproperties = {
-            key: value for key, value in kwargs.items()
-            if key in {"font", "font_properties", "fontproperties"}}
-        title._internal_update(fontproperties)
-        title._internal_update({
-            key: value for key, value in kwargs.items()
-            if key not in fontproperties})
+        title._internal_update(kwargs)
         return title
 
     def get_legend_handles_labels(self, legend_handler_map=None):

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -214,7 +214,15 @@ class Axes(_AxesBase):
         title.update(default)
         if fontdict is not None:
             title.update(fontdict)
-        title._internal_update(kwargs)
+        # Apply complete font properties before individual font properties so
+        # the latter take precedence regardless of keyword argument order.
+        fontproperties = {
+            key: value for key, value in kwargs.items()
+            if key in {"font", "font_properties", "fontproperties"}}
+        title._internal_update(fontproperties)
+        title._internal_update({
+            key: value for key, value in kwargs.items()
+            if key not in fontproperties})
         return title
 
     def get_legend_handles_labels(self, legend_handler_map=None):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -7543,6 +7543,18 @@ def test_title_location_roundtrip():
         ax.set_title('fail', loc='foo')
 
 
+@pytest.mark.parametrize("kwargs", [
+    {"font": "DejaVu Sans", "fontsize": 20},
+    {"fontsize": 20, "font": "DejaVu Sans"},
+    {"font": mfont_manager.FontProperties(family="DejaVu Sans"), "fontsize": 20},
+    {"fontsize": 20, "font": mfont_manager.FontProperties(family="DejaVu Sans")},
+])
+def test_title_fontproperties_kwarg_precedence(kwargs):
+    fig, ax = plt.subplots()
+    title = ax.set_title("Title", **kwargs)
+    assert title.get_fontsize() == 20
+
+
 @pytest.mark.parametrize('sharex', [True, False])
 def test_title_location_shared(sharex):
     fig, axs = plt.subplots(2, 1, sharex=sharex)

--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -776,6 +776,18 @@ def test_fontproperties_kwarg_precedence():
     assert text2.get_size() == 40.0
 
 
+@pytest.mark.parametrize("kwargs", [
+    {"font": "DejaVu Sans", "fontsize": 20},
+    {"fontsize": 20, "font": "DejaVu Sans"},
+    {"font_properties": FontProperties(family="DejaVu Sans"), "fontsize": 20},
+    {"fontsize": 20, "fontproperties": FontProperties(family="DejaVu Sans")},
+])
+def test_internal_update_fontproperties_kwarg_precedence(kwargs):
+    text = Text()
+    text._internal_update(kwargs)
+    assert text.get_fontsize() == 20
+
+
 def test_transform_rotates_text():
     ax = plt.gca()
     transform = mtransforms.Affine2D().rotate_deg(30)

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -262,6 +262,16 @@ class Text(Artist):
             ret.append(self.set_bbox(bbox))
         return ret
 
+    def _internal_update(self, kwargs):
+        # Apply complete font properties first, as they have lowest priority.
+        kwargs = kwargs.copy()
+        fontproperties = {
+            key: kwargs.pop(key) for key in list(kwargs)
+            if key in {"font", "font_properties", "fontproperties"}}
+        ret = super()._internal_update(fontproperties)
+        ret.extend(super()._internal_update(kwargs))
+        return ret
+
     def __getstate__(self):
         d = super().__getstate__()
         # remove the cached _renderer (if it exists)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Explicit title font properties now take precedence over complete `font` or `fontproperties` values regardless of keyword argument order.


Previously, these calls produced different font sizes:

```python
ax.set_title("Title", font="DejaVu Sans", fontsize=20)
ax.set_title("Title", fontsize=20, font="DejaVu Sans")
```

`Axes.set_title()` now applies complete font properties first, followed by individual properties such as `fontsize`. Regression tests cover both keyword orders using font-family strings and `FontProperties` objects.

closes #27608

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
OpenAI Codex was used to analyze the issue, implement the fix and add regression tests. The changes were reviewed and validated with the available local checks.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N?A ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
