### PR TITLE
MAINT: Use the "PR: dependencies" label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,8 @@ updates:
       actions:
         patterns:
           - "*"
+    labels:
+      - "PR: dependencies"
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
@@ -19,6 +21,8 @@ updates:
       default-days: 7
     exclude-paths:
       - "ci/minver-requirements.txt"
+    labels:
+      - "PR: dependencies"
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
@@ -29,3 +33,5 @@ updates:
       pre-commit:
         patterns:
           - "*"
+    labels:
+      - "PR: dependencies"


### PR DESCRIPTION
## PR summary

Following some maintenance discussions, use the "PR: dependencies" label for dependabot PRs, instead of the default "dependencies" so we can eliminate duplication of labels in the repo.

## AI Disclosure
None

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
