### PR TITLE
Skip hidden y-axis offset text when positioning titles (fix #31881)

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3261,7 +3261,12 @@ class _AxesBase(martist.Artist):
             if title.get_text():
                 for ax in axs:
                     ax.yaxis.get_tightbbox(renderer)  # update offsetText
-                    if ax.yaxis.offsetText.get_text():
+                    # A hidden offset text (e.g. on the shared y axis of an
+                    # inner subplot) is not drawn, so it must not move the
+                    # title: its tight bbox is non-finite and would otherwise
+                    # push the title to infinity.
+                    if (ax.yaxis.offsetText.get_visible()
+                            and ax.yaxis.offsetText.get_text()):
                         bb = ax.yaxis.offsetText.get_tightbbox(renderer)
                         if bb.intersection(title.get_tightbbox(renderer), bb):
                             top = bb.ymax

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8009,6 +8009,22 @@ def test_title_above_offset(left, center):
         assert ycenter == yleft
 
 
+def test_title_above_hidden_offset():
+    # On an inner subplot with a shared y axis the offset text is hidden, but
+    # it still carries text. It must not be considered when positioning the
+    # title: its tight bbox is non-finite and used to push the title (and the
+    # subplot position computed by tight_layout) to NaN/inf. See #31881.
+    mpl.rcParams['axes.titley'] = None
+    fig, axs = plt.subplots(1, 2, sharey=True, tight_layout=True)
+    for i, ax in enumerate(axs):
+        ax.set_title(f'Subplot {i}')
+        ax.plot(range(10), [1e53] * 10)
+    fig.draw_without_rendering()  # used to raise ValueError (NaN -> int)
+    for ax in axs:
+        assert np.isfinite(ax.title.get_window_extent().ymin)
+        assert np.all(np.isfinite(ax.get_position().bounds))
+
+
 def test_title_no_move_off_page():
     # If an Axes is off the figure (ie. if it is cropped during a save)
     # make sure that the automatic title repositioning does not get done.


### PR DESCRIPTION
## PR summary

Fixes #31881 — `plt.subplots(1, 2, sharey=True, tight_layout=True)` with per-subplot titles and large y-values raised `ValueError: cannot convert float NaN to integer` on draw. Regression in 3.11.0, bisected by @ksunden to #31285.

### Root cause

On the inner subplot the y axis is shared, so its offset text is hidden (`set_visible(False)`) but still carries text (e.g. `'1e53'`). `Axes._update_title_position` decides whether to lift the title above the offset text by checking only `offsetText.get_text()`, not its visibility:

```python
if ax.yaxis.offsetText.get_text():
    bb = ax.yaxis.offsetText.get_tightbbox(renderer)
    if bb.intersection(title.get_tightbbox(renderer), bb):
        top = bb.ymax
```

Since #31285, `Text.get_tightbbox` returns `Bbox.null()` for hidden/empty text. `Bbox.null()` is `[[inf, inf], [-inf, -inf]]`, which has `xmin=-inf, xmax=+inf` — so it behaves as an *infinite* box under `intersection`, making the guard pass and setting `top = bb.ymax = inf`. The title is then placed at `y = inf`; its window extent feeds `tight_layout`, which computes a NaN subplot position, and the subsequent `YAxis.get_tick_space` does `int(np.floor(NaN))` → the error.

### Fix

A hidden offset text is not drawn, so it should not influence the title position. Only consider it when it is visible. This also fixes the (silently broken) title placement that occurs without `tight_layout` — the title was being moved to infinity there too, just without a downstream crash.

### Test

`test_title_above_hidden_offset` reproduces the issue and asserts the title and subplot positions stay finite. It fails on `main` (raises the original `ValueError`) and passes with the fix. The existing `test_title_above_offset` covers the visible-offset case, which is unchanged.

I verified the change against an installed 3.11.0 build by patching the single edited file (the change is pure-Python).