### PR TITLE
Fix PDF path collection culling for `hexbin` offsets

### DIFF
--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2018,7 +2018,13 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             path_extents.append(path.get_extents(transform).frozen())
 
         # Create a mapping from path_id to extent for efficient lookup
-        path_extent_map = dict(zip(path_codes, path_extents))
+        # for cases with multiple paths
+        if len(path_codes) == 1:
+            single_path_extent = path_extents[0]
+            path_extent_map = None
+        else:
+            single_path_extent = None
+            path_extent_map = dict(zip(path_codes, path_extents))
 
         canvas_width = self.file.width * 72
         canvas_height = self.file.height * 72
@@ -2034,7 +2040,7 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             # Skip markers completely outside the canvas to reduce PDF size.
             # Use the translated path bounds, not the offset alone: the offset
             # need not be the marker center in canvas coordinates.
-            bbox = path_extent_map[path_id]
+            bbox = path_extent_map[path_id] if path_extent_map else single_path_extent
             if (bbox.x1 + xo < 0 or bbox.x0 + xo > canvas_width
                     or bbox.y1 + yo < 0 or bbox.y0 + yo > canvas_height):
                 continue

--- a/lib/matplotlib/backends/backend_pdf.py
+++ b/lib/matplotlib/backends/backend_pdf.py
@@ -2011,16 +2011,11 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
             name = self.file.pathCollectionObject(
                 gc, path, transform, padding, filled, stroked)
             path_codes.append(name)
-            # Compute the extent of each marker path to enable per-marker
-            # bounds checking. This allows us to skip markers that are
-            # completely outside the visible canvas while preserving markers
-            # that are partially visible.
-            if len(path.vertices):
-                bbox = path.get_extents(transform)
-                # Store half-width and half-height for efficient bounds checking
-                path_extents.append((bbox.width / 2, bbox.height / 2))
-            else:
-                path_extents.append((0, 0))
+            # Compute each transformed path's exact bounds for per-marker
+            # canvas checks.  Offsets are not necessarily full canvas-space
+            # centers, e.g. for collections using AffineDeltaTransform, so
+            # cull based on the final path bounds translated by the offset.
+            path_extents.append(path.get_extents(transform).frozen())
 
         # Create a mapping from path_id to extent for efficient lookup
         path_extent_map = dict(zip(path_codes, path_extents))
@@ -2036,26 +2031,12 @@ class RendererPdf(_backend_pdf_ps.RendererPDFPSBase):
                 facecolors, edgecolors, linewidths, linestyles,
                 antialiaseds, urls, offset_position, hatchcolors=hatchcolors):
 
-            # Optimization: Fast path for markers with centers inside canvas.
-            # This avoids the dictionary lookup for the common case where
-            # markers are visible, improving performance for large scatter plots.
-            if 0 <= xo <= canvas_width and 0 <= yo <= canvas_height:
-                # Marker center is inside canvas - definitely render it
-                self.check_gc(gc0, rgbFace)
-                dx, dy = xo - lastx, yo - lasty
-                output(1, 0, 0, 1, dx, dy, Op.concat_matrix, path_id,
-                       Op.use_xobject)
-                lastx, lasty = xo, yo
-                continue
-
-            # Marker center is outside canvas - check if partially visible.
-            # Skip markers completely outside visible canvas bounds to reduce
-            # PDF file size. Use per-marker extents to handle large markers
-            # correctly: only skip if the marker's bounding box doesn't
-            # intersect the canvas at all.
-            extent_x, extent_y = path_extent_map[path_id]
-            if not (-extent_x <= xo <= canvas_width + extent_x
-                    and -extent_y <= yo <= canvas_height + extent_y):
+            # Skip markers completely outside the canvas to reduce PDF size.
+            # Use the translated path bounds, not the offset alone: the offset
+            # need not be the marker center in canvas coordinates.
+            bbox = path_extent_map[path_id]
+            if (bbox.x1 + xo < 0 or bbox.x0 + xo > canvas_width
+                    or bbox.y1 + yo < 0 or bbox.y0 + yo > canvas_height):
                 continue
 
             self.check_gc(gc0, rgbFace)

--- a/lib/matplotlib/tests/test_backend_pdf.py
+++ b/lib/matplotlib/tests/test_backend_pdf.py
@@ -732,3 +732,30 @@ def test_scatter_polar(fig_test, fig_ref):
     ax_ref = fig_ref.subplots(subplot_kw={'projection': 'polar'})
     ax_ref.scatter(theta, r, c=c, s=50)
     ax_ref.set_ylim(0, 2)
+
+
+@check_figures_equal(extensions=["pdf"], tol=1.0)
+def test_hexbin_negative_offsets(fig_test, fig_ref):
+    """
+    Test path collection culling with non-canvas-space offsets.
+
+    Hexbin uses a repeated polygon path with offsets transformed by
+    AffineDeltaTransform.  The transformed offsets are displacements, not the
+    final canvas-space marker centers, so PDF backend culling must account for
+    the transformed path bounds as well.
+    """
+    rng = np.random.default_rng(19680801)
+    x = rng.normal(size=10_000)
+    y = rng.normal(size=10_000)
+
+    ax_test = fig_test.subplots()
+    ax_test.hexbin(x, y, gridsize=25, edgecolors="none")
+    ax_test.set_xlim(-2.0, 2.0)
+    ax_test.set_ylim(-2.0, 2.0)
+    ax_test.set_axis_off()
+
+    ax_ref = fig_ref.subplots()
+    ax_ref.hexbin(x + 2.0, y + 2.0, gridsize=25, edgecolors="none")
+    ax_ref.set_xlim(0.0, 4.0)
+    ax_ref.set_ylim(0.0, 4.0)
+    ax_ref.set_axis_off()


### PR DESCRIPTION
## PR summary

This PR fixes a PDF backend regression where visible `hexbin` cells can be incorrectly skipped in Matplotlib 3.11.0.

Closes #31999.

PR #30746 added path collection culling to the PDF backend to avoid bloated PDFs when many colored `scatter` markers are fully outside the canvas. That optimization works for `scatter`, where transformed offsets correspond to marker centers in canvas coordinates. However, `hexbin` uses a repeated hexagon path with offsets transformed by `AffineDeltaTransform(self.transData)`. Those transformed offsets are displacements, not absolute canvas-space marker
  centers.

The PDF backend was culling collections by checking the transformed offset plus an approximate marker extent. For `hexbin`, this can classify visible cells as off-canvas, especially when offsets are negative, so the PDF output loses part of the plot while raster output renders correctly.

This PR keeps the optimization from #30746, but changes the culling check to use the actual transformed reusable path bounds translated by each offset. This preserves PDF size improvements for truly off-canvas `scatter` markers while correctly rendering `hexbin` and other collections whose transformed offsets are not absolute marker centers. This fix make the example in #31999 work as expected.

A PDF regression test for `hexbin` with negative offsets, compared against an equivalent shifted reference.

## AI Disclosure

Agentic AI was employed to identify the origin of the issue, make the original fix, add the original test, and write the original issue and the PR description. The AI suggestions were reviewed and polished by human.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] ~Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines~

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
