### PR TITLE
FIX: use requested style for empty bar charts.

### DIFF
--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -2453,6 +2453,15 @@ class Axes(_AxesBase):
         linewidth = kwargs.pop('linewidth', None)
         hatch = kwargs.pop('hatch', None)
 
+        # store style for an empty data scenario that would otherwise be lost.
+        legend_fallback_kwargs = {
+            'facecolor': facecolor[0] if len(facecolor) else 'none',
+            'edgecolor': edgecolor,
+            'linewidth': linewidth,
+            'label': '_nolegend_',
+            'hatch': hatch,
+        }
+
         # Because xerr and yerr will be passed to errorbar, most dimension
         # checking and processing will be left to the errorbar method.
         xerr = kwargs.pop('xerr', None)
@@ -2618,6 +2627,14 @@ class Axes(_AxesBase):
             self.add_patch(r)
             patches.append(r)
 
+        if not patches:
+            legend_fallback = mpatches.Rectangle(
+                xy=(0, 0), width=0, height=0,
+                **legend_fallback_kwargs)
+            legend_fallback._internal_update(kwargs)
+        else:
+            legend_fallback = None
+
         if xerr is not None or yerr is not None:
             if orientation == 'vertical':
                 # using list comps rather than arrays to preserve unit info
@@ -2646,6 +2663,7 @@ class Axes(_AxesBase):
         bar_container = BarContainer(patches, errorbar, datavalues=datavalues,
                                      orientation=orientation,
                                      label=bar_container_label)
+        bar_container._legend_fallback = legend_fallback
         self.add_container(bar_container)
 
         if tick_labels is not None:

--- a/lib/matplotlib/legend_handler.py
+++ b/lib/matplotlib/legend_handler.py
@@ -39,6 +39,8 @@ import matplotlib.collections as mcoll
 
 def update_from_first_child(tgt, src):
     first_child = next(iter(src.get_children()), None)
+    if first_child is None:
+        first_child = getattr(src, '_legend_fallback', None)
     if first_child is not None:
         tgt.update_from(first_child)
 

--- a/lib/matplotlib/tests/test_legend.py
+++ b/lib/matplotlib/tests/test_legend.py
@@ -663,6 +663,39 @@ def test_empty_bar_chart_with_legend():
     plt.legend()
 
 
+def test_empty_bar_chart_legend_style():
+    # issue #21506
+    _, ax = plt.subplots()
+    ax.bar([], [], color='red', alpha=0.3, label='empty')
+    assert mpl.colors.same_color(
+        ax.legend().legend_handles[0].get_facecolor(),
+        mpl.colors.to_rgba('red', 0.3),
+    )
+
+    _, ax = plt.subplots()
+    ax.bar([], [], label='a')
+    ax.bar([], [], label='b')
+    handles = ax.legend().legend_handles
+    assert mpl.colors.same_color(handles[0].get_facecolor(), 'C0')
+    assert mpl.colors.same_color(handles[1].get_facecolor(), 'C1')
+
+    _, ax = plt.subplots()
+    ax.bar([], [],
+           facecolor='red', edgecolor='black', linewidth=3,
+           label='styled', hatch='//')
+    handle = ax.legend().legend_handles[0]
+    assert mpl.colors.same_color(handle.get_edgecolor(), 'black')
+    assert handle.get_linewidth() == 3
+    assert handle.get_hatch() == '//'
+
+    _, ax = plt.subplots()
+    ax.barh([], [], color='green', label='h')
+    assert mpl.colors.same_color(
+        ax.legend().legend_handles[0].get_facecolor(),
+        'green',
+    )
+
+
 @image_comparison(['shadow_argument_types.png'], remove_text=True, style='mpl20',
                   tol=0 if platform.machine() == 'x86_64' else 0.028)
 def test_shadow_argument_types():


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->
Issue: Bar has no child patches when input data is empty, this leads to the legend handle being left at default as there are no children.

Fix: Store the style information as a fallback and use it when there are no children. This closes #21506.

Example:
 ```
import matplotlib.pyplot as plt

ax = plt.figure().add_subplot()
ax.bar([], [], color="red", alpha=0.3, label="empty")
handler = ax.legend().legend_handles[0]
print(handler.get_facecolor()) # (1.0, 0.0, 0.0, 0.3)
print(handler.get_alpha()) # 0.3
```

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
Fixed manually.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #21506" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
