### PR TITLE
FIX: fill contourf minimum region when it falls just below the lowest level (#21382)

### DIFF
--- a/lib/matplotlib/contour.py
+++ b/lib/matplotlib/contour.py
@@ -953,8 +953,18 @@ class ContourSet(ContourLabeler, mcoll.Collection):
         Return ``(lowers, uppers)`` for filled contours.
         """
         lowers = self._levels[:-1]
-        if self.zmin == lowers[0]:
-            # Include minimum values in lowest interval
+        # Include minimum values in the lowest interval.  The lowest level can
+        # end up a hair above the data minimum rather than exactly equal to it,
+        # either because the data minimum is itself the result of a computation
+        # (e.g. a value of -1.7e-13 that should be 0) or because of rounding in
+        # automatic level selection.  A strict equality test misses these cases
+        # and leaves the minimum-valued region unfilled (see #21382), so treat
+        # the level as coincident with the data minimum when it sits within a
+        # floating-point tolerance of it.  The tolerance is scaled to the data
+        # range; a genuine gap (e.g. user-specified levels starting above the
+        # data) is far larger than this and is left untouched.
+        tol = (self.zmax - self.zmin) * 1e-12
+        if 0 <= lowers[0] - self.zmin <= tol:
             lowers = lowers.copy()  # so we don't change self._levels
             if self.logscale:
                 lowers[0] = 0.99 * self.zmin

--- a/lib/matplotlib/tests/test_contour.py
+++ b/lib/matplotlib/tests/test_contour.py
@@ -352,6 +352,34 @@ def test_contourf_symmetric_locator():
     assert_array_almost_equal(cs.levels, np.linspace(-12, 12, 5))
 
 
+@pytest.mark.parametrize('z_min', [
+    0.0,        # data minimum exactly on the lowest level
+    -1e-13,     # a floating-point hair below it ...
+    -1.7e-13,   # github issue 21382
+])
+@check_figures_equal()
+def test_contourf_min_at_lowest_level(fig_test, fig_ref, z_min):
+    # The region at the data minimum must be filled even when that minimum is
+    # a floating-point hair below the lowest contour level rather than exactly
+    # equal to it.  Each case must therefore match a clean minimum of zero.
+    levels = [0, 0.5, 1, 1.5, 2]
+    z = np.array([[0., 0., 2.], [0., 0., 1.], [2., 1., z_min]])
+    z_ref = np.array([[0., 0., 2.], [0., 0., 1.], [2., 1., 0.]])
+    fig_test.subplots().contourf(z, levels=levels)
+    fig_ref.subplots().contourf(z_ref, levels=levels)
+
+
+def test_contourf_lowest_level_gap_not_filled():
+    # The floating-point tolerance that fixes issue 21382 must not back-fill a
+    # genuine gap: a user-specified lowest level clearly above the data minimum
+    # marks a region that should stay unfilled, so the lowest interval keeps the
+    # chosen level as its lower bound rather than being extended downwards.
+    z = np.array([[0.2, 0.2, 5.], [0.2, 3., 1.], [5., 1., 0.2]])
+    cs = plt.figure().subplots().contourf(z, levels=[2, 3, 4, 5])
+    lowers, _ = cs._get_lowers_and_uppers()
+    assert lowers[0] == 2
+
+
 def test_circular_contour_warning():
     # Check that almost circular contours don't throw a warning
     x, y = np.meshgrid(np.linspace(-2, 2, 4), np.linspace(-2, 2, 4))


### PR DESCRIPTION
## PR summary

Closes #21382.

`contourf` leaves the minimum-valued region unfilled when the data minimum
falls a floating-point hair below the lowest contour level instead of being
exactly equal to it. The reported case is a data minimum of `-1.7e-13` (a
computed value that "should" be `0`), but the same thing happens whenever
rounding in automatic level selection puts the lowest level just above the
data minimum.

The cause is in `ContourSet._get_lowers_and_uppers`. The lowest filled
interval is only extended downwards to include the data minimum when
`self.zmin == lowers[0]` exactly:

```python
z0 = np.array([[0., 0., 2.], [0., 0., 1.], [2., 1., 0.]])        # min == 0     -> filled
z1 = np.array([[0., 0., 2.], [0., 0., 1.], [2., 1., -1.7e-13]])  # min ~ -1e-13 -> clipped
```

![z0 vs z1](https://user-images.githubusercontent.com/2179825/96325527-2312cd80-0fee-11eb-8bd7-6de7d4837966.png)

This picks up the discussion on the issue (thanks @anntzer and @tacaswell):
the data minimum is, within floating-point error, *on* the lowest level, so
that level should be treated as coincident with it.

## What this changes

Compare the lowest level against the data minimum with a tolerance scaled to
the data range, rather than with strict equality:

```python
tol = (self.zmax - self.zmin) * 1e-12
if 0 <= lowers[0] - self.zmin <= tol:
    ...
```

This **strictly generalises** the previous behaviour: the test is a superset
of the old `==`, so every case that extended the lowest interval before still
extends it identically. It only additionally catches the case where the level
sits within floating-point tolerance above the minimum.

The check is deliberately one-sided and tolerance-bounded so that a genuine
gap is left alone. For example, user-specified levels that start above the
data minimum mark a region that should stay unfilled, and that gap is many
orders of magnitude larger than `range * 1e-12`, so it is untouched. The
`1e-12` factor follows the precedent in #31844: comfortably above numeric
noise (~1e-15) yet far below any meaningful contour spacing.

I implemented this in `_get_lowers_and_uppers` rather than in level selection
to keep the blast radius small and avoid perturbing the public `levels`
array / colorbar. Happy to move it into the locator path instead if that is
preferred.

## Tests

- `test_contourf_min_at_lowest_level` (`check_figures_equal`, parametrised over
  `0.0`, `-1e-13`, `-1.7e-13`): a float-noise minimum must render identically
  to a clean minimum of zero.
- `test_contourf_lowest_level_gap_not_filled`: a user-specified lowest level
  above the data minimum is **not** back-filled (guards against over-extending).

## PR checklist

- [x] "closes #21382" is in the PR description.
- [x] New/changed code is tested.
- [x] Bug fix; no API changes, so no API change notes or what's-new entry.