### PR TITLE
ENH: Support mixed shading in pcolor/pcolormesh

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -6462,23 +6462,52 @@ or pandas.DataFrame
         # - reset shading if shading='auto' to flat or nearest
         #   depending on size;
 
+        # Check and normalize shading parameter:
+        if isinstance(shading, str):
+            shading = shading.lower()
+            shading_x = shading_y = shading
+        else:
+            try:
+                shading_x, shading_y = shading
+                if isinstance(shading_x, str):
+                    shading_x = shading_x.lower()
+                if isinstance(shading_y, str):
+                    shading_y = shading_y.lower()
+            except (ValueError, TypeError) as e:
+                raise ValueError(
+                    "shading must be a string or a 2-tuple of strings"
+                ) from e
+
         _valid_shading = ['gouraud', 'nearest', 'flat', 'auto']
-        try:
-            _api.check_in_list(_valid_shading, shading=shading)
-        except ValueError:
-            _api.warn_external(f"shading value '{shading}' not in list of "
-                               f"valid values {_valid_shading}. Setting "
-                               "shading='auto'.")
-            shading = 'auto'
+        _api.check_in_list(_valid_shading, shading_x=shading_x)
+        _api.check_in_list(_valid_shading, shading_y=shading_y)
+
+        if (
+            (shading_x == 'gouraud' or shading_y == 'gouraud')
+            and shading_x != shading_y
+        ):
+            raise ValueError(
+                "shading='gouraud' cannot be mixed with other shading types."
+            )
 
         if len(args) == 1:
             C = np.asanyarray(args[0])
             nrows, ncols = C.shape[:2]
-            if shading in ['gouraud', 'nearest']:
-                X, Y = np.meshgrid(np.arange(ncols), np.arange(nrows))
+
+            grid_shading_x = 'flat' if shading_x == 'auto' else shading_x
+            grid_shading_y = 'flat' if shading_y == 'auto' else shading_y
+
+            if grid_shading_x in ['gouraud', 'nearest']:
+                x_grid = np.arange(ncols)
             else:
-                X, Y = np.meshgrid(np.arange(ncols + 1), np.arange(nrows + 1))
-                shading = 'flat'
+                x_grid = np.arange(ncols + 1)
+
+            if grid_shading_y in ['gouraud', 'nearest']:
+                y_grid = np.arange(nrows)
+            else:
+                y_grid = np.arange(nrows + 1)
+
+            X, Y = np.meshgrid(x_grid, y_grid)
         elif len(args) == 3:
             # Check x and y for bad data...
             C = np.asanyarray(args[2])
@@ -6509,61 +6538,81 @@ or pandas.DataFrame
             raise TypeError(f'Incompatible X, Y inputs to {funcname}; '
                             f'see help({funcname})')
 
-        if shading == 'auto':
-            if ncols == Nx and nrows == Ny:
-                shading = 'nearest'
+        if shading_x == 'auto':
+            if ncols == Nx:
+                shading_x = 'nearest'
             else:
-                shading = 'flat'
+                shading_x = 'flat'
+        if shading_y == 'auto':
+            if nrows == Ny:
+                shading_y = 'nearest'
+            else:
+                shading_y = 'flat'
 
-        if shading == 'flat':
-            if (Nx, Ny) != (ncols + 1, nrows + 1):
-                raise TypeError(f"Dimensions of C {C.shape} should"
-                                f" be one smaller than X({Nx}) and Y({Ny})"
-                                f" while using shading='flat'"
-                                f" see help({funcname})")
-        else:    # ['nearest', 'gouraud']:
+        if shading_x == 'gouraud':
             if (Nx, Ny) != (ncols, nrows):
                 raise TypeError('Dimensions of C %s are incompatible with'
                                 ' X (%d) and/or Y (%d); see help(%s)' % (
                                     C.shape, Nx, Ny, funcname))
-            if shading == 'nearest':
-                # grid is specified at the center, so define corners
-                # at the midpoints between the grid centers and then use the
-                # flat algorithm.
-                def _interp_grid(X, require_monotonicity=False):
-                    # helper for below. To ensure the cell edges are calculated
-                    # correctly, when expanding columns, the monotonicity of
-                    # X coords needs to be checked. When expanding rows, the
-                    # monotonicity of Y coords needs to be checked.
-                    if np.shape(X)[1] > 1:
-                        dX = np.diff(X, axis=1) * 0.5
-                        if (require_monotonicity and
-                                not (np.all(dX >= 0) or np.all(dX <= 0))):
-                            _api.warn_external(
-                                f"The input coordinates to {funcname} are "
-                                "interpreted as cell centers, but are not "
-                                "monotonically increasing or decreasing. "
-                                "This may lead to incorrectly calculated cell "
-                                "edges, in which case, please supply "
-                                f"explicit cell edges to {funcname}.")
+            shading = 'gouraud'
+        else:
+            if shading_x == 'flat' and Nx != ncols + 1:
+                raise TypeError(f"Dimensions of C {C.shape} should be one smaller than "
+                                f"X ({Nx}) along the X-axis while using shading='flat'")
+            if shading_x == 'nearest' and Nx != ncols:
+                raise TypeError(
+                    f"Dimensions of C {C.shape} should be equal to "
+                    f"X ({Nx}) along the X-axis while using "
+                    "shading='nearest'"
+                )
 
-                        hstack = np.ma.hstack if np.ma.isMA(X) else np.hstack
-                        X = hstack((X[:, [0]] - dX[:, [0]],
-                                    X[:, :-1] + dX,
-                                    X[:, [-1]] + dX[:, [-1]]))
-                    else:
-                        # This is just degenerate, but we can't reliably guess
-                        # a dX if there is just one value.
-                        X = np.hstack((X, X))
-                    return X
+            if shading_y == 'flat' and Ny != nrows + 1:
+                raise TypeError(f"Dimensions of C {C.shape} should be one smaller than "
+                                f"Y ({Ny}) along the Y-axis while using shading='flat'")
+            if shading_y == 'nearest' and Ny != nrows:
+                raise TypeError(
+                    f"Dimensions of C {C.shape} should be equal to "
+                    f"Y ({Ny}) along the Y-axis while using "
+                    "shading='nearest'"
+                )
 
-                if ncols == Nx:
-                    X = _interp_grid(X, require_monotonicity=True)
-                    Y = _interp_grid(Y)
-                if nrows == Ny:
-                    X = _interp_grid(X.T).T
-                    Y = _interp_grid(Y.T, require_monotonicity=True).T
-                shading = 'flat'
+            # grid is specified at the center, so define corners
+            # at the midpoints between the grid centers and then use the
+            # flat algorithm.
+            def _interp_grid(X, require_monotonicity=False):
+                # helper for below. To ensure the cell edges are calculated
+                # correctly, when expanding columns, the monotonicity of
+                # X coords needs to be checked. When expanding rows, the
+                # monotonicity of Y coords needs to be checked.
+                if np.shape(X)[1] > 1:
+                    dX = np.diff(X, axis=1) * 0.5
+                    if (require_monotonicity and
+                            not (np.all(dX >= 0) or np.all(dX <= 0))):
+                        _api.warn_external(
+                            f"The input coordinates to {funcname} are "
+                            "interpreted as cell centers, but are not "
+                            "monotonically increasing or decreasing. "
+                            "This may lead to incorrectly calculated cell "
+                            "edges, in which case, please supply "
+                            f"explicit cell edges to {funcname}.")
+
+                    hstack = np.ma.hstack if np.ma.isMA(X) else np.hstack
+                    X = hstack((X[:, [0]] - dX[:, [0]],
+                                X[:, :-1] + dX,
+                                X[:, [-1]] + dX[:, [-1]]))
+                else:
+                    # This is just degenerate, but we can't reliably guess
+                    # a dX if there is just one value.
+                    X = np.hstack((X, X))
+                return X
+
+            if shading_x == 'nearest':
+                X = _interp_grid(X, require_monotonicity=True)
+                Y = _interp_grid(Y)
+            if shading_y == 'nearest':
+                X = _interp_grid(X.T).T
+                Y = _interp_grid(Y.T, require_monotonicity=True).T
+            shading = 'flat'
 
         C = cbook.safe_masked_invalid(C, copy=True)
         return X, Y, C, shading
@@ -6623,7 +6672,7 @@ or pandas.DataFrame
             expanded as needed into the appropriate 2D arrays, making a
             rectangular grid.
 
-        shading : {'flat', 'nearest', 'auto'}, default: :rc:`pcolor.shading`
+        shading : {'flat', 'nearest', 'auto'} or 2-tuple, default: :rc:`pcolor.shading`
             The fill style for the quadrilateral. Possible values:
 
             - 'flat': A solid color is used for each quad. The color of the
@@ -6635,6 +6684,10 @@ or pandas.DataFrame
               dimensions of *X* and *Y* must be the same as *C*.
             - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
               larger than *C*.  Choose 'nearest' if dimensions are the same.
+
+            Additionally, a 2-tuple of strings `(shading_x, shading_y)` can be
+            passed to specify different shading types for the X and Y axes
+            individually.
 
             See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
             for more description.
@@ -6717,7 +6770,8 @@ or pandas.DataFrame
 
         if shading is None:
             shading = mpl.rcParams['pcolor.shading']
-        shading = shading.lower()
+        if isinstance(shading, str):
+            shading = shading.lower()
         X, Y, C, shading = self._pcolorargs('pcolor', *args, shading=shading,
                                             kwargs=kwargs)
         linewidths = (0.25,)
@@ -6850,7 +6904,7 @@ or pandas.DataFrame
         alpha : float, default: None
             The alpha blending value, between 0 (transparent) and 1 (opaque).
 
-        shading : {'flat', 'nearest', 'gouraud', 'auto'}, optional
+        shading : {'flat', 'nearest', 'gouraud', 'auto'} or 2-tuple, optional
             The fill style for the quadrilateral; defaults to
             :rc:`pcolor.shading`. Possible values:
 
@@ -6868,6 +6922,11 @@ or pandas.DataFrame
               Gouraud shading is used, *edgecolors* is ignored.
             - 'auto': Choose 'flat' if dimensions of *X* and *Y* are one
               larger than *C*.  Choose 'nearest' if dimensions are the same.
+
+            Additionally, a 2-tuple of strings `(shading_x, shading_y)` can be
+            passed to specify different shading types for the X and Y axes
+            individually. Note that 'gouraud' cannot be mixed with other shading
+            types.
 
             See :doc:`/gallery/images_contours_and_fields/pcolormesh_grids`
             for more description.
@@ -6953,7 +7012,9 @@ or pandas.DataFrame
         `~.Axes.pcolormesh`, which is not available with `~.Axes.pcolor`.
 
         """
-        shading = mpl._val_or_rc(shading, 'pcolor.shading').lower()
+        shading = mpl._val_or_rc(shading, 'pcolor.shading')
+        if isinstance(shading, str):
+            shading = shading.lower()
         kwargs.setdefault('edgecolors', 'none')
 
         X, Y, C, shading = self._pcolorargs('pcolormesh', *args,

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -526,7 +526,12 @@ class Axes(_AxesBase):
     def pcolor(
         self,
         *args: ArrayLike,
-        shading: Literal["flat", "nearest", "auto"] | None = ...,
+        shading: Literal["flat", "nearest", "auto"]
+        | tuple[
+            Literal["flat", "nearest", "auto"],
+            Literal["flat", "nearest", "auto"],
+        ]
+        | None = ...,
         alpha: float | None = ...,
         norm: str | Normalize | None = ...,
         cmap: str | Colormap | None = ...,
@@ -545,7 +550,12 @@ class Axes(_AxesBase):
         vmin: float | None = ...,
         vmax: float | None = ...,
         colorizer: Colorizer | None = ...,
-        shading: Literal["flat", "nearest", "gouraud", "auto"] | None = ...,
+        shading: Literal["flat", "nearest", "gouraud", "auto"]
+        | tuple[
+            Literal["flat", "nearest", "gouraud", "auto"],
+            Literal["flat", "nearest", "gouraud", "auto"],
+        ]
+        | None = ...,
         antialiased: bool = ...,
         data: DataParamType = ...,
         **kwargs

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -3881,7 +3881,11 @@ def minorticks_on() -> None:
 @_copy_docstring_and_deprecators(Axes.pcolor)
 def pcolor(
     *args: ArrayLike,
-    shading: Literal["flat", "nearest", "auto"] | None = None,
+    shading: (
+        Literal["flat", "nearest", "auto"]
+        | tuple[Literal["flat", "nearest", "auto"], Literal["flat", "nearest", "auto"]]
+        | None
+    ) = None,
     alpha: float | None = None,
     norm: str | Normalize | None = None,
     cmap: str | Colormap | None = None,
@@ -3917,7 +3921,14 @@ def pcolormesh(
     vmin: float | None = None,
     vmax: float | None = None,
     colorizer: Colorizer | None = None,
-    shading: Literal["flat", "nearest", "gouraud", "auto"] | None = None,
+    shading: (
+        Literal["flat", "nearest", "gouraud", "auto"]
+        | tuple[
+            Literal["flat", "nearest", "gouraud", "auto"],
+            Literal["flat", "nearest", "gouraud", "auto"],
+        ]
+        | None
+    ) = None,
     antialiased: bool = False,
     data: DataParamType = None,
     **kwargs,

--- a/lib/matplotlib/rcsetup.py
+++ b/lib/matplotlib/rcsetup.py
@@ -979,6 +979,46 @@ def validate_hist_bins(s):
                      " a sequence of floats")
 
 
+def validate_pcolor_shading(s):
+    valid = ["auto", "flat", "nearest", "gouraud"]
+    if isinstance(s, str):
+        s = s.lower()
+        if s in valid:
+            return s
+        raise ValueError(f"shading {s!r} must be one of {valid}")
+    # Otherwise, check if it's an iterable of size 2
+    try:
+        s_tuple = tuple(s)
+    except TypeError as e:
+        raise ValueError(
+            f"shading {s!r} must be a string or a 2-tuple of strings"
+        ) from e
+    if len(s_tuple) != 2:
+        raise ValueError(
+            f"shading {s!r} must be a string or a 2-tuple of strings"
+        )
+
+    normalized = []
+    for item in s_tuple:
+        if isinstance(item, str):
+            item = item.lower()
+            if item in valid:
+                normalized.append(item)
+                continue
+        raise ValueError(
+            f"shading components must be one of {valid}, got {item!r}"
+        )
+    if (
+        (normalized[0] == 'gouraud' or normalized[1] == 'gouraud')
+        and normalized[0] != normalized[1]
+    ):
+        raise ValueError(
+            "shading='gouraud' cannot be mixed with other shading types."
+        )
+    return tuple(normalized)
+
+
+
 class _ignorecase(list):
     """A marker class indicating that a list-of-str is case-insensitive."""
 
@@ -1032,7 +1072,7 @@ _validators = {
     "markers.fillstyle": validate_fillstyle,
 
     ## pcolor(mesh) props:
-    "pcolor.shading": ["auto", "flat", "nearest", "gouraud"],
+    "pcolor.shading": validate_pcolor_shading,
     "pcolormesh.snap": validate_bool,
 
     ## patch props
@@ -1691,7 +1731,7 @@ _DEFINITION = [
     _Param(
         "pcolor.shading",
         default="auto",
-        validator=["auto", "flat", "nearest", "gouraud"]
+        validator=validate_pcolor_shading
     ),
     _Param(
         "pcolormesh.snap",

--- a/lib/matplotlib/rcsetup.pyi
+++ b/lib/matplotlib/rcsetup.pyi
@@ -155,6 +155,15 @@ def validate_hist_bins(
 ) -> Literal["auto", "sturges", "fd", "doane", "scott", "rice", "sqrt"] | int | list[
     float
 ]: ...
+def validate_pcolor_shading(
+    s: Any,
+) -> (
+    Literal["auto", "flat", "nearest", "gouraud"]
+    | tuple[
+        Literal["auto", "flat", "nearest", "gouraud"],
+        Literal["auto", "flat", "nearest", "gouraud"],
+    ]
+): ...
 
 # At runtime is added in __init__.py
 defaultParams: dict[str, Any]

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -1784,6 +1784,72 @@ def test_pcolorauto(fig_test, fig_ref, snap):
     ax.pcolormesh(x2, y2, Z, snap=snap)
 
 
+@check_figures_equal()
+def test_mixed_shading(fig_test, fig_ref):
+    x = np.arange(0, 10)  # edges for X (length 10)
+    y = np.arange(0, 4)   # edges for Y (length 4)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+
+    # test: X specified at centers, Y at edges, shading=('nearest', 'flat')
+    ax_test = fig_test.subplots()
+    x_centers = x[:-1] + np.diff(x) / 2
+    ax_test.pcolormesh(x_centers, y, Z, shading=('nearest', 'flat'))
+
+    # ref: both X and Y at edges, shading='flat'
+    ax_ref = fig_ref.subplots()
+    ax_ref.pcolormesh(x, y, Z, shading='flat')
+
+
+@check_figures_equal()
+def test_mixed_shading_yx(fig_test, fig_ref):
+    x = np.arange(0, 10)
+    y = np.arange(0, 4)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+
+    # test: X at edges, Y at centers, shading=('flat', 'nearest')
+    ax_test = fig_test.subplots()
+    y_centers = y[:-1] + np.diff(y) / 2
+    ax_test.pcolormesh(x, y_centers, Z, shading=('flat', 'nearest'))
+
+    # ref: both at edges, shading='flat'
+    ax_ref = fig_ref.subplots()
+    ax_ref.pcolormesh(x, y, Z, shading='flat')
+
+
+@check_figures_equal()
+def test_mixed_shading_auto(fig_test, fig_ref):
+    x = np.arange(0, 10)
+    y = np.arange(0, 4)
+    np.random.seed(19680801)
+    Z = np.random.randn(3, 9)
+
+    # test: shading='auto'
+    ax_test = fig_test.subplots()
+    x_centers = x[:-1] + np.diff(x) / 2
+    ax_test.pcolormesh(x_centers, y, Z, shading='auto')
+
+    # ref: shading=('nearest', 'flat')
+    ax_ref = fig_ref.subplots()
+    ax_ref.pcolormesh(x_centers, y, Z, shading=('nearest', 'flat'))
+
+
+def test_mixed_shading_errors():
+    fig, ax = plt.subplots()
+    Z = np.random.randn(3, 9)
+    # Check that mixing gouraud and other shadings raises ValueError
+    with pytest.raises(ValueError, match="cannot be mixed with other shading"):
+        ax.pcolormesh(Z, shading=('gouraud', 'flat'))
+    with pytest.raises(ValueError, match="cannot be mixed with other shading"):
+        ax.pcolormesh(Z, shading=('nearest', 'gouraud'))
+    # Check that invalid string raises ValueError
+    with pytest.raises(
+        ValueError, match="'invalid' is not a valid value for shading_x"
+    ):
+        ax.pcolormesh(Z, shading=('invalid', 'flat'))
+
+
 @image_comparison(['canonical'], style='mpl20',
                   tol=0 if platform.machine() == 'x86_64' else 0.03)
 def test_canonical():


### PR DESCRIPTION
Description

Allow specifying shading style individually for x and y axes as a 2-tuple.
Resolve 'auto' individually per axis.
Added validation for 2-tuple configurations in rcsetup.
Added comprehensive tests covering correct resolution, shape checks, and error cases.

PR summary

Currently, pcolor and pcolormesh support coordinate grids that are either the same size as the 2D data array (shading='nearest'), or one larger than the array (shading='flat'). However, it was not possible to plot a dataset where the coordinate grid is defined by cell centers along one dimension and cell edges along the other.

This PR introduces support for mixed shading styles by allowing a 2-tuple of shadings (e.g. shading=('nearest', 'flat') or shading=('flat', 'nearest')). It also updates shading='auto' to automatically resolve to a mixed shading configuration depending on the coordinate and data dimensions.

Implementation Details:

Validation: Updated validation in rcsetup.py via validate_pcolor_shading to support a 2-tuple of values, ensuring that 'gouraud' cannot be mixed with other shading styles (which raises a ValueError).
Grid Generation: In _axes.py: _pcolorargs, the shading parameter is unpacked/normalized. If either dimension has 'nearest' shading, its coordinate centers are interpolated to cell edges, while the other dimension is left as-is if it is already 'flat'. This results in a final rectangular grid of cell corners which is then rendered with 'flat' shading.
Compatibility: Standard single-string shadings ('flat', 'nearest', 'gouraud', 'auto') continue to work exactly as before.

Example usage:

python
import matplotlib.pyplot as plt
import numpy as np
# Data shape: 4 rows, 5 columns
Z = np.random.rand(4, 5)
# X matches columns (5 centers -> nearest)
X = np.arange(5)
# Y matches cell edges (5 edges for 4 rows -> flat)
Y = np.arange(5)
fig, ax = plt.subplots()
# Automatically resolves to shading=('nearest', 'flat')
pcm = ax.pcolormesh(X, Y, Z, shading='auto')
plt.show()

closes #31607

AI Disclosure

Antigravity was used to assist in writing parts of the implementation logic and formatting unit tests.

PR checklist

 - [✓]"closes #31607" is in the body of the PR description to link the related issue
 - [✓]new and changed code is tested
 - []Plotting related features are demonstrated in an example
 - []New Features and API Changes are noted with a directive and release note
 - [✓]Documentation complies with general and docstring guidelines