### PR TITLE
Break out gif test so it can be XFailed on Azure

### DIFF
--- a/lib/matplotlib/tests/test_agg_filter.py
+++ b/lib/matplotlib/tests/test_agg_filter.py
@@ -1,12 +1,14 @@
+import os
+
+import pytest
+
 import numpy as np
 
 import matplotlib.pyplot as plt
 from matplotlib.testing.decorators import image_comparison
 
 
-@image_comparison(baseline_images=['agg_filter_alpha'],
-                  extensions=['gif', 'png', 'pdf'], style='mpl20')
-def test_agg_filter_alpha():
+def _test_agg_filter_alpha_impl():
     ax = plt.axes()
     x, y = np.mgrid[0:7, 0:8]
     data = x**2 - y**2
@@ -28,3 +30,23 @@ def test_agg_filter_alpha():
     mesh.set_rasterized(True)
 
     ax.plot([0, 4, 7], [1, 3, 8])
+
+
+@image_comparison(baseline_images=['agg_filter_alpha'],
+                  extensions=['png', 'pdf'], style='mpl20')
+def test_agg_filter_alpha():
+    _test_agg_filter_alpha_impl()
+
+
+# This test was broken out due to failing on Azure with py3.13
+# This was the easiset way to XFail just a single image type
+# Once that is sorted, this can return to being a single test with all extensions.
+# And the impl method can be inlined again
+@pytest.mark.xfail("TF_BUILD" in os.environ
+                   and os.environ.get("VMIMAGE") == "windows-latest",
+                   reason="Test failing on Azure under Python 3.13",
+)
+@image_comparison(baseline_images=['agg_filter_alpha'],
+                  extensions=['gif'], style='mpl20')
+def test_agg_filter_alpha_gif():
+    _test_agg_filter_alpha_impl()


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

This test has been consistently failing on exactly one CI setup.
I've been unable to reproduce it locally, so XFailing the test specific to that CI setup.

I'd like to actually fix the underlying problem, but for now, limiting the amount of "it's red but we can ignore that" is better.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
None

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
