### PR TITLE
MNT: add `@classmethod` and remove `ignore` post #31867

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.pyi
+++ b/lib/matplotlib/backends/backend_pdf.pyi
@@ -408,8 +408,8 @@ class PdfPages:
 
 class FigureCanvasPdf(FigureCanvasBase):
     filetypes: dict[str, str]
-    # FIXME: `get_default_filetype` does not inherit from `FigureCanvasBase` correctly
-    def get_default_filetype(cls) -> str: ...  # type: ignore[override]
+    @classmethod
+    def get_default_filetype(cls) -> str: ...
     def print_pdf(
         self,
         filename: PdfPages | str | os.PathLike | IO[Any],


### PR DESCRIPTION

- Why is this change necessary? #31867 now renders part of #31854 obsolete
- What problem does it solve? Missing `@classmethod` and unused `type: ignore`
## PR checklist

- [ ] [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) ... via `mypy` and project test
- [ ] [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
