### PR TITLE
ENH/MAINT: Improve legend handling in Qt figure options dialog

### DIFF
--- a/lib/matplotlib/backends/qt_editor/figureoptions.py
+++ b/lib/matplotlib/backends/qt_editor/figureoptions.py
@@ -61,6 +61,7 @@ def figure_edit(axes, parent=None):
             )
             for name, axis in axis_map.items()
         ]),
+        ('Show legend', axes.legend_ is not None and axes.legend_.get_visible()),
         ('(Re-)Generate automatic legend', False),
     ]
 
@@ -196,6 +197,7 @@ def figure_edit(axes, parent=None):
         title = general.pop(0)
         axes.title.set_text(title)
         generate_legend = general.pop()
+        show_legend = general.pop()
 
         for i, (name, axis) in enumerate(axis_map.items()):
             axis_min = general[4*i]
@@ -248,13 +250,30 @@ def figure_edit(axes, parent=None):
         if generate_legend:
             draggable = None
             ncols = 1
+            kwargs = {}
             if axes.legend_ is not None:
                 old_legend = axes.get_legend()
                 draggable = old_legend._draggable is not None
                 ncols = old_legend._ncols
-            new_legend = axes.legend(ncols=ncols)
+                kwargs = {
+                    'loc': old_legend._loc_real,
+                    'title': old_legend.get_title().get_text(),
+                    'frameon': old_legend.get_frame_on(),
+                    'shadow': old_legend.shadow,
+                }
+                # Clone frame properties if the frame exists
+                frame = old_legend.get_frame()
+                if frame is not None:
+                    kwargs['edgecolor'] = frame.get_edgecolor()
+                    kwargs['facecolor'] = frame.get_facecolor()
+                    kwargs['framealpha'] = frame.get_alpha()
+
+            new_legend = axes.legend(ncols=ncols, **kwargs)
             if new_legend:
                 new_legend.set_draggable(draggable)
+
+        if axes.legend_ is not None:
+            axes.legend_.set_visible(show_legend)
 
         # Redraw
         figure = axes.get_figure()


### PR DESCRIPTION
Closes #17775
Closes #11109

## PR summary

This PR addresses two related issues in the Qt figure options dialog, both concerning legend handling in `lib/matplotlib/backends/qt_editor/figureoptions.py`.

**Problem 1 (#17775): Legend settings are lost when regenerating**

When a user clicks "Re-generate automatic legend" in the figure options dialog, the code previously only restored `ncols` and `draggable`. Any other settings the user had configured — such as the legend title, position, frame style, shadow, or transparency — were silently discarded and reset to their defaults.

**Fix**: Before regenerating, the existing legend's properties are captured and passed to `axes.legend()` as keyword arguments:
- `loc` — legend position
- `title` — legend title text
- `frameon` — whether to show the frame
- `shadow` — whether to draw a shadow
- `edgecolor`, `facecolor`, `framealpha` — frame appearance

**Problem 2 (#11109): No way to hide the legend from the options dialog**

There was no way to toggle legend visibility in the figure options dialog without fully deleting the legend. This was inconvenient when a legend obscured part of the plot.

**Fix**: A "Show legend" checkbox is added to the Axes tab. Its initial state reflects the current visibility of the legend. When unchecked, the legend is hidden (but not deleted), and it can be shown again by re-checking the box.

## AI Disclosure

I used an AI assistant to help navigate the codebase and understand the structure of `figureoptions.py`. The implementation logic and final code were verified and understood by me before submission.

## PR checklist

- [x] "closes #17775" and "closes #11109" are in the body of the PR description
- [N/A] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example
- [N/A] *New Features* and *API Changes* are noted with a directive and release note
- [N/A] Documentation complies with general and docstring guidelines
