### PR TITLE
Fix NoNorm cursor formatting for uint8 images

### DIFF
--- a/lib/matplotlib/colorizer.py
+++ b/lib/matplotlib/colorizer.py
@@ -505,7 +505,8 @@ class _ColorizerInterface:
                 delta = np.abs(norm.vmin * .1)
             else:
                 # Midpoints of neighboring color intervals.
-                neighbors = norm.inverse((int(normed * n) + np.array([0, 1])) / n)
+                neighbors = norm.inverse(
+                    (int(float(normed) * n) + np.array([0, 1])) / n)
                 delta = abs(neighbors - data).max()
 
             g_sig_digits = cbook._g_sig_digits(data, delta)

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -14,6 +14,7 @@ from PIL import Image
 import matplotlib as mpl
 from matplotlib import (
     colors, image as mimage, patches, pyplot as plt, style, rcParams)
+from matplotlib.backend_bases import MouseEvent
 from matplotlib.image import (AxesImage, BboxImage, FigureImage,
                               NonUniformImage, PcolorImage)
 from matplotlib.patches import Rectangle
@@ -455,14 +456,22 @@ def test_cursor_data_nonuniform(xy, data):
         ([[0, 0]], "[0.00]"),
     ])
 def test_format_cursor_data(data, text):
-    from matplotlib.backend_bases import MouseEvent
-
     fig, ax = plt.subplots()
     im = ax.imshow(data)
 
     xdisp, ydisp = ax.transData.transform([0, 0])
     event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
     assert im.format_cursor_data(im.get_cursor_data(event)) == text
+
+
+def test_format_cursor_data_uint8_no_norm():
+    data = np.array([[0, 44]], dtype=np.uint8)
+    fig, ax = plt.subplots()
+    im = ax.imshow(data, norm=colors.NoNorm())
+
+    xdisp, ydisp = ax.transData.transform([1, 0])
+    event = MouseEvent('motion_notify_event', fig.canvas, xdisp, ydisp)
+    assert im.format_cursor_data(im.get_cursor_data(event)) == "[44.000]"
 
 
 @pytest.mark.parametrize(
@@ -472,7 +481,6 @@ def test_format_cursor_data(data, text):
         ([[[np.nan, 1, 2]], [[0, 0, 0]]], "[]"),
     ])
 def test_format_cursor_data_multinorm(data, text):
-    from matplotlib.backend_bases import MouseEvent
     fig, ax = plt.subplots()
     cmap_bivar = mpl.bivar_colormaps['BiOrangeBlue']
     cmap_multivar = mpl.multivar_colormaps['2VarAddA']


### PR DESCRIPTION
## PR summary

closes #31960

This fixes cursor formatting for `uint8` image data displayed with `colors.NoNorm()`.

`NoNorm` returns the original NumPy scalar value. With recent NumPy versions, multiplying a `uint8` cursor value by the colormap size can raise `OverflowError` while Matplotlib computes neighboring color intervals for cursor display precision.

This change converts the normalized scalar to a Python scalar at the point where that interval arithmetic is needed, preserving the existing cursor readout behavior while avoiding the narrow-dtype overflow.

Before this change, formatting a `uint8` cursor value from a `NoNorm` image raised `OverflowError`. After this change, it returns the expected cursor label.

Breaking changes: None.

Tests run:

- `python -P -m pytest lib/matplotlib/tests/test_image.py::test_format_cursor_data_uint8_no_norm lib/matplotlib/tests/test_image.py::test_format_cursor_data`
- `python -P -m pytest lib/matplotlib/tests/test_image.py::test_format_cursor_data_multinorm lib/matplotlib/tests/test_artist.py::test_format_cursor_data_BoundaryNorm`
- `python -P -m pytest lib/matplotlib/tests/test_image.py -k cursor_data`

## AI Disclosure

I used Codex to review the relevant code and understand the existing codebase.

## PR checklist

- [x] "closes #31960" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
