### PR TITLE
DOC: omit basic_units helper from gallery

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -315,7 +315,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'within_subsection_order': gallery_order_subsectionorder,
     'capture_repr': (),
-    'copyfile_regex': r'(.*\.rst|.*basic_units\.py)',
+    'copyfile_regex': r'(.*\.rst|.*basic_units\.(py|ipynb))',
 }
 
 if parse_version(sphinx_gallery.__version__) >= parse_version('0.17.0'):

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -299,7 +299,7 @@ sphinx_gallery_conf = {
     'doc_module': ('matplotlib', 'mpl_toolkits'),
     'examples_dirs': example_dirs,
     'filename_pattern': '^((?!sgskip).)*$',
-    'ignore_pattern': r'basic_units\.py',
+    'ignore_pattern': r'(__init__|basic_units)\.py',
     'gallery_dirs': gallery_dirs,
     'image_scrapers': (matplotlib_reduced_latex_scraper, ),
     'image_srcset': ["2x"],

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -299,6 +299,7 @@ sphinx_gallery_conf = {
     'doc_module': ('matplotlib', 'mpl_toolkits'),
     'examples_dirs': example_dirs,
     'filename_pattern': '^((?!sgskip).)*$',
+    'ignore_pattern': r'basic_units\.py',
     'gallery_dirs': gallery_dirs,
     'image_scrapers': (matplotlib_reduced_latex_scraper, ),
     'image_srcset': ["2x"],
@@ -314,7 +315,7 @@ sphinx_gallery_conf = {
     'thumbnail_size': (320, 224),
     'within_subsection_order': gallery_order_subsectionorder,
     'capture_repr': (),
-    'copyfile_regex': r'.*\.rst',
+    'copyfile_regex': r'(.*\.rst|.*basic_units\.py)',
 }
 
 if parse_version(sphinx_gallery.__version__) >= parse_version('0.17.0'):

--- a/galleries/examples/units/basic_units.ipynb
+++ b/galleries/examples/units/basic_units.ipynb
@@ -1,0 +1,25 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Basic units\n",
+    "\n",
+    "This notebook accompanies `basic_units.py`, the helper module used by the units gallery examples."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/galleries/users_explain/axes/axes_units.py
+++ b/galleries/users_explain/axes/axes_units.py
@@ -267,7 +267,7 @@ ax.set_xlabel(label)
 #
 # The support for dates and categories is part of "units" support that is built
 # into Matplotlib.  This is described at `.matplotlib.units` and in the
-# :ref:`basic_units` example.
+# :ref:`units examples <units-examples-index>`.
 #
 # Unit support works by querying the type of data passed to the plotting
 # function and dispatching to the first converter in a list that accepts that


### PR DESCRIPTION
# DOC: omit basic_units helper from gallery

## PR summary

This PR prevents `galleries/examples/units/basic_units.py` from being rendered as a standalone gallery page. The file is a helper module used by the units examples, not a visual gallery example, and issue #17479 notes that it should likely be omitted from the gallery listing.

The file is still copied into the generated gallery output via `copyfile_regex`, so existing examples can continue to import it and users can still download it from links such as `:download:\`basic_units.py <basic_units.py>\``.

Addresses one item from #17479.

## AI Disclosure

I used Codex to inspect the issue, read the repository documentation, identify the smallest scoped change, and run local checks. I reviewed the resulting configuration change and verified the regex behavior locally.

## PR checklist

- [ ] "closes #0000" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines

## Testing

- `git diff --check`
- `python -m py_compile doc/conf.py`
- Local regex check confirming:
  - `../galleries/examples/units/basic_units.py` matches `ignore_pattern`
  - `../galleries/examples/units/basic_units.py` matches `copyfile_regex`
  - ordinary `.rst` files still match `copyfile_regex`
  - ordinary example `.py` files such as `bar_unit_demo.py` do not match either rule

Full documentation build was not run locally because this environment does not have Matplotlib's documentation dependencies installed, including `sphinx_gallery`.
