### PR TITLE
DOC: fix two broken links in resources and wx5 example

### DIFF
--- a/doc/users/resources/index.rst
+++ b/doc/users/resources/index.rst
@@ -71,7 +71,7 @@ Videos
 Tutorials
 =========
 
-* `Matplotlib tutorial <https://www.labri.fr/perso/nrougier/teaching/matplotlib/>`_
+* `Matplotlib tutorial <https://github.com/rougier/matplotlib-tutorial>`_
   by Nicolas P. Rougier
 
 * `Anatomy of Matplotlib - IPython Notebooks

--- a/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -8,7 +8,7 @@ Embed in wx #5
     As a development and debugging aid, you can replace :class:`wx.App`
     by :class:`wx.lib.mixins.inspection.InspectableApp`.
     This adds the capability to start the `Widget Inspection Tool
-    <https://wiki.wxpython.org/How%20to%20use%20Widget%20Inspection%20Tool%20-%20WIT%20%28Phoenix%29>`_
+    <https://docs.wxpython.org/wx.lib.inspection.InspectionTool.html>`_
     via :kbd:`Ctrl-Alt-I`.
 """
 


### PR DESCRIPTION
Fix two broken documentation links mentioned in #30306 issue:

  - `doc/users/resources/index.rst`: replace timed-out `labri.fr` URL with github mirror for Nicolas Rougier's matplotlib tutorial
  - `galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py`: fix 404'd wxpython wiki link with current `docs.wxpython.org` URL

Thank you
