### PR TITLE
Add loongarch64 image comparison tolerances

### DIFF
--- a/lib/matplotlib/tests/test_inset.py
+++ b/lib/matplotlib/tests/test_inset.py
@@ -93,8 +93,10 @@ def test_inset_indicator_zorder():
     assert inset.get_zorder() == 42
 
 
-@image_comparison(['zoom_inset_connector_styles.png'], remove_text=True, style='mpl20',
-                  tol=0.024 if platform.machine() in ['aarch64', 'arm64'] else 0)
+@image_comparison(['zoom_inset_connector_styles.png'],
+                  remove_text=True, style='mpl20',
+                  tol=(0.024 if platform.machine() in ['aarch64', 'arm64',
+                                                       'loongarch64'] else 0))
 def test_zoom_inset_connector_styles():
     fig, axs = plt.subplots(2)
     for ax in axs:


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

LoongArch64 Linux produces small rasterization differences compared to the x86_64 baselines, similar to the existing tolerances for macOS and ARM64.

This adds loongarch64 to the platform checks in the 15 image comparison tests that currently fail on LoongArch64.

Each value is reused from the one already used for darwin or aarch64 in the same test.

Verified by running the full matplotlib test suite on real LoongArch64 hardware on Arch Linux for Loong64. (Python 3.14, FreeType 2.13.1)

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

AI was used to help identify the failing tests, analyze the correlation with existing macOS/ARM64 tolerances to reuse the exsting code correctly.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
