### PR TITLE
PDF: disable default ligatures in Type 42 text and add regression test

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2309,7 +2309,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
 
         # Disable common ligatures by default for PDF output unless user
         # explicitly set fontfeatures.
-        if features is None:
+        if features is None and mpl.rcParams['pdf.fonttype'] == 42:
             features = ('-liga', '-clig')
 
         # For Type-1 fonts, emit the whole string at once without manual kerning.

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2307,6 +2307,11 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
         else:
             features = language = None
 
+        # Disable common ligatures by default for PDF output unless user
+        # explicitly set fontfeatures.
+        if features is None:
+            features = ('-liga', '-clig')
+
         # For Type-1 fonts, emit the whole string at once without manual kerning.
         if mpl.rcParams['pdf.use14corefonts']:
             font = self._get_font_afm(prop)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -705,6 +705,60 @@ def test_scatter_logscale(fig_test, fig_ref):
     ax_ref.set_ylim(100, 1000)
 
 
+def _pdf_type42_text_metrics(text, *, fontfeatures=None):
+    with mpl.rc_context({"pdf.fonttype": 42, "pdf.compression": 9}):
+        fig, ax = plt.subplots()
+        kwargs = {}
+        if fontfeatures is not None:
+            kwargs["fontfeatures"] = fontfeatures
+        ax.set_title(text, **kwargs)
+
+        buffer = io.BytesIO()
+        try:
+            with PdfPages(buffer) as pdf:
+                fig.savefig(pdf, format="pdf")
+                used = pdf._file._character_tracker.used
+                assert len(used) == 1
+                subsets = next(iter(used.values()))
+                subset_count = len(subsets)
+                subset_sizes = [len(charmap) for charmap in subsets]
+        finally:
+            plt.close(fig)
+
+    return buffer.tell(), subset_count, subset_sizes
+
+
+def test_pdf_type42_ligature_size_regression():
+    """Regression test for issue #31955.
+
+    The default Type 42 PDF path should not introduce a ligature-driven size
+    increase relative to explicitly disabling ligatures, while an explicit
+    ligature opt-in should still produce the larger, multi-subset output.
+    """
+    default_size, default_subset_count, default_subset_sizes = (
+        _pdf_type42_text_metrics("Ecoflow")
+    )
+    no_liga_size, no_liga_subset_count, no_liga_subset_sizes = (
+        _pdf_type42_text_metrics("Ecoflow", fontfeatures=["-liga"])
+    )
+    no_fl_size, no_fl_subset_count, no_fl_subset_sizes = (
+        _pdf_type42_text_metrics("Ecolow")
+    )
+    explicit_liga_size, explicit_liga_subset_count, explicit_liga_subset_sizes = (
+        _pdf_type42_text_metrics("Ecoflow", fontfeatures=["liga"])
+    )
+
+    assert default_size == no_liga_size
+    assert default_subset_count == 1
+    assert no_liga_subset_count == 1
+    assert default_subset_sizes == no_liga_subset_sizes
+    assert no_fl_subset_count == 1
+    assert no_fl_size < default_size
+    assert explicit_liga_subset_count > 1
+    assert explicit_liga_size > default_size + 2_500
+    assert explicit_liga_subset_sizes != default_subset_sizes
+
+
 @check_figures_equal(extensions=["pdf"])
 def test_scatter_polar(fig_test, fig_ref):
     """

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -712,6 +712,7 @@ def _pdf_type42_text_metrics(text, *, fontfeatures=None):
         if fontfeatures is not None:
             kwargs["fontfeatures"] = fontfeatures
         ax.set_title(text, **kwargs)
+        ax.set_axis_off()
 
         buffer = io.BytesIO()
         try:


### PR DESCRIPTION
**Summary**
This PR fixes the PDF Type 42 ligature regression reported in #31955.

When rendering text to PDF, common ligatures are now disabled by default only when no explicit font features are provided. This preserves existing user intent for explicit fontfeatures while preventing unintended ligature shaping that was causing:

- changed text appearance (for example, fl ligature substitution), and
- larger PDFs due to additional font subset embedding.

**What Changed**

- Updated PDF text rendering logic to apply -liga and -clig only when fontfeatures is not explicitly set.
- Added a regression test in test_backend_pdf.py that validates:
- Default Type 42 output matches explicit -liga behavior.
- Explicit liga opt-in still produces the larger, multi-subset output.
- A control string without fl remains smaller.
- The size/subset behavior does not regress.

**Why**
The regression came from shaped vector text behavior interacting with Type 42 subsetting for multi-character glyphs. In affected cases, default rendering could introduce ligature glyphs and trigger extra subset embedding, increasing file size.

**Validation**
Targeted regression test passes:
python -m pytest test_backend_pdf.py -k pdf_type42_ligature_size_regression -q
PDF backend test file run was also executed locally during investigation.
Scope

This change is intentionally limited to:

- backend_pdf.py
- test_backend_pdf.py

## AI Disclosure

- AI was used to identify possible test cases- including edge case
- To generate commit messages
- Generate pull request description
- Github MCP server used to commit, push and create pull request


## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://github.com/matplotlib/matplotlib/issues/31955)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->

