### PR TITLE
TST: unpin pytest

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -63,7 +63,7 @@ dependencies:
   - psutil
   - prek
   - pydocstyle>=5.1.0
-  - pytest!=4.6.0,!=5.4.0,!=8.1.0,<9.1.0
+  - pytest!=4.6.0,!=5.4.0,!=8.1.0
   - pytest-cov
   - pytest-rerunfailures
   - pytest-timeout

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -181,7 +181,7 @@ def gen_writers():
 # Smoke test for saving animations.  In the future, we should probably
 # design more sophisticated tests which compare resulting frames a-la
 # matplotlib.testing.image_comparison
-@pytest.mark.parametrize('writer, frame_format, output', gen_writers())
+@pytest.mark.parametrize('writer, frame_format, output', list(gen_writers()))
 @pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_save_animation_smoketest(tmp_path, writer, frame_format, output, anim):
     if frame_format is not None:
@@ -201,7 +201,7 @@ def test_save_animation_smoketest(tmp_path, writer, frame_format, output, anim):
     del anim
 
 
-@pytest.mark.parametrize('writer, frame_format, output', gen_writers())
+@pytest.mark.parametrize('writer, frame_format, output', list(gen_writers()))
 def test_grabframe(tmp_path, writer, frame_format, output):
     WriterClass = animation.writers[writer]
 

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -221,7 +221,7 @@ def baseline_images(request, fontset, index, text):
 
 
 @pytest.mark.parametrize(
-    'index, text', enumerate(math_tests), ids=range(len(math_tests)))
+    'index, text', list(enumerate(math_tests)), ids=range(len(math_tests)))
 @pytest.mark.parametrize(
     'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
 @pytest.mark.parametrize('baseline_images', ['mathtext'], indirect=True)
@@ -237,7 +237,7 @@ def test_mathtext_rendering(baseline_images, fontset, index, text):
              horizontalalignment='center', verticalalignment='center')
 
 
-@pytest.mark.parametrize('index, text', enumerate(svgastext_math_tests),
+@pytest.mark.parametrize('index, text', list(enumerate(svgastext_math_tests)),
                          ids=range(len(svgastext_math_tests)))
 @pytest.mark.parametrize('fontset', ['cm', 'dejavusans'])
 @pytest.mark.parametrize('baseline_images', ['mathtext0'], indirect=True)
@@ -254,7 +254,7 @@ def test_mathtext_rendering_svgastext(baseline_images, fontset, index, text):
              horizontalalignment='center', verticalalignment='center')
 
 
-@pytest.mark.parametrize('index, text', enumerate(lightweight_math_tests),
+@pytest.mark.parametrize('index, text', list(enumerate(lightweight_math_tests)),
                          ids=range(len(lightweight_math_tests)))
 @pytest.mark.parametrize('fontset', ['dejavusans'])
 @pytest.mark.parametrize('baseline_images', ['mathtext1'], indirect=True)
@@ -266,7 +266,7 @@ def test_mathtext_rendering_lightweight(baseline_images, fontset, index, text):
 
 
 @pytest.mark.parametrize(
-    'index, text', enumerate(font_tests), ids=range(len(font_tests)))
+    'index, text', list(enumerate(font_tests)), ids=range(len(font_tests)))
 @pytest.mark.parametrize(
     'fontset', ['cm', 'stix', 'stixsans', 'dejavusans', 'dejavuserif'])
 @pytest.mark.parametrize('baseline_images', ['mathfont'], indirect=True)

--- a/lib/matplotlib/tests/test_mlab.py
+++ b/lib/matplotlib/tests/test_mlab.py
@@ -207,7 +207,8 @@ class TestDetrend:
     scope='class')
 class TestSpectral:
     @pytest.fixture(scope='class', autouse=True)
-    def stim(self, request, fstims, iscomplex, sides, len_x, NFFT_density,
+    @classmethod
+    def stim(cls, request, fstims, iscomplex, sides, len_x, NFFT_density,
              nover_density, pad_to_density, pad_to_spectrum):
         Fs = 100.
 
@@ -322,11 +323,6 @@ class TestSpectral:
 
         if iscomplex:
             y = y.astype('complex')
-
-        # Interestingly, the instance on which this fixture is called is not
-        # the same as the one on which a test is run. So we need to modify the
-        # class itself when using a class-scoped fixture.
-        cls = request.cls
 
         cls.Fs = Fs
         cls.sides = sides

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -105,7 +105,7 @@ _test_path_extents = [(0., 0., 0.75, 1.), (0., 0., 1., 0.5), (0., 1., 1., 1.),
                       (1., 2., 1., 2.)]
 
 
-@pytest.mark.parametrize('path, extents', zip(_test_paths, _test_path_extents))
+@pytest.mark.parametrize('path, extents', list(zip(_test_paths, _test_path_extents)))
 def test_exact_extents(path, extents):
     # notice that if we just looked at the control points to get the bounding
     # box of each curve, we would get the wrong answers. For example, for

--- a/lib/matplotlib/tests/test_rcparams.py
+++ b/lib/matplotlib/tests/test_rcparams.py
@@ -444,7 +444,7 @@ def generate_validator_testcases(valid):
 
 
 @pytest.mark.parametrize('validator, arg, target',
-                         generate_validator_testcases(True))
+                         list(generate_validator_testcases(True)))
 def test_validator_valid(validator, arg, target):
     res = validator(arg)
     if isinstance(target, np.ndarray):
@@ -457,7 +457,7 @@ def test_validator_valid(validator, arg, target):
 
 
 @pytest.mark.parametrize('validator, arg, exception_type',
-                         generate_validator_testcases(False))
+                         list(generate_validator_testcases(False)))
 def test_validator_invalid(validator, arg, exception_type):
     with pytest.raises(exception_type):
         validator(arg)

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -461,7 +461,7 @@ class TestLogitLocator:
 
     @pytest.mark.parametrize(
         "lims, expected_low_ticks",
-        zip(ref_basic_limits, ref_basic_major_ticks),
+        list(zip(ref_basic_limits, ref_basic_major_ticks)),
     )
     def test_basic_major(self, lims, expected_low_ticks):
         """
@@ -506,7 +506,7 @@ class TestLogitLocator:
 
     @pytest.mark.parametrize(
         "lims, expected_low_ticks",
-        zip(ref_basic_limits, ref_basic_major_ticks),
+        list(zip(ref_basic_limits, ref_basic_major_ticks)),
     )
     def test_minor(self, lims, expected_low_ticks):
         """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ test = [
     "certifi",
     "coverage!=6.3",
     "psutil; sys_platform != 'cygwin'",
-    "pytest!=4.6.0,!=5.4.0,!=8.1.0,<9.1.0",
+    "pytest!=4.6.0,!=5.4.0,!=8.1.0",
     "pytest-cov",
     "pytest-rerunfailures!=16.0",
     "pytest-timeout",


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Closes #31897.  Turned out to not be as difficult as I thought.

* Change the `TestSpectral.stim` fixture method to be a class method, following [pytest's deprecation](https://docs.pytest.org/en/stable/deprecations.html#class-scoped-fixture-as-instance-method).  This actually makes the code a little more intuitive as shown by the deleted comment.

* Make lists from all the generators we use for parametrization, as [that is also now deprecated](https://docs.pytest.org/en/stable/deprecations.html#non-collection-iterables-in-pytest-mark-parametrize).

I'm not sure why I had problems with the tests hanging when I tried yesterday, but it was fine on a different machine today 🤷‍♀️ 

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
No AI used.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
