### PR TITLE
fix: handle NoNorm in format_cursor_data to prevent OverflowError

### DIFF
--- a/lib/matplotlib/colorizer.py
+++ b/lib/matplotlib/colorizer.py
@@ -493,6 +493,8 @@ class _ColorizerInterface:
         # to use for a number given a norm, and n, where n is the
         # number of colors in  the colormap.
         normed = norm(data)
+        if isinstance(norm, colors.NoNorm):
+            normed = np.asarray(normed, dtype=float)
         if np.isfinite(normed):
             if isinstance(norm, colors.BoundaryNorm):
                 # not an invertible normalization mapping


### PR DESCRIPTION
## Bug

Fixes #31960

When imshow is used with uint8 data and colors.NoNorm(), mousing over the image causes an OverflowError because NoNorm.__call__ returns the raw uint8 value unchanged, and subsequent arithmetic (
ormed * n) overflows uint8 in NumPy 2.x.

## Fix

In _sig_digits_from_norm, cast 
ormed to float when NoNorm is used. This prevents the uint8 overflow while preserving correct behavior for all other norms.

## Reproduction

\\\python
import matplotlib
import matplotlib.pyplot as plt
import numpy as np

img = np.tile(np.arange(100, dtype=np.uint8), (100, 1))
plt.imshow(img, norm=matplotlib.colors.NoNorm())
plt.show()
# Mouse over the image — OverflowError
\\\

## Test

Verified the fix resolves the overflow by confirming 
ormed * n no longer overflows when normed is cast to float.