### PR TITLE
Partially revert "DOC: fix two broken links in resources and wx5 example

### DIFF
--- a/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_in_wx5_sgskip.py
@@ -8,7 +8,7 @@ Embed in wx #5
     As a development and debugging aid, you can replace :class:`wx.App`
     by :class:`wx.lib.mixins.inspection.InspectableApp`.
     This adds the capability to start the `Widget Inspection Tool
-    <https://docs.wxpython.org/wx.lib.inspection.InspectionTool.html>`_
+    <https://wiki.wxpython.org/How%20to%20use%20Widget%20Inspection%20Tool%20-%20WIT%20%28Phoenix%29>`_
     via :kbd:`Ctrl-Alt-I`.
 """
 


### PR DESCRIPTION
## PR summary

There is no 404 with the wxPython wiki link, and the replacement link is not as good as the original.

This is a partial revert of #31980.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [n/a] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines