### PR TITLE
check transform mesh shape in _get_transform_mesh

### DIFF
--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1677,6 +1677,23 @@ def test__resample_valid_output():
         resample(np.zeros((9, 9)), out)
 
 
+def test__resample_nonaffine_mesh_shape():
+    # A non-affine transform whose inverse returns the wrong number of mesh
+    # points must be rejected rather than read past the mesh buffer.
+    class BadMeshTransform(Transform):
+        input_dims = output_dims = 2
+
+        def inverted(self):
+            return self
+
+        def transform(self, values):
+            return np.zeros((1, 2))
+
+    with pytest.raises(RuntimeError, match="mesh array should have shape"):
+        mpl._image.resample(np.zeros((9, 9)), np.zeros((9, 9)),
+                            BadMeshTransform())
+
+
 @pytest.mark.parametrize("data, interpolation, expected",
     [(np.array([[0.1, 0.3, 0.2]]), mimage.NEAREST,
       np.array([[0.1, 0.1, 0.1, 0.3, 0.3, 0.3, 0.3, 0.2, 0.2, 0.2]])),

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -86,6 +86,7 @@ _get_transform_mesh(const py::object& transform, const py::ssize_t *dims)
                 output_mesh_array.ndim()));
     }
 
+    // An undersized mesh would be read out of bounds by the resampler.
     if (output_mesh_array.shape(0) != mesh_dims[0] ||
             output_mesh_array.shape(1) != mesh_dims[1]) {
         throw std::runtime_error(

--- a/src/_image_wrapper.cpp
+++ b/src/_image_wrapper.cpp
@@ -86,6 +86,14 @@ _get_transform_mesh(const py::object& transform, const py::ssize_t *dims)
                 output_mesh_array.ndim()));
     }
 
+    if (output_mesh_array.shape(0) != mesh_dims[0] ||
+            output_mesh_array.shape(1) != mesh_dims[1]) {
+        throw std::runtime_error(
+            "Inverse transformed mesh array should have shape ({}, {}) not ({}, {})"_s.format(
+                mesh_dims[0], mesh_dims[1],
+                output_mesh_array.shape(0), output_mesh_array.shape(1)));
+    }
+
     return output_mesh_array;
 }
 


### PR DESCRIPTION
## PR summary

`_get_transform_mesh` builds an input mesh sized to the output image, hands it to the supplied transform's `inverted().transform()`, and forwards whatever comes back to the resampler as a flat table of `out_h * out_w` coordinate pairs. The only check on the returned array is `ndim == 2`. A non-affine transform whose inverse returns fewer rows than requested, or a trailing dimension other than 2, leaves `lookup_distortion` in `_image_resample.h` indexing past the end of that buffer.

Before: an undersized mesh produces an out-of-bounds read during resampling, and with a large output array it segfaults. After: the row and column counts are checked against the requested size and a `RuntimeError` is raised, alongside the existing `ndim` check directly above it. The tradeoff is two integer comparisons per non-affine resample; keeping the check next to the mesh construction lets the resampler keep treating the buffer as exactly sized.

Minimal repro on the current tree:

```python
import numpy as np
import matplotlib._image as _image
from matplotlib.transforms import Transform

class Bad(Transform):
    input_dims = output_dims = 2
    def inverted(self): return self
    def transform(self, v): return np.zeros((1, 2))  # should be out_h*out_w rows

_image.resample(np.zeros((10, 10, 4), np.uint8),
                np.zeros((2000, 2000, 4), np.uint8), Bad(),
                interpolation=_image._InterpolationType.NEAREST)  # SIGSEGV
```

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
