### PR TITLE
Don't require an axis in PercentFormatter with explicit decimals

### DIFF
--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1764,6 +1764,14 @@ class TestPercentFormatter:
         with mpl.rc_context(rc={'text.usetex': usetex}):
             assert fmt.format_pct(50, 100) == expected
 
+    def test_call_without_axis(self):
+        # With explicit decimals the axis view interval is not needed, so the
+        # formatter should format a value even when it is not attached to an
+        # axis, instead of raising an AttributeError.
+        with mpl.rc_context(rc={'text.usetex': False}):
+            assert mticker.PercentFormatter(xmax=1.0, decimals=1)(0.5) == '50.0%'
+            assert mticker.PercentFormatter(xmax=100, decimals=0)(50) == '50%'
+
 
 def _impl_locale_comma():
     try:

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1638,8 +1638,15 @@ class PercentFormatter(Formatter):
 
     def __call__(self, x, pos=None):
         """Format the tick as a percentage with the appropriate scaling."""
-        ax_min, ax_max = self.axis.get_view_interval()
-        display_range = abs(ax_max - ax_min)
+        if self.decimals is None:
+            # The display range of the axis is only needed to pick the number
+            # of decimals automatically; when ``decimals`` is set explicitly we
+            # avoid touching ``self.axis`` so the formatter also works when it
+            # is not attached to an axis.
+            ax_min, ax_max = self.axis.get_view_interval()
+            display_range = abs(ax_max - ax_min)
+        else:
+            display_range = None
         return self.fix_minus(self.format_pct(x, display_range))
 
     def format_pct(self, x, display_range):


### PR DESCRIPTION
## PR summary

`PercentFormatter.__call__` always reads `self.axis.get_view_interval()`, but that display range is only used to choose the number of decimals automatically, i.e. when `decimals is None`. With `decimals` set explicitly, calling the formatter while it is not attached to an axis raised `AttributeError`, even though the axis value is never needed.

- **What problem does it solve?** A `PercentFormatter` created with explicit `decimals` already has everything it needs to format a value, but it still required an axis, so using it standalone (for example to build a label or annotation) crashed.
- **Reasoning for the implementation:** the axis view interval is only consulted in the auto-decimals branch of `format_pct`, so `__call__` now reads it only when `decimals is None`. Auto-decimals still requires an axis, unchanged.

Minimal self-contained example:

```python
import matplotlib.ticker as mticker

# Before: AttributeError: 'NoneType' object has no attribute 'get_view_interval'
# After:  '50.0%'
print(mticker.PercentFormatter(xmax=1.0, decimals=1)(0.5))
```

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description - no issue; small self-contained bug fix (happy to open one if preferred)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) - added `TestPercentFormatter.test_call_without_axis`; existing `format_pct` cases are unchanged and still pass
- [N/A] *Plotting related* features are demonstrated in an example - bug fix, no new plotting feature
- [N/A] *New Features* and *API Changes* are noted with a directive and release note - bug fix, not a new feature or API change
- [x] Documentation complies with general and docstring guidelines - no documentation changes; existing docstrings unaffected