### PR TITLE
FIX: include axis labels in get_tightbbox when not for_layout_only

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -4747,7 +4747,10 @@ class _AxesBase(martist.Artist):
 
         for axis in self._axis_map.values():
             if self.axison and axis.get_visible():
-                ba = martist._get_tightbbox_for_layout_only(axis, renderer)
+                if for_layout_only:
+                    ba = martist._get_tightbbox_for_layout_only(axis, renderer)
+                else:
+                    ba = axis.get_tightbbox(renderer)
                 if ba:
                     bb.append(ba)
         self._update_title_position(renderer)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -8374,6 +8374,21 @@ def test_tick_padding_tightbbox():
     assert bb.y0 < bb2.y0
 
 
+def test_tightbbox_includes_long_label():
+    fig, ax = plt.subplots()
+
+    renderer = fig._get_renderer()
+    bbox_no_xlabel = ax.get_tightbbox(renderer, for_layout_only=False)
+
+    ax.set_xlabel(
+        'loooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooooong')
+    bbox_long_xlabel = ax.get_tightbbox(renderer, for_layout_only=False)
+
+    # When for_layout_only is False, the axes tightbbox should encompass its labels even
+    # if they are long enough to extent beyond its limits.
+    assert bbox_long_xlabel.width > bbox_no_xlabel.width
+
+
 def test_inset():
     """
     Ensure that inset_ax argument is indeed optional

--- a/lib/mpl_toolkits/mplot3d/axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/axes3d.py
@@ -4167,8 +4167,10 @@ class Axes3D(Axes):
         if self._axis3don:
             for axis in self._axis_map.values():
                 if axis.get_visible():
-                    axis_bb = martist._get_tightbbox_for_layout_only(
-                        axis, renderer)
+                    if for_layout_only:
+                        axis_bb = martist._get_tightbbox_for_layout_only(axis, renderer)
+                    else:
+                        axis_bb = axis.get_tightbbox(renderer=renderer)
                     if axis_bb:
                         batch.append(axis_bb)
         return mtransforms.Bbox.union(batch)

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -3202,3 +3202,24 @@ def test_plot_surface_log_scale_invalid_values():
 
     zmin, zmax = ax.get_zlim()
     assert 1e-3 < zmin < zmax < 1e3, f"zlim corrupted: {(zmin, zmax)}"
+
+
+def test_axes3d_tightbbox_includes_axis_labels():
+    fig = plt.figure()
+    ax = fig.add_subplot(projection='3d')
+    ax.scatter([1], [1], [1])
+
+    fig.draw_without_rendering()
+    renderer = fig._get_renderer()
+    bb_no_labels = ax.get_tightbbox(renderer)
+
+    ax.set_xlabel('X label')
+    ax.set_ylabel('Y label')
+    ax.set_zlabel('Z label')
+
+    fig.draw_without_rendering()
+    bb_full = ax.get_tightbbox(renderer)
+
+    # The full bbox must be strictly larger in at least one dimension than the
+    # bbox not including labels.
+    assert bb_full.width > bb_no_labels.width or bb_full.height > bb_no_labels.height


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Fixes #28117 and fixes #31568

This is the rebased branch from #31571, with some modifications for the 3D case and an added fix for the standard axes case.  Since 5c758074b423338d92aa8721b39a8419f48851f1 we have not been passing `for_layout_only=False` from the axes `get_tightbbox` down to the axis `get_tightbbox`.  This PR makes sure that we do by explicitly calling `axis.get_tightbbox()` for that case, without the keyword in case we have hold of a third party axis that does not support it.

An alternative solution is to modify the `_get_tightbbox_for_layout_only` helper function, which I tried at https://github.com/matplotlib/matplotlib/issues/28117#issuecomment-4338275234.  I'd be happy to switch to that - I don't have an opinion on which is better.

The code from #31568 now gives
<img width="303" height="283" alt="3d_tight" src="https://github.com/user-attachments/assets/bbb138dc-e19f-440e-807d-dd09450689ab" />

The code from https://github.com/matplotlib/matplotlib/issues/28117#issuecomment-4338062046 now gives
<img width="672" height="433" alt="test" src="https://github.com/user-attachments/assets/3e9794d4-9b13-479a-adeb-4e518e5d7e88" />

Note there is also #31573, but I prefer the solution from #31571 because it leaves the responsibility for the axis labels with the relevant axis.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
No AI used by me.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
