### PR TITLE
Remove deprecated freethreading option from cibuildwheel

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Build wheels for wasm
         uses: pypa/cibuildwheel@294735312765b09d24a2fbec22660ce817587d55  # v4.1.0
         env:
-          CIBW_BUILD: "cp312-*"
           CIBW_PLATFORM: "pyodide"
           CIBW_TEST_COMMAND: "true"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -401,7 +401,6 @@ addopts = [
 ]
 
 [tool.cibuildwheel]
-enable = ["cpython-freethreading"]
 skip = "*-musllinux_aarch64"
 manylinux-x86_64-image = "manylinux2014"
 


### PR DESCRIPTION
## PR summary

This was removed in 4.0.0, and is now causing failures since #31994.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines