### PR TITLE
Sync shared limits without callbacks

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1304,7 +1304,9 @@ class _AxesBase(martist.Artist):
         self.xaxis.major = other.xaxis.major  # Ticker instances holding
         self.xaxis.minor = other.xaxis.minor  # locator and formatter.
         x0, x1 = other.get_xlim()
-        self.set_xlim(x0, x1, emit=False, auto=other.get_autoscalex_on())
+        self.xaxis._set_lim(
+            x0, x1, emit=False, auto=other.get_autoscalex_on(),
+            propagate=False)
         self.xaxis._scale = other.xaxis._scale
 
     def sharey(self, other):
@@ -1323,7 +1325,9 @@ class _AxesBase(martist.Artist):
         self.yaxis.major = other.yaxis.major  # Ticker instances holding
         self.yaxis.minor = other.yaxis.minor  # locator and formatter.
         y0, y1 = other.get_ylim()
-        self.set_ylim(y0, y1, emit=False, auto=other.get_autoscaley_on())
+        self.yaxis._set_lim(
+            y0, y1, emit=False, auto=other.get_autoscaley_on(),
+            propagate=False)
         self.yaxis._scale = other.yaxis._scale
 
     def __clear(self):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -1319,7 +1319,7 @@ class Axis(martist.Artist):
         # attribute, and the derived code below will check for that
         # and use it if it's available (else just use 0..1)
 
-    def _set_lim(self, v0, v1, *, emit=True, auto):
+    def _set_lim(self, v0, v1, *, emit=True, auto, propagate=True):
         """
         Set view limits.
 
@@ -1336,6 +1336,8 @@ class Axis(martist.Artist):
         auto : bool or None, default: False
             Whether to turn on autoscaling of the x-axis. True turns on, False
             turns off, None leaves unchanged.
+        propagate : bool, default: True
+            Whether to propagate the limits to shared axes.
         """
         name = self._get_axis_name()
 
@@ -1381,11 +1383,14 @@ class Axis(martist.Artist):
 
         if emit:
             self.axes.callbacks.process(f"{name}lim_changed", self.axes)
+
+        if propagate:
             # Call all of the other Axes that are shared with this one
             for other in self._get_shared_axes():
                 if other is self.axes:
                     continue
-                other._axis_map[name]._set_lim(v0, v1, emit=False, auto=auto)
+                other._axis_map[name]._set_lim(
+                    v0, v1, emit=False, auto=auto, propagate=False)
                 if emit:
                     other.callbacks.process(f"{name}lim_changed", other)
                 if ((other_fig := other.get_figure(root=False)) !=

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -10005,12 +10005,22 @@ def test_set_secondary_axis_color():
 
 
 def test_xylim_changed_shared():
-    fig, axs = plt.subplots(2, sharex=True, sharey=True)
+    fig, axs = plt.subplots(3, sharex=True, sharey=True)
     events = []
     axs[1].callbacks.connect("xlim_changed", events.append)
     axs[1].callbacks.connect("ylim_changed", events.append)
     axs[0].set(xlim=[1, 3], ylim=[2, 4])
     assert events == [axs[1], axs[1]]
+
+    axs[0].callbacks.connect("xlim_changed", events.append)
+    axs[0].callbacks.connect("ylim_changed", events.append)
+    events.clear()
+    axs[0].set_xlim(4, 5, emit=False)
+    axs[0].set_ylim(6, 7, emit=False)
+    for ax in axs[1:]:
+        assert ax.get_xlim() == (4, 5)
+        assert ax.get_ylim() == (6, 7)
+    assert events == []
 
 
 @image_comparison(["axhvlinespan_interpolation.png"], style="default")


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
Shared axes now remain synchronized when axis limits are changed with
`emit=False`.

Previously, `Axis._set_lim()` used `emit` to control both callback emission and
shared-axis limit propagation. As a result, calls such as:

```python
fig, axs = plt.subplots(1, 2, sharex=True)
axs[0].set_xlim(0, 0.1, emit=False)
```

updated only the first Axes. The shared Axes retained different limits while
using the same tick locator, which could produce incorrect tick positions.

This change separates shared-axis propagation from callback emission by adding
an internal propagation flag. The initiating call updates every shared Axes,
while propagated updates disable further propagation to prevent infinite
recursion. `emit=False` continues to suppress limit-change callbacks.

The existing shared-axis callback test now also verifies that:

- x and y limits propagate to every Axes in a shared group when `emit=False`;
- no callbacks are emitted by either the initiating or shared Axes.

This follows the design discussion in #26011.

Closes #26085
## AI Disclosure
OpenAI Codex was used to implement the fix, add regression coverage, run available validation. The changes were reviewed and validated with local static checks and runtime smoke tests.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #26085" is in the body of the PR description
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines
<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
