### PR TITLE
Stop passing symlinks to ImageMagick

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -100,9 +100,15 @@ class _Converter:
 class _MagickConverter:
     def __call__(self, orig, dest):
         try:
-            subprocess.run(
-                [mpl._get_executable_info("magick").executable, orig, dest],
-                check=True)
+            with TemporaryDirectory() as tmpdirname:
+                # ImageMagick may not be permitted to follow symlinks, so make a copy
+                if orig.is_symlink():
+                    new_orig = tmpdirname + orig.name
+                    shutil.copyfile(orig, new_orig)
+                    orig = new_orig
+                subprocess.run(
+                    [mpl._get_executable_info("magick").executable, orig, dest],
+                    check=True)
         except subprocess.CalledProcessError as e:
             raise _ConverterError() from e
 

--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -100,15 +100,12 @@ class _Converter:
 class _MagickConverter:
     def __call__(self, orig, dest):
         try:
-            with TemporaryDirectory() as tmpdirname:
-                # ImageMagick may not be permitted to follow symlinks, so make a copy
-                if orig.is_symlink():
-                    new_orig = tmpdirname + orig.name
-                    shutil.copyfile(orig, new_orig)
-                    orig = new_orig
-                subprocess.run(
-                    [mpl._get_executable_info("magick").executable, orig, dest],
-                    check=True)
+            # ImageMagick may not be permitted to follow a symlink, so resolve it
+            if orig.is_symlink():
+                orig = orig.resolve()
+            subprocess.run(
+                [mpl._get_executable_info("magick").executable, orig, dest],
+                check=True)
         except subprocess.CalledProcessError as e:
             raise _ConverterError() from e
 


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

This is an alternative to merging #31954.

When doing an image-comparison test for a GIF, ImageMagick is invoked to convert the expected-image GIF file to PNG, and the expected-image files are actually symbolic links (when possible on the OS).  However, the default security policy of ImageMagick (as of a few months back) is to not follow symlinks.  For some reason that I do not understand, this causes a problem for us on only one of the CI build environments – even though I see no indication of a different version of ImageMagick or a non-default security policy – but I suspect other CI builds could fail in the future.  As a fix and preventative measure, this PR ~makes a copy of any symlinked file~ simply resolves any symlink before passing it on to ImageMagick.

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

No AI was used

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
