### PR TITLE
TST: Increase some tolerances for non-x86_64 architectures

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -240,7 +240,7 @@ def test_matshow(fig_test, fig_ref):
 
 
 @image_comparison([f'formatter_ticker_{i:03d}.png' for i in range(1, 6)], style='mpl20',
-                  tol=0.03 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.03)
 def test_formatter_ticker():
     import matplotlib.testing.jpl_units as units
     units.register()
@@ -5608,7 +5608,7 @@ def test_marker_styles():
 
 
 @image_comparison(['rc_markerfill.png'], style='mpl20',
-                  tol=0.033 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.033)
 def test_markers_fillstyle_rcparams():
     fig, ax = plt.subplots()
     x = np.arange(7)
@@ -5631,7 +5631,7 @@ def test_vertex_markers():
 
 
 @image_comparison(['vline_hline_zorder.png', 'errorbar_zorder.png'], style='mpl20',
-                  tol=0.02 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.02)
 def test_eb_line_zorder():
     x = list(range(10))
 
@@ -6681,7 +6681,7 @@ def test_pie_linewidth_0():
 
 
 @image_comparison(['pie_center_radius.png'], style='mpl20',
-                  tol=0.01 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_pie_center_radius():
     # The slices will be ordered and plotted counter-clockwise.
     labels = 'Frogs', 'Hogs', 'Dogs', 'Logs'
@@ -9901,7 +9901,7 @@ def test_zorder_and_explicit_rasterization():
 
 
 @image_comparison(["preset_clip_paths.png"], remove_text=True, style="mpl20",
-                  tol=0.01 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_preset_clip_paths():
     fig, ax = plt.subplots()
 

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1397,7 +1397,7 @@ def test_subfigure_dpi():
 
 @image_comparison(['test_subfigure_ss.png'], style='mpl20',
                   savefig_kwarg={'facecolor': 'teal'},
-                  tol=0.022 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.022)
 def test_subfigure_ss():
     # test assigning the subfigure via subplotspec
     np.random.seed(19680801)

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -2,7 +2,6 @@ import collections
 import io
 import itertools
 import platform
-import sys
 import time
 from unittest import mock
 import warnings
@@ -203,7 +202,7 @@ def test_alpha_rcparam():
 
 
 @image_comparison(['fancy.png'], remove_text=True, style='mpl20',
-                  tol=0.01 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_fancy():
     # using subplot triggers some offsetbox functionality untested elsewhere
     plt.subplot(121)
@@ -665,7 +664,7 @@ def test_empty_bar_chart_with_legend():
 
 
 @image_comparison(['shadow_argument_types.png'], remove_text=True, style='mpl20',
-                  tol=0.028 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.028)
 def test_shadow_argument_types():
     # Test that different arguments for shadow work as expected
     fig, ax = plt.subplots()

--- a/lib/matplotlib/tests/test_patheffects.py
+++ b/lib/matplotlib/tests/test_patheffects.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 
 import numpy as np
 
@@ -30,7 +30,7 @@ def test_patheffect1():
 
 
 @image_comparison(['patheffect2'], remove_text=True, style='mpl20',
-                  tol=0.051 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.051)
 def test_patheffect2():
 
     ax2 = plt.subplot()
@@ -46,7 +46,7 @@ def test_patheffect2():
 
 
 @image_comparison(['patheffect3'], style='mpl20',
-                  tol=0.02 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.02)
 def test_patheffect3():
     plt.figure(figsize=(8, 6))
     p1, = plt.plot([1, 3, 5, 4, 3], 'o-b', lw=4)

--- a/lib/matplotlib/tests/test_polar.py
+++ b/lib/matplotlib/tests/test_polar.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 
 import numpy as np
 from numpy.testing import assert_allclose
@@ -12,7 +12,7 @@ import matplotlib.ticker as mticker
 
 
 @image_comparison(['polar_axes.png'], style='default',
-                  tol=0.009 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.009)
 def test_polar_annotations():
     # You can specify the xypoint and the xytext in different positions and
     # coordinate systems, and optionally turn on a connecting line and mark the
@@ -47,7 +47,7 @@ def test_polar_annotations():
 
 
 @image_comparison(['polar_coords.png'], style='default', remove_text=True,
-                  tol=0.013 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.013)
 def test_polar_coord_annotations():
     # You can also use polar notation on a cartesian axes.  Here the native
     # coordinate system ('data') is cartesian, so you need to specify the

--- a/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_axes3d.py
@@ -1722,7 +1722,7 @@ def test_errorbar3d_errorevery():
 
 
 @mpl3d_image_comparison(['errorbar3d.png'], style='mpl20',
-                        tol=0.015 if sys.platform == 'darwin' else 0)
+                        tol=0 if platform.machine() == 'x86_64' else 0.015)
 def test_errorbar3d():
     """Tests limits, color styling, and legend for 3D errorbars."""
     fig = plt.figure()

--- a/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_legend3d.py
@@ -1,4 +1,4 @@
-import sys
+import platform
 
 import numpy as np
 
@@ -28,7 +28,7 @@ def test_legend_bar():
 
 
 @image_comparison(['fancy.png'], remove_text=True, style='mpl20',
-                  tol=0.01 if sys.platform == 'darwin' else 0)
+                  tol=0 if platform.machine() == 'x86_64' else 0.01)
 def test_fancy():
     fig, ax = plt.subplots(subplot_kw=dict(projection='3d'))
     ax.plot(np.arange(10), np.full(10, 5), np.full(10, 5), 'o--', label='line')


### PR DESCRIPTION
## PR summary

All of these were tightened in #31303, but it appears necessary to increase these ones for at least aarch64, ppc64le, and s390x, so switch the condition to the architecture. Note that our CI runs macOS on ARM, so the conditions for those should be fine to switch to architectures, since they aren't x86_64.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines