### PR TITLE
FIX: keep sub-pixel segments visible when snapping (#20243)

### DIFF
--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -5484,6 +5484,38 @@ def test_eventplot_defaults():
     axobj.eventplot(data)
 
 
+def test_eventplot_sub_pixel_events_not_dropped():
+    """
+    Event marks shorter than a pixel must still be drawn.
+
+    When an event line is less than a pixel tall, pixel snapping used to round
+    both of its endpoints to the same pixel, collapsing it to a zero-length
+    segment that the Agg renderer drew as nothing.  With many such events most
+    of the data silently disappeared.  Regression test for issue #20243.
+    """
+    n_events = 200
+    # One row of events, each in its own x column so a dropped mark leaves a
+    # detectable empty column.
+    positions = np.linspace(0.02, 0.98, n_events)
+
+    fig, ax = plt.subplots(figsize=(6, 2), dpi=100)  # 600 x 200 px
+    ax.eventplot(positions, linelengths=1, lineoffsets=0, colors='black')
+    ax.set_xlim(0, 1)
+    ax.set_ylim(-200, 200)  # each mark ~0.5 px tall -> would collapse if snapped
+    ax.set_axis_off()
+    fig.subplots_adjust(left=0, right=1, bottom=0, top=1)
+
+    fig.canvas.draw()
+    buf = np.asarray(fig.canvas.buffer_rgba())
+
+    # Count image columns containing a mark.  Before the fix this was 0 (every
+    # sub-pixel mark vanished); afterwards each requested mark is rendered.
+    non_white = (buf[:, :, :3] < 128).any(axis=2)
+    cols_with_ink = non_white.any(axis=0).sum()
+
+    assert cols_with_ink >= n_events
+
+
 @pytest.mark.parametrize(('colors'), [
     ('0.5',),  # string color with multiple characters: not OK before #8193 fix
     ('tab:orange', 'tab:pink', 'tab:cyan', 'bLacK'),  # case-insensitive

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -556,6 +556,14 @@ class PathSnapper
     bool m_snap;
     double m_snap_value;
 
+    // Previous vertex, kept so that the first segment of a subpath is not lost
+    // when snapping rounds both of its endpoints onto the same pixel.
+    unsigned m_prev_code;
+    double m_prev_snapped_x;
+    double m_prev_snapped_y;
+    double m_prev_raw_x;
+    double m_prev_raw_y;
+
     static bool should_snap(VertexSource &path, e_snap_mode snap_mode, unsigned total_vertices)
     {
         // If this contains only straight horizontal or vertical lines, it should be
@@ -609,7 +617,12 @@ class PathSnapper
                 e_snap_mode snap_mode,
                 unsigned total_vertices = 15,
                 double stroke_width = 0.0)
-        : m_source(&source)
+        : m_source(&source),
+          m_prev_code(agg::path_cmd_stop),
+          m_prev_snapped_x(0.0),
+          m_prev_snapped_y(0.0),
+          m_prev_raw_x(0.0),
+          m_prev_raw_y(0.0)
     {
         m_snap = should_snap(source, snap_mode, total_vertices);
 
@@ -623,6 +636,7 @@ class PathSnapper
 
     inline void rewind(unsigned path_id)
     {
+        m_prev_code = agg::path_cmd_stop;
         m_source->rewind(path_id);
     }
 
@@ -631,8 +645,36 @@ class PathSnapper
         unsigned code;
         code = m_source->vertex(x, y);
         if (m_snap && agg::is_vertex(code)) {
-            *x = floor(*x + 0.5) + m_snap_value;
-            *y = floor(*y + 0.5) + m_snap_value;
+            double raw_x = *x, raw_y = *y;
+            *x = floor(raw_x + 0.5) + m_snap_value;
+            *y = floor(raw_y + 0.5) + m_snap_value;
+
+            // A short line drawn on its own (an eventplot row, an hlines/vlines
+            // mark, a tick) is a MOVETO followed by a single LINETO.  If it is
+            // less than a pixel long both endpoints snap to the same pixel and
+            // nothing is drawn.  Keep the mark visible by extending the endpoint
+            // one pixel along the segment's dominant axis.  Only the opening
+            // segment of a subpath is treated this way, so polygon outlines
+            // (bars, markers) keep snapping unchanged.
+            if (code == agg::path_cmd_line_to &&
+                m_prev_code == agg::path_cmd_move_to &&
+                *x == m_prev_snapped_x && *y == m_prev_snapped_y) {
+                double dx = raw_x - m_prev_raw_x;
+                double dy = raw_y - m_prev_raw_y;
+                if (dx != 0.0 || dy != 0.0) {
+                    if (fabs(dx) >= fabs(dy)) {
+                        *x += (dx >= 0.0) ? 1.0 : -1.0;
+                    } else {
+                        *y += (dy >= 0.0) ? 1.0 : -1.0;
+                    }
+                }
+            }
+
+            m_prev_code = code;
+            m_prev_snapped_x = *x;
+            m_prev_snapped_y = *y;
+            m_prev_raw_x = raw_x;
+            m_prev_raw_y = raw_y;
         }
         return code;
     }

--- a/src/path_converters.h
+++ b/src/path_converters.h
@@ -564,11 +564,17 @@ class PathSnapper
     double m_prev_raw_x;
     double m_prev_raw_y;
 
+    bool m_has_next;
+    unsigned m_next_code;
+    double m_next_x;
+    double m_next_y;
+
     static bool should_snap(VertexSource &path, e_snap_mode snap_mode, unsigned total_vertices)
     {
         // If this contains only straight horizontal or vertical lines, it should be
         // snapped to the nearest pixels
-        double x0 = 0, y0 = 0, x1 = 0, y1 = 0;
+        double x0 = 0.0, y0 = 0.0;
+        double x1 = 0.0, y1 = 0.0;
         unsigned code;
 
         switch (snap_mode) {
@@ -576,34 +582,34 @@ class PathSnapper
             if (total_vertices > 1024) {
                 return false;
             }
-
-            code = path.vertex(&x0, &y0);
-            if (code == agg::path_cmd_stop) {
-                return false;
-            }
-
-            while ((code = path.vertex(&x1, &y1)) != agg::path_cmd_stop) {
-                switch (code) {
-                case agg::path_cmd_curve3:
-                case agg::path_cmd_curve4:
-                    return false;
-                case agg::path_cmd_line_to:
-                    if (fabs(x0 - x1) >= 1e-4 && fabs(y0 - y1) >= 1e-4) {
-                        return false;
-                    }
-                }
-                x0 = x1;
-                y0 = y1;
-            }
-
-            return true;
+            break;
         case SNAP_FALSE:
             return false;
         case SNAP_TRUE:
             return true;
         }
 
-        return false;
+        code = path.vertex(&x0, &y0);
+        if (code == agg::path_cmd_stop) {
+            return false;
+        }
+
+        while ((code = path.vertex(&x1, &y1)) != agg::path_cmd_stop) {
+            if (agg::is_curve(code)) {
+                return false;
+            }
+            if (agg::is_line_to(code)) {
+                double dx = fabs(x1 - x0);
+                double dy = fabs(y1 - y0);
+                if (dx > 1e-4 && dy > 1e-4) {
+                    return false;
+                }
+            }
+            x0 = x1;
+            y0 = y1;
+        }
+
+        return true;
     }
 
   public:
@@ -622,7 +628,11 @@ class PathSnapper
           m_prev_snapped_x(0.0),
           m_prev_snapped_y(0.0),
           m_prev_raw_x(0.0),
-          m_prev_raw_y(0.0)
+          m_prev_raw_y(0.0),
+          m_has_next(false),
+          m_next_code(agg::path_cmd_stop),
+          m_next_x(0.0),
+          m_next_y(0.0)
     {
         m_snap = should_snap(source, snap_mode, total_vertices);
 
@@ -636,6 +646,7 @@ class PathSnapper
 
     inline void rewind(unsigned path_id)
     {
+        m_has_next = false;
         m_prev_code = agg::path_cmd_stop;
         m_source->rewind(path_id);
     }
@@ -643,7 +654,15 @@ class PathSnapper
     inline unsigned vertex(double *x, double *y)
     {
         unsigned code;
-        code = m_source->vertex(x, y);
+        if (m_has_next) {
+            code = m_next_code;
+            *x = m_next_x;
+            *y = m_next_y;
+            m_has_next = false;
+        } else {
+            code = m_source->vertex(x, y);
+        }
+
         if (m_snap && agg::is_vertex(code)) {
             double raw_x = *x, raw_y = *y;
             *x = floor(raw_x + 0.5) + m_snap_value;
@@ -653,19 +672,25 @@ class PathSnapper
             // mark, a tick) is a MOVETO followed by a single LINETO.  If it is
             // less than a pixel long both endpoints snap to the same pixel and
             // nothing is drawn.  Keep the mark visible by extending the endpoint
-            // one pixel along the segment's dominant axis.  Only the opening
-            // segment of a subpath is treated this way, so polygon outlines
-            // (bars, markers) keep snapping unchanged.
-            if (code == agg::path_cmd_line_to &&
-                m_prev_code == agg::path_cmd_move_to &&
+            // one pixel along the segment's dominant axis.  Only an isolated
+            // subpath is treated this way, so polygon outlines (bars, markers)
+            // keep snapping unchanged.
+            if (agg::is_line_to(code) &&
+                agg::is_move_to(m_prev_code) &&
                 *x == m_prev_snapped_x && *y == m_prev_snapped_y) {
-                double dx = raw_x - m_prev_raw_x;
-                double dy = raw_y - m_prev_raw_y;
-                if (dx != 0.0 || dy != 0.0) {
-                    if (fabs(dx) >= fabs(dy)) {
-                        *x += (dx >= 0.0) ? 1.0 : -1.0;
-                    } else {
-                        *y += (dy >= 0.0) ? 1.0 : -1.0;
+                
+                m_next_code = m_source->vertex(&m_next_x, &m_next_y);
+                m_has_next = true;
+
+                if (!agg::is_vertex(m_next_code) || agg::is_move_to(m_next_code)) {
+                    double dx = raw_x - m_prev_raw_x;
+                    double dy = raw_y - m_prev_raw_y;
+                    if (dx != 0.0 || dy != 0.0) {
+                        if (fabs(dx) >= fabs(dy)) {
+                            *x += (dx >= 0.0) ? 1.0 : -1.0;
+                        } else {
+                            *y += (dy >= 0.0) ? 1.0 : -1.0;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
PR summary

  Closes #20243
  
  PathSnapper rounds every vertex to the nearest pixel. When a line segment is shorter than a pixel, both endpoints
  round to the same pixel, so the segment collapses to zero length and the Agg renderer draws nothing. With eventplots 
  of many events, this silently dropped most of the data, see #20243.

  This change tracks the previous raw/snapped vertex in PathSnapper. When a LINETO snaps onto the previous point even  
  though the raw segment had non-zero length, the snapped endpoint is nudged by one pixel along the segment's dominant 
  direction. The result is at least one full-color pixel rather than blurring the mark by disabling snapping (per the  
  discussion in #20243, this matches the preference for a full-color pixel over anti-aliased fuzz). Segments that      
  already span a pixel are untouched, so normal rendering (lines, bars, grids) is byte-for-byte unchanged.

  <details>
  <summary>Minimum self-contained example</summary>

  import matplotlib.pyplot as plt
  import numpy as np

  data = [np.random.random(np.random.randint(10)) for _ in range(500)]
  fig, ax = plt.subplots()
  ax.eventplot(data, linelength=1)
  plt.show()

  Before: most rows are missing.
  After: every event renders as at least one full pixel.

  </details>

  Verification: A regression test (test_eventplot_sub_pixel_events_not_dropped) renders 200 isolated sub-pixel event   
  marks and asserts they are all drawn. On the unpatched renderer 0/200 marks appear; with this change all of them do. 
  A separate check confirms the pixel buffers of ordinary line plots, bar charts, grids, and normal-scale eventplots   
  are identical before and after the change, so there is no visual regression on content that already covers a pixel. 

  PR checklist

  - [x] "closes #0000" is in the body of the PR description to link the related issue
  (https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
  - [x] new and changed code is tested (https://matplotlib.org/devdocs/devel/testing.html)
  - [N/A] Plotting related features are demonstrated in an example
  (https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
  - [N/A] New Features and API Changes are noted with a directive and release note
  (https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
  - [N/A] Documentation complies with general (https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and
  docstring (https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines