### PR TITLE
FIX: Add mtext into RendererBase._draw_as_path() arguments

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -506,7 +506,7 @@ class RendererBase:
         mtext : `~matplotlib.text.Text`
             The original text object to be rendered.
         """
-        self._draw_text_as_path(gc, x, y, s, prop, angle, ismath="TeX")
+        self._draw_text_as_path(gc, x, y, s, prop, angle, ismath="TeX", mtext=mtext)
 
     def draw_text(self, gc, x, y, s, prop, angle, ismath=False, mtext=None):
         """

--- a/lib/matplotlib/tests/test_usetex.py
+++ b/lib/matplotlib/tests/test_usetex.py
@@ -44,6 +44,18 @@ def test_usetex():
     ax.set_axis_off()
 
 
+def test_usetex_fallback(monkeypatch):
+    # Smoke test that the base draw_tex implementation works.
+    from matplotlib.backend_bases import RendererBase
+    from matplotlib.backends.backend_agg import RendererAgg
+    monkeypatch.setattr(RendererAgg, 'draw_tex', RendererBase.draw_tex)
+
+    plt.rcParams["text.usetex"] = True
+    fig, ax = plt.subplots()
+    ax.text(0, 0, "foo_bar")
+    fig.canvas.draw()
+
+
 @check_figures_equal(extensions=['png', 'pdf', 'svg'])
 def test_empty(fig_test, fig_ref):
     mpl.rcParams['text.usetex'] = True


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary

### Why is this change necessary?
User might be unable to use LaTeX formatting for plots.

### What problem does it solve?
Fixes the `TypeError` with missing positional argument for `RendererBase._draw_text_as_path()` by adding `mtext=mtext` into the arguments.

### What is the reasoning for this implementation?
The function that calls `RendererBase._draw_text_as_path()` already includes `mtext=None` as a default argument. Therefore, this `mtext` is just passed into `RendererBase._draw_text_as_path()` too.

## AI Disclosure
All fixes and code were done manually.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
