### PR TITLE
Fix legend settings not preserved when regenerating in Qt dialog

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -6,7 +6,7 @@
 """Module that provides a GUI-based editor for Matplotlib's figure options."""
 
 from itertools import chain
-from matplotlib import cbook, cm, colors as mcolors, markers, image as mimage
+from matplotlib import cbook, cm, colors as mcolors, markers, image as mimage, patches as mpatches
 from matplotlib.backends.qt_compat import QtGui
 from matplotlib.backends.qt_editor import _formlayout
 from matplotlib.dates import DateConverter, num2date
@@ -248,12 +248,45 @@ def figure_edit(axes, parent=None):
         if generate_legend:
             draggable = None
             ncols = 1
+            shadow = False
+            fancybox = None
+            framealpha = None
+            legend_title = None
+            bbox_to_anchor = None
+            loc = 'best'
+            mode = None
+            borderaxespad = None
+
             if axes.legend_ is not None:
                 old_legend = axes.get_legend()
                 draggable = old_legend._draggable is not None
                 ncols = old_legend._ncols
-            new_legend = axes.legend(ncols=ncols)
+                shadow = old_legend.shadow
+                fancybox = isinstance(
+                    old_legend.legendPatch.get_boxstyle(),
+                    mpatches.BoxStyle.Round)
+                framealpha = old_legend.get_frame().get_alpha()
+                legend_title = old_legend.get_title().get_text() or None
+                loc = old_legend._loc
+                mode = old_legend._mode
+                borderaxespad = old_legend.borderaxespad
+                # Preserve bbox_to_anchor if it was explicitly set
+                if not old_legend._loc_used_default:
+                    bbox_to_anchor = old_legend.get_bbox_to_anchor()
+
+            new_legend = axes.legend(
+                ncols=ncols,
+                shadow=shadow,
+                fancybox=fancybox,
+                framealpha=framealpha,
+                title=legend_title,
+                loc=loc,
+                mode=mode,
+                borderaxespad=borderaxespad,
+            )
             if new_legend:
+                if bbox_to_anchor is not None:
+                    new_legend.set_bbox_to_anchor(bbox_to_anchor)
                 new_legend.set_draggable(draggable)
 
         # Redraw


### PR DESCRIPTION
Clone ncols, shadow, fancybox, framealpha, title, loc, mode, borderaxespad and bbox_to_anchor from the existing legend before regenerating, so custom legend state is not discarded.

Closes #17775

<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
When the "(Re-)Generate automatic legend" checkbox is used in the Qt 
figure options dialog, the existing code only preserved `ncols` and 
`draggable`. All other custom legend settings (shadow, fancybox, 
framealpha, title, loc, mode, borderaxespad, bbox_to_anchor) were 
silently discarded.

This fix reads all relevant properties from the existing legend before 
calling `axes.legend()` again, so the regenerated legend matches the 
original state.

Minimum reproducible example:
```python
import matplotlib.pyplot as plt
fig, ax = plt.subplots()
ax.plot(range(5), label='a')
ax.plot(range(3)[::-1], label='b')
ax.legend(bbox_to_anchor=(0,1.02,1,0.2), loc="lower left", 
          mode="expand", borderaxespad=0, ncols=3)
plt.show()
# Open figure options, tick "(Re)-generate legend", click OK
# Legend settings are lost
```
## AI Disclosure
Used Claude (Anthropic) to assist with identifying the correct 
attributes to read from the Legend object and to verify the fix 
via a test script.
## PR checklist
- [x] "closes #17775" is in the body of the PR description
- [x] new and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines