### PR TITLE
FIX: macOS backend reports wrong button for button_release_event

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -331,17 +331,21 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
     def mousePressEvent(self, event):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
+            mods = self._mpl_modifiers()
             MouseEvent("button_press_event", self,
-                       *self.mouseEventCoords(event), button,
-                       modifiers=self._mpl_modifiers(),
+                       *self.mouseEventCoords(event),
+                       self._remap_darwin_button(button, mods),
+                       modifiers=mods,
                        guiEvent=event)._process()
 
     def mouseDoubleClickEvent(self, event):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
+            mods = self._mpl_modifiers()
             MouseEvent("button_press_event", self,
-                       *self.mouseEventCoords(event), button, dblclick=True,
-                       modifiers=self._mpl_modifiers(),
+                       *self.mouseEventCoords(event),
+                       self._remap_darwin_button(button, mods), dblclick=True,
+                       modifiers=mods,
                        guiEvent=event)._process()
 
     def mouseMoveEvent(self, event):
@@ -356,9 +360,11 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
     def mouseReleaseEvent(self, event):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
+            mods = self._mpl_modifiers()
             MouseEvent("button_release_event", self,
-                       *self.mouseEventCoords(event), button,
-                       modifiers=self._mpl_modifiers(),
+                       *self.mouseEventCoords(event),
+                       self._remap_darwin_button(button, mods),
+                       modifiers=mods,
                        guiEvent=event)._process()
 
     def wheelEvent(self, event):
@@ -423,6 +429,13 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         # State *after* press/release.
         return {button for mask, button in FigureCanvasQT.buttond.items()
                 if _to_int(mask) & buttons}
+
+    @staticmethod
+    def _remap_darwin_button(button, mods):
+        # On macOS, Option+left-click emulates middle-click (mirrors _macosx.m).
+        if sys.platform == "darwin" and button == MouseButton.LEFT and 'alt' in mods:
+            return MouseButton.MIDDLE
+        return button
 
     @staticmethod
     def _mpl_modifiers(modifiers=None, *, exclude=None):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -239,6 +239,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         self._is_drawing = False
         self._draw_rect_callback = lambda painter: None
         self._in_resize_event = False
+        self._pressed_buttons = {}
 
         self.setAttribute(QtCore.Qt.WidgetAttribute.WA_OpaquePaintEvent)
         self.setMouseTracking(True)
@@ -332,9 +333,11 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
             mods = self._mpl_modifiers()
+            button = self._remap_darwin_button(button, mods)
+            self._pressed_buttons[event.button()] = button
             MouseEvent("button_press_event", self,
                        *self.mouseEventCoords(event),
-                       self._remap_darwin_button(button, mods),
+                       button,
                        modifiers=mods,
                        guiEvent=event)._process()
 
@@ -342,9 +345,11 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
             mods = self._mpl_modifiers()
+            button = self._remap_darwin_button(button, mods)
+            self._pressed_buttons[event.button()] = button
             MouseEvent("button_press_event", self,
                        *self.mouseEventCoords(event),
-                       self._remap_darwin_button(button, mods), dblclick=True,
+                       button, dblclick=True,
                        modifiers=mods,
                        guiEvent=event)._process()
 
@@ -361,9 +366,13 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         button = self.buttond.get(event.button())
         if button is not None and self.figure is not None:
             mods = self._mpl_modifiers()
+            # use the button remapped at the press time, so releasing Option
+            # before the mouse button still reports the press time button
+            button = self._pressed_buttons.pop(
+                event.button(), self._remap_darwin_button(button, mods))
             MouseEvent("button_release_event", self,
                        *self.mouseEventCoords(event),
-                       self._remap_darwin_button(button, mods),
+                       button,
                        modifiers=mods,
                        guiEvent=event)._process()
 

--- a/lib/matplotlib/tests/test_backend_qt.py
+++ b/lib/matplotlib/tests/test_backend_qt.py
@@ -131,6 +131,43 @@ def test_correct_key(backend, qt_key, qt_mods, answer, monkeypatch):
     assert result == answer
 
 
+@pytest.mark.parametrize('backend', [
+    # Note: the value is irrelevant; the important part is the marker.
+    pytest.param(
+        'Qt5Agg',
+        marks=pytest.mark.backend('Qt5Agg', skip_on_importerror=True)),
+    pytest.param(
+        'QtAgg',
+        marks=pytest.mark.backend('QtAgg', skip_on_importerror=True)),
+])
+def test_macos_option_click_emulates_middle_button(backend, monkeypatch):
+    """
+    Make a figure.
+    Send a mouse press and release event with the Alt/Option modifier held.
+    Catch the events.
+    Assert the button is remapped to middle on macOS, unchanged elsewhere.
+    """
+    from matplotlib.backend_bases import MouseButton
+    from matplotlib.backends.qt_compat import QtCore, QtWidgets
+
+    monkeypatch.setattr(QtWidgets.QApplication, "keyboardModifiers",
+                        lambda self: QtCore.Qt.KeyboardModifier.AltModifier)
+
+    class _MouseEvent:
+        def button(self): return QtCore.Qt.MouseButton.LeftButton
+        def position(self): return QtCore.QPointF(0, 0)  # Qt6
+        def pos(self): return QtCore.QPoint(0, 0)        # Qt5
+
+    expected = MouseButton.MIDDLE if sys.platform == "darwin" else MouseButton.LEFT
+    results = []
+    fig = plt.figure()
+    fig.canvas.mpl_connect('button_press_event', lambda e: results.append(e.button))
+    fig.canvas.mpl_connect('button_release_event', lambda e: results.append(e.button))
+    fig.canvas.mousePressEvent(_MouseEvent())
+    fig.canvas.mouseReleaseEvent(_MouseEvent())
+    assert results == [expected, expected]
+
+
 @pytest.mark.backend('QtAgg', skip_on_importerror=True)
 def test_device_pixel_ratio_change():
     """

--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -71,6 +71,8 @@ static bool keyChangeOption = false;
 static bool keyChangeCapsLock = false;
 /* Keep track of the current mouse up/down state for open/closed cursor hand */
 static bool leftMouseGrabbing = false;
+/* Mouse button number set on press, Option/Ctrl remap effective left to 2/3 */
+static int effectiveLeftButton = 1;
 // Global variable to store the original SIGINT handler
 static PyOS_sighandler_t originalSigintAction = NULL;
 
@@ -1597,6 +1599,7 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
                      [[NSCursor closedHandCursor] set];
                  }
              }
+             effectiveLeftButton = button;
              break;
          }
          case NSEventTypeOtherMouseDown: button = 2; break;
@@ -1622,8 +1625,8 @@ static int _copy_agg_buffer(CGContextRef cr, PyObject *renderer)
     y = location.y * device_scale;
     switch ([event type])
     {    case NSEventTypeLeftMouseUp:
+             button = effectiveLeftButton;
              leftMouseGrabbing = false;
-             button = 1;
              if ([NSCursor currentCursor]==[NSCursor closedHandCursor])
                  [[NSCursor openHandCursor] set];
              break;


### PR DESCRIPTION
Fixes #31899 

## PR summary

The issue reports on macOS that Option+click and Ctrl+click were not correctly mapped to middle and right button clicks, respectively.

In **qtagg**, Option+click was hardcoded to `button = 1` as `backend_qt.py` did not contain a button modifier mapping. So `event.button()` returned the physical button, which resulted in Option+click incorrectly emulating button 1 instead of button 2.

In **macosx**, the `mouseDown:` method was correctly mapped, however, `mouseUp:` hardcoded `button = 1`, which resulted in press and release being inconsistent.

### Fixes
For **qtagg**, I added a `_remap_darwin_button(...)` static method in `backend_qt.py` that maps Alt/Option+left-click to the middle button on macOS.

For **macosx**, I added a static variable `effectiveLeftButton` to store the resolved button at press time, allowing `mouseUp:` to read it back instead of hardcoding `1`.
 
### Minimum self-contained example

Instructions:
- Left Click 
- Left Click + Option
- Left Click + Control

```py
import matplotlib
matplotlib.use('macosx') # macosx/qtagg
import matplotlib.pyplot as plt

def on_press(event):
    print(f'button press:   {event.button}')

def on_release(event):
    print(f'button release: {event.button}')
    print()

fig = plt.figure()
fig.canvas.mpl_connect('button_press_event', on_press)
fig.canvas.mpl_connect('button_release_event', on_release)
plt.show()
```

### Outputs

#### Current
macosx
```txt
button press:   1
button release: 1

button press:   2
button release: 1

button press:   3
button release: 1
```

qtagg (PyQt6)
```txt
button press:   1
button release: 1

button press:   1
button release: 1

button press:   3
button release: 3
```
#### With Fixes
macosx & qtagg
```txt
button press:   1
button release: 1

button press:   2
button release: 2

button press:   3
button release: 3
```

### Question
As raised in the initial issue, should the intended behaviour for the action `Alt + left-click` result in the middle mouse? This implements it, but can be dropped by removing `_remap_darwin_button(...)` helper function.

## AI Disclosure
Claude Opus 4.8 was utilised to proofread my changes.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] closes #31899 
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines 