### PR TITLE
FIX: fall back to kpsewhich when luatex starts but is unusable

### DIFF
--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1267,10 +1267,16 @@ class _LuatexKpsewhich:
     def search(self, filename):
         if self._proc.poll() is not None:  # Dead, restart it.
             self._proc = self._new_proc()
-        self._proc.stdin.write(os.fsencode(filename) + b"\n")
-        self._proc.stdin.flush()
-        out = self._proc.stdout.readline().rstrip()
-        return None if out == b"nil" else os.fsdecode(out)
+        try:
+            self._proc.stdin.write(os.fsencode(filename) + b"\n")
+            self._proc.stdin.flush()
+            out = self._proc.stdout.readline().rstrip()
+        except OSError:  # luatex started but is now unusable.
+            return None
+        if out == b"":  # Empty read: luatex died; unusable.
+            return None
+        # "nil" => file missing but luatex works; return "" (not None).
+        return "" if out == b"nil" else os.fsdecode(out)
 
 
 @lru_cache
@@ -1280,7 +1286,8 @@ def find_tex_file(filename):
 
     The kpathsea library, provided by most existing TeX distributions, both
     on Unix-like systems and on Windows (MikTeX), is invoked via a long-lived
-    luatex process if luatex is installed, or via kpsewhich otherwise.
+    luatex process if luatex is installed and working, or via kpsewhich
+    otherwise.
 
     .. _kpathsea: https://www.tug.org/kpathsea/
 
@@ -1304,9 +1311,10 @@ def find_tex_file(filename):
     except (FileNotFoundError, OSError):
         lk = None  # Fallback to directly calling kpsewhich, as below.
 
+    path = None
     if lk:
         path = lk.search(filename)
-    else:
+    if path is None:  # luatex unavailable or unusable; fall back to kpsewhich.
         if sys.platform == 'win32':
             # On Windows only, kpathsea can use utf-8 for cmd args and output.
             # The `command_line_encoding` environment variable is set to force

--- a/lib/matplotlib/dviread.py
+++ b/lib/matplotlib/dviread.py
@@ -1265,15 +1265,20 @@ class _LuatexKpsewhich:
                  **os.environ})
 
     def search(self, filename):
-        if self._proc.poll() is not None:  # Dead, restart it.
+        # Searches for a file in the latex tree by communicating with a luatex
+        # instance. Returns:
+        #   - None: luatex is unusable (died, or the pipe broke);
+        #   - "": luatex is alive and answered, but the file doesn't exist;
+        #   - anything else: the path of the found file
+        if self._proc.poll() is not None:  # luatex instance is dead, restart it.
             self._proc = self._new_proc()
         try:
             self._proc.stdin.write(os.fsencode(filename) + b"\n")
             self._proc.stdin.flush()
             out = self._proc.stdout.readline().rstrip()
-        except OSError:  # luatex started but is now unusable.
+        except OSError:  # Pipe broke mid-communication: luatex is unusable.
             return None
-        if out == b"":  # Empty read: luatex died; unusable.
+        if out == b"":  # Empty read (EOF): luatex died; unusable.
             return None
         # "nil" => file missing but luatex works; return "" (not None).
         return "" if out == b"nil" else os.fsdecode(out)

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -150,32 +150,57 @@ def test_dviread_pk(tmp_path):
     assert data == correct
 
 
+# About this test: _LuatexKpsewhich.search() communicates with a long-lived `luatex`
+# subprocess over pipes and turns whatever comes back into one of three
+# outcomes that its caller (find_tex_file) depends on:
+#   * a path string  -> luatex found the file;
+#   * ""             -> luatex works but the file genuinely doesn't exist;
+#   * None           -> luatex is unusable, so the caller must fall back to
+#                       running kpsewhich directly.
+# Each parametrized case below feeds search() one scenario and asserts it maps
+# to the right outcome.
+#
+# Notice: We use mock-based testing here for cross-platform compatibility and
+# deterministic/standardized testing. This means that testing is quite heavily
+# tied to the internals of the tested function. Restructuring or rewriting of
+# code might break testing without actually changing the overall behaviour.
+# This tradeoff was accepted in #31984.
 @pytest.mark.parametrize("readline, write_error, expected", [
-    (b"/texmf/pdftex.map\n", None, "/texmf/pdftex.map"),  # normal result
-    (b"nil\n", None, ""),                                 # luatex ok, not found
-    (b"", None, None),                                    # process died (EOF)
-    (b"unused", BrokenPipeError, None),                   # dead pipe on write
+    # (bytes luatex "prints", exception raised on write, expected return)
+    # Case 1: supply a path with no error; check search() passes it through
+    (b"/texmf/pdftex.map\n", None, "/texmf/pdftex.map"),
+    # Case 2: make luatex answer "nil" (file missing); check search() returns ""
+    (b"nil\n", None, ""),
+    # Case 3: supply an empty read (luatex died); check search() returns None
+    (b"", None, None),
+    # Case 4: raise an error on write (pipe broke); check search() returns None
+    (b"unused", BrokenPipeError, None),
 ])
 def test_luatexkpsewhich_search(readline, write_error, expected):
-    # None => luatex unusable (triggers fallback); "" => file missing.  See #31984.
-    proc = mock.Mock()
-    proc.poll.return_value = None  # pretend the process is alive (no restart)
-    proc.stdin.write.side_effect = write_error
-    proc.stdout.readline.return_value = readline
-    lk = object.__new__(dr._LuatexKpsewhich)
-    lk._proc = proc
+    proc = mock.Mock()  # stand-in for the luatex subprocess
+    proc.poll.return_value = None  # so search() won't mark it dead and restart it
+    proc.stdin.write.side_effect = write_error  # None => write ok; else pipe broke
+    proc.stdout.readline.return_value = readline  # luatex's answer, read by search()
+    lk = object.__new__(dr._LuatexKpsewhich)  # bypass __new__ (spawns a real luatex)
+    lk._proc = proc  # hand search() our fake process instead
     assert lk.search("pdftex.map") == expected
 
 
 def test_find_tex_file_fallback_to_kpsewhich(monkeypatch):
-    # A luatex that starts but never returns a usable result (search() -> None)
-    # must not prevent falling back to kpsewhich.  Regression test for #31983.
+    # Unlike the search() test above, this checks the routing in find_tex_file,
+    # which takes the result of search() and acts accordingly by either calling
+    # the fallback (kpsewhich) if the search failed via luatex, or just forwarding
+    # the results. We therefore replace the whole _LuatexKpsewhich with a stub
+    # whose search() always returns None (luatex unusable), and check that
+    # find_tex_file then falls back to kpsewhich.
     class _UnusableLuatex:
         def search(self, filename):
             return None
 
     monkeypatch.setattr(dr, "_LuatexKpsewhich", _UnusableLuatex)
 
+    # kpsewhich is run via cbook._check_and_log_subprocess; intercept it so no
+    # real process is spawned, record what was called, and hand back a path.
     commands = []
 
     def fake_check_and_log_subprocess(command, logger, **kwargs):
@@ -185,27 +210,36 @@ def test_find_tex_file_fallback_to_kpsewhich(monkeypatch):
     monkeypatch.setattr(
         cbook, "_check_and_log_subprocess", fake_check_and_log_subprocess)
 
+    # cache_clear() before and after: find_tex_file is lru_cached, so a stale
+    # entry could hide the behaviour we test / leak our injected fake function
+    # into other tests.
     dr.find_tex_file.cache_clear()
     try:
         assert dr.find_tex_file("pdftex.map") == "/texmf/pdftex.map"
     finally:
         dr.find_tex_file.cache_clear()
+    # Check if the intercepted command was indeed kpsewhich (fallback was called).
     assert commands and commands[0][0] == "kpsewhich"
 
 
 def test_find_tex_file_no_fallback_when_luatex_reports_missing(monkeypatch):
-    # search() -> "" (luatex works, file missing) must not trigger kpsewhich.
+    # This exactly mirrors the one above.  Here,
+    # search() returns "" (luatex works, file genuinely missing), which must
+    # explicitly not trigger the kpsewhich fallback. find_tex_file should just
+    # raise.
     class _WorkingLuatex:
         def search(self, filename):
             return ""
 
     monkeypatch.setattr(dr, "_LuatexKpsewhich", _WorkingLuatex)
 
+    # Guard: if the fallback wrongly fired, kpsewhich would run and fail loudly.
     def fail_if_called(command, logger, **kwargs):
         raise AssertionError("kpsewhich should not be called")
 
     monkeypatch.setattr(cbook, "_check_and_log_subprocess", fail_if_called)
 
+    # cache_clear() around the call, as above, to isolate this from other tests.
     dr.find_tex_file.cache_clear()
     try:
         with pytest.raises(FileNotFoundError):

--- a/lib/matplotlib/tests/test_dviread.py
+++ b/lib/matplotlib/tests/test_dviread.py
@@ -2,6 +2,7 @@ import json
 from pathlib import Path
 import shutil
 import sys
+from unittest import mock
 
 from matplotlib import cbook, dviread as dr
 from matplotlib.testing import subprocess_run_for_testing, _has_tex_package
@@ -147,3 +148,67 @@ def test_dviread_pk(tmp_path):
         ],
     }]
     assert data == correct
+
+
+@pytest.mark.parametrize("readline, write_error, expected", [
+    (b"/texmf/pdftex.map\n", None, "/texmf/pdftex.map"),  # normal result
+    (b"nil\n", None, ""),                                 # luatex ok, not found
+    (b"", None, None),                                    # process died (EOF)
+    (b"unused", BrokenPipeError, None),                   # dead pipe on write
+])
+def test_luatexkpsewhich_search(readline, write_error, expected):
+    # None => luatex unusable (triggers fallback); "" => file missing.  See #31984.
+    proc = mock.Mock()
+    proc.poll.return_value = None  # pretend the process is alive (no restart)
+    proc.stdin.write.side_effect = write_error
+    proc.stdout.readline.return_value = readline
+    lk = object.__new__(dr._LuatexKpsewhich)
+    lk._proc = proc
+    assert lk.search("pdftex.map") == expected
+
+
+def test_find_tex_file_fallback_to_kpsewhich(monkeypatch):
+    # A luatex that starts but never returns a usable result (search() -> None)
+    # must not prevent falling back to kpsewhich.  Regression test for #31983.
+    class _UnusableLuatex:
+        def search(self, filename):
+            return None
+
+    monkeypatch.setattr(dr, "_LuatexKpsewhich", _UnusableLuatex)
+
+    commands = []
+
+    def fake_check_and_log_subprocess(command, logger, **kwargs):
+        commands.append(command)
+        return "/texmf/pdftex.map\n"
+
+    monkeypatch.setattr(
+        cbook, "_check_and_log_subprocess", fake_check_and_log_subprocess)
+
+    dr.find_tex_file.cache_clear()
+    try:
+        assert dr.find_tex_file("pdftex.map") == "/texmf/pdftex.map"
+    finally:
+        dr.find_tex_file.cache_clear()
+    assert commands and commands[0][0] == "kpsewhich"
+
+
+def test_find_tex_file_no_fallback_when_luatex_reports_missing(monkeypatch):
+    # search() -> "" (luatex works, file missing) must not trigger kpsewhich.
+    class _WorkingLuatex:
+        def search(self, filename):
+            return ""
+
+    monkeypatch.setattr(dr, "_LuatexKpsewhich", _WorkingLuatex)
+
+    def fail_if_called(command, logger, **kwargs):
+        raise AssertionError("kpsewhich should not be called")
+
+    monkeypatch.setattr(cbook, "_check_and_log_subprocess", fail_if_called)
+
+    dr.find_tex_file.cache_clear()
+    try:
+        with pytest.raises(FileNotFoundError):
+            dr.find_tex_file("missing.tfm")
+    finally:
+        dr.find_tex_file.cache_clear()


### PR DESCRIPTION
find_tex_file spawns a luatex instance via which it can locate files in the path of a latex installation. If this doesnt work, we fallback to calling kpsewhich directly. Currently this only happens when the luatex process failed to start. If luatex started but then died or became unusable at runtime, its search() returned an empty result and find_tex_file raised FileNotFoundError without ever trying kpsewhich. In practice this means a user whose luatex is broken cant use usetex at all, even though kpsewhich works fine on their machine

I fixed this by making _LuatexKpsewhich.search() return None on a broken pipe or empty read, and restructuring find_tex_file to fall back to kpsewhich whenever the luatex route yields no usable path.

AI disclosure:
I used AI to get feedback on my proposal of how to fix, with the idea and diagnosis being fully mine (obviously inspired by the issue creators hotfix to give credit where its due). I also used it to draft test cases. I understand the code fully and can explain and defend all decisions undertaken. 

Closes #31983