### PR TITLE
TST: temporarily pin pytest

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -63,7 +63,7 @@ dependencies:
   - psutil
   - prek
   - pydocstyle>=5.1.0
-  - pytest!=4.6.0,!=5.4.0,!=8.1.0
+  - pytest!=4.6.0,!=5.4.0,!=8.1.0,<9.1.0
   - pytest-cov
   - pytest-rerunfailures
   - pytest-timeout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ test = [
     "certifi",
     "coverage!=6.3",
     "psutil; sys_platform != 'cygwin'",
-    "pytest!=4.6.0,!=5.4.0,!=8.1.0",
+    "pytest!=4.6.0,!=5.4.0,!=8.1.0,<9.1.0",
     "pytest-cov",
     "pytest-rerunfailures!=16.0",
     "pytest-timeout",


### PR DESCRIPTION
Pytest 9.1 was released yesterday and [lots of our tests are broken.](https://github.com/matplotlib/matplotlib/actions/runs/27499575277/job/81279875226)  I looked into it a little but it is not a five minute job to fix, so for now I suggest we pin to unbreak CI.