### PR TITLE
Fix: Vertical Misalignment of LaTeX X-tick Labels

### DIFF
--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1546,6 +1546,46 @@ class Axis(martist.Artist):
             values.append(self.minorTicks[0].get_tick_padding())
         return max(values, default=0)
 
+    def _align_xtick_label_baselines(self, renderer):
+
+        # Shift x-axis tick label1's down so their baselines align,
+        # compensating for differing ascents.
+
+        if self.axis_name != 'x':
+            return
+
+        entries = []
+        for tick in self.get_major_ticks():
+            label = tick.label1
+            if not (label.get_visible() and label.get_text()):
+                continue
+            try:
+                _, info, _ = label._get_layout(renderer)
+            except Exception:
+                continue
+            if not info:
+                continue
+            ascent = info[0][1][1]
+            entries.append((tick, label, ascent))
+
+        if not entries:
+            return
+
+        max_ascent = max(a for _, _, a in entries)
+        fig = self.get_figure(root=True)
+        dpi_scale_trans = fig.dpi_scale_trans
+        dpi = fig.dpi
+
+        for tick, label, ascent in entries:
+            base_trans = tick._get_text1_transform()[0]
+            extra_px = max_ascent - ascent
+            if extra_px <= 0.5:
+                label.set_transform(base_trans)
+                continue
+            shift = mtransforms.ScaledTranslation(
+                0, -extra_px / dpi, dpi_scale_trans)
+            label.set_transform(label.get_transform() + shift)
+
     @martist.allow_rasterization
     def draw(self, renderer):
         # docstring inherited
@@ -1556,6 +1596,8 @@ class Axis(martist.Artist):
 
         ticks_to_draw = self._update_ticks()
         tlb1, tlb2 = self._get_ticklabel_bboxes(ticks_to_draw, renderer)
+
+        self._align_xtick_label_baselines(renderer)
 
         for tick in ticks_to_draw:
             tick.draw(renderer)

--- a/lib/matplotlib/tests/test_axis.py
+++ b/lib/matplotlib/tests/test_axis.py
@@ -128,3 +128,27 @@ def test_set_ticks_emits_lim_changed():
     ax2.callbacks.connect("ylim_changed", called_polar.append)
     ax2.set_rticks([1, 2, 3])
     assert called_polar
+
+    def test_xtick_label_baselines_alignment():
+
+        fig, ax = plt.subplots(figsize=(3, 3), dpi=300)
+        ax.set_xlim(-0.5, 2.5)
+        ax.set_ylim(-3, 3)
+        labels = [r"$w^{(2)}_1$", r"$w^{(2)}_2$", r"$b^{(2)}$"]
+        ax.set_xticks([0, 1, 2], labels)
+        ax.set_yticks([])
+        ax.tick_params(which="both", length=0)
+        fig.tight_layout()
+
+        fig.canvas.draw()
+        renderer = fig.canvas.get_renderer()
+
+        baselines = []
+        for tick in ax.xaxis.get_major_ticks():
+            label = tick.label1
+            bbox = label.get_window_extent(renderer)
+            _, info, _ = label._get_layout(renderer)
+            descent = info[0][1][2]
+            baselines.append(bbox.y0 + descent)
+
+        assert max(baselines) - min(baselines) < 0.01


### PR DESCRIPTION
closes #31802

## PR Summary
x-tick labels using LaTeX/mathtext were vertically misaligned when `savefig(dpi=300)` was used, specifically when labels had different "ascents" (height above baseline) due to differing mathtext content — e.g. `$w^{(2)}_1$` (superscript + subscript) vs `$b^{(2)}$` (superscript only).

### Why is this change necessary?
All x-tick `label1`s are top-aligned (`va='top'`) to the same y-position via `_get_text1_transform()`. Since `baseline_y = y1 - ascent`, labels with different ascents end up with different baseline positions even though their top edges align. This difference is small but becomes visually noticeable at high DPI.

### What problem does it solve?
It fixes the vertical misalignment of LaTeX x-tick labels, where one label (with a smaller ascent) appeared visually higher than the others.

###  Reason for this implementation?
Added `Axis._align_xtick_label_baselines()`, called from `Axis.draw()` after `_update_ticks()`. For each visible x-tick label1:
1. Measure its `ascent` via `label._get_layout(renderer)`.
2. Find `max_ascent` across all labels.
3. Shift labels with smaller ascent down by `(max_ascent - ascent)`,  so all baselines align with the label that has the largest ascent.
4.  Added Regression test.

 **NOTE:** A 0.5px threshold skips labels whose ascent differs only by sub-pixel amounts, so plain numeric/text tick labels (where this difference is negligible) remain unaffected.


## AI Disclosure
 AI was used in documentation build and suggesting validation scenarios.
All Implementation, testing, and verification were done manually.

## PR checklist


- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

