### PR TITLE
DOC fix parameter name in CharacterMapping.add docstring

### DIFF
--- a/lib/matplotlib/backends/_backend_pdf_ps.py
+++ b/lib/matplotlib/backends/_backend_pdf_ps.py
@@ -149,7 +149,7 @@ class GlyphMap:
         ----------
         charcode : CharacterCodeType
             The character code to record.
-        glyph : GlyphIndexType
+        glyph_index : GlyphIndexType
             The corresponding glyph index to record.
         subset : int
             The subset in which the subset character code resides.


### PR DESCRIPTION
## PR summary

The `add` method of `CharacterMapping` in `backends/_backend_pdf_ps.py` documents parameter `glyph` but the actual function signature uses `glyph_index`.

```python
def add(self, charcode: str, glyph_index: GlyphIndexType, subset: int,
        subset_charcode: CharacterCodeType) -> None:
    """
    ...
    glyph : GlyphIndexType   # <-- wrong: should be glyph_index
    """
```

One-line docstring fix.

## AI Disclosure

Partial - used an AST script to find parameter name mismatches between docstrings and signatures; verified the fix manually by reading the source.

## PR checklist

- [N/A] "closes #0000" (no related issue for a doc typo fix)
- [N/A] new and changed code is tested (docstring only)
- [N/A] plotting related features demonstrated in example
- [N/A] New Features and API Changes noted (no API change)
- [x] Documentation complies with docstring guidelines