### PR TITLE
DOC: update outdated examples/api directory reference

### DIFF
--- a/galleries/examples/user_interfaces/GALLERY_HEADER.rst
+++ b/galleries/examples/user_interfaces/GALLERY_HEADER.rst
@@ -8,6 +8,5 @@ following the embedding_in_SOMEGUI.py examples here. Currently
 Matplotlib supports PyQt/PySide, PyGObject, Tkinter, and wxPython.
 
 When embedding Matplotlib in a GUI, you must use the Matplotlib API
-directly rather than the pylab/pyplot procedural interface, so take a
-look at the examples/api directory for some example code working with
-the API.
+directly rather than the pylab/pyplot procedural interface. See
+:ref:`api_interfaces` for an overview of Matplotlib's API interfaces.

--- a/galleries/examples/user_interfaces/GALLERY_HEADER.rst
+++ b/galleries/examples/user_interfaces/GALLERY_HEADER.rst
@@ -8,5 +8,5 @@ following the embedding_in_SOMEGUI.py examples here. Currently
 Matplotlib supports PyQt/PySide, PyGObject, Tkinter, and wxPython.
 
 When embedding Matplotlib in a GUI, you must use the Matplotlib API
-directly rather than the pylab/pyplot procedural interface. See
+directly rather than the pyplot procedural interface. See
 :ref:`api_interfaces` for an overview of Matplotlib's API interfaces.


### PR DESCRIPTION
Fixes #31935

Replaced the outdated reference to the examples/api directory, which no longer exists, with a reference to the API interfaces documentation.