### PR TITLE
DOC: Fix broken configobj link in 0.99.x API changes

### DIFF
--- a/doc/api/prev_api_changes/api_changes_0.99.x.rst
+++ b/doc/api/prev_api_changes/api_changes_0.99.x.rst
@@ -67,7 +67,7 @@ Changes beyond 0.99.x
   required by the experimental traited config and are somewhat out of
   date. If needed, install them independently.
 
-.. _configobj: http://www.voidspace.org.uk/python/configobj.html
+.. _configobj: https://configobj.readthedocs.io/en/latest/
 .. _`enthought.traits`: http://code.enthought.com/pages/traits.html
 
 * The new rc parameter ``savefig.extension`` sets the filename extension


### PR DESCRIPTION
## PR summary
The domain `voidspace.org.uk` has lapsed and been re-registered: `http://www.voidspace.org.uk/python/configobj.html` now returns HTTP 200 but serves unrelated offshore-gambling content rather than ConfigObj documentation. This updates the `configobj` link target in `doc/api/prev_api_changes/api_changes_0.99.x.rst` to the project's current docs at https://configobj.readthedocs.io/en/latest/ — the same replacement already merged in #30317 for another occurrence. Part of #30306.

## AI Disclosure
No. I did not use AI to write or implement this PR.

## PR checklist
- [N/A] "closes #0000" is in the body (this is *part of* #30306, not a full closure)
- [N/A] new and changed code is tested (documentation-only change)
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [x] Documentation complies with the general and docstring guidelines