### PR TITLE
PERF: Speed up add_patch

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2570,18 +2570,28 @@ class _AxesBase(martist.Artist):
         if (isinstance(patch, mpatches.Rectangle) and
                 ((not patch.get_width()) and (not patch.get_height()))):
             return
-        p = patch.get_path()
-        # Get all vertices on the path
-        # Loop through each segment to get extrema for Bezier curve sections
-        vertices = []
-        for curve, code in p.iter_bezier(simplify=False):
-            # Get distance along the curve of any extrema
-            _, dzeros = curve.axis_aligned_extrema()
-            # Calculate vertices of start, end and any extrema in between
-            vertices.append(curve([0, *dzeros, 1]))
 
-        if len(vertices):
-            vertices = np.vstack(vertices)
+        # Fast-path curve-free paths, like Path.get_extents does
+        p = patch.get_path()
+        if p.codes is None:
+            vertices = p.vertices
+        elif not ((p.codes == p.CURVE3) | (p.codes == p.CURVE4)).any():
+            # Optimization for the straight line case.
+            # Instead of iterating through each curve, consider
+            # each line segment's end-points
+            ignore = (p.codes == p.STOP) | (p.codes == p.CLOSEPOLY)
+            vertices = p.vertices[~ignore] if ignore.any() else p.vertices
+        else:
+            # Loop through each segment to get extrema for Bezier curve sections
+            vertices = []
+            for curve, code in p.iter_bezier(simplify=False):
+                # Get distance along the curve of any extrema
+                _, dzeros = curve.axis_aligned_extrema()
+                # Calculate vertices of start, end and any extrema in between
+                vertices.append(curve([0, *dzeros, 1]))
+
+            if len(vertices):
+                vertices = np.vstack(vertices)
 
         patch_trf = patch.get_transform()
         updatex, updatey = patch_trf.contains_branch_separately(self.transData)

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -2571,27 +2571,8 @@ class _AxesBase(martist.Artist):
                 ((not patch.get_width()) and (not patch.get_height()))):
             return
 
-        # Fast-path curve-free paths, like Path.get_extents does
         p = patch.get_path()
-        if p.codes is None:
-            vertices = p.vertices
-        elif not ((p.codes == p.CURVE3) | (p.codes == p.CURVE4)).any():
-            # Optimization for the straight line case.
-            # Instead of iterating through each curve, consider
-            # each line segment's end-points
-            ignore = (p.codes == p.STOP) | (p.codes == p.CLOSEPOLY)
-            vertices = p.vertices[~ignore] if ignore.any() else p.vertices
-        else:
-            # Loop through each segment to get extrema for Bezier curve sections
-            vertices = []
-            for curve, code in p.iter_bezier(simplify=False):
-                # Get distance along the curve of any extrema
-                _, dzeros = curve.axis_aligned_extrema()
-                # Calculate vertices of start, end and any extrema in between
-                vertices.append(curve([0, *dzeros, 1]))
-
-            if len(vertices):
-                vertices = np.vstack(vertices)
+        extent_vertices = p._extent_vertices(simplify=False)
 
         patch_trf = patch.get_transform()
         updatex, updatey = patch_trf.contains_branch_separately(self.transData)
@@ -2604,7 +2585,7 @@ class _AxesBase(martist.Artist):
             if updatey and patch_trf == self.get_xaxis_transform():
                 updatey = False
         trf_to_data = patch_trf - self.transData
-        xys = trf_to_data.transform(vertices)
+        xys = trf_to_data.transform(extent_vertices)
         self.update_datalim(xys, updatex=updatex, updatey=updatey)
 
     def _update_collection_limits(self, collection):

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -644,13 +644,13 @@ class Path:
             self = transform.transform_path(self)
         if self.codes is None:
             xys = self.vertices
-        elif len(np.intersect1d(self.codes, [Path.CURVE3, Path.CURVE4])) == 0:
+        elif not ((self.codes == Path.CURVE3)
+                  | (self.codes == Path.CURVE4)).any():
             # Optimization for the straight line case.
             # Instead of iterating through each curve, consider
             # each line segment's end-points
-            # (recall that STOP and CLOSEPOLY vertices are ignored)
-            xys = self.vertices[np.isin(self.codes,
-                                        [Path.MOVETO, Path.LINETO])]
+            ignore = (self.codes == Path.STOP) | (self.codes == Path.CLOSEPOLY)
+            xys = self.vertices[~ignore] if ignore.any() else self.vertices
         else:
             xys = []
             for curve, code in self.iter_bezier(**kwargs):
@@ -660,7 +660,9 @@ class Path:
                 xys.append(curve([0, *dzeros, 1]))
             xys = np.concatenate(xys)
         if len(xys):
-            return Bbox([xys.min(axis=0), xys.max(axis=0)])
+            x = xys[:, 0]
+            y = xys[:, 1]
+            return Bbox([[x.min(), y.min()], [x.max(), y.max()]])
         else:
             return Bbox.null()
 

--- a/lib/matplotlib/path.py
+++ b/lib/matplotlib/path.py
@@ -623,6 +623,35 @@ class Path:
             transform = transform.frozen()
         return _path.path_in_path(self, None, path, transform)
 
+    def _extent_vertices(self, **kwargs):
+        """
+        Return the vertices that determine this path's axis-aligned extents.
+
+        Parameters
+        ----------
+        **kwargs
+            Forwarded to `.iter_bezier`.
+
+        Returns
+        -------
+        (N, 2) array of float
+            The vertices whose bounding box equals the bounding box of the path.
+        """
+        if self.codes is None:
+            return self.vertices
+        if not ((self.codes == Path.CURVE3) | (self.codes == Path.CURVE4)).any():
+            # No curves: every vertex lies on a straight segment except the
+            # STOP/CLOSEPOLY placeholders, which do not affect the extents.
+            ignore = (self.codes == Path.STOP) | (self.codes == Path.CLOSEPOLY)
+            return self.vertices[~ignore] if ignore.any() else self.vertices
+        # Curved segments: solve for each segment's endpoints and interior
+        # extrema, since the control points may lie outside the drawn curve.
+        vertices = []
+        for curve, _ in self.iter_bezier(**kwargs):
+            _, dzeros = curve.axis_aligned_extrema()
+            vertices.append(curve([0, *dzeros, 1]))
+        return np.concatenate(vertices) if vertices else np.empty((0, 2))
+
     def get_extents(self, transform=None, **kwargs):
         """
         Get Bbox of the path.
@@ -642,23 +671,7 @@ class Path:
         from .transforms import Bbox
         if transform is not None:
             self = transform.transform_path(self)
-        if self.codes is None:
-            xys = self.vertices
-        elif not ((self.codes == Path.CURVE3)
-                  | (self.codes == Path.CURVE4)).any():
-            # Optimization for the straight line case.
-            # Instead of iterating through each curve, consider
-            # each line segment's end-points
-            ignore = (self.codes == Path.STOP) | (self.codes == Path.CLOSEPOLY)
-            xys = self.vertices[~ignore] if ignore.any() else self.vertices
-        else:
-            xys = []
-            for curve, code in self.iter_bezier(**kwargs):
-                # places where the derivative is zero can be extrema
-                _, dzeros = curve.axis_aligned_extrema()
-                # as can the ends of the curve
-                xys.append(curve([0, *dzeros, 1]))
-            xys = np.concatenate(xys)
+        xys = self._extent_vertices(**kwargs)
         if len(xys):
             x = xys[:, 0]
             y = xys[:, 1]

--- a/lib/matplotlib/tests/test_path.py
+++ b/lib/matplotlib/tests/test_path.py
@@ -3,7 +3,7 @@ import re
 
 import numpy as np
 
-from numpy.testing import assert_array_equal
+from numpy.testing import assert_array_equal, assert_allclose
 import pytest
 
 from matplotlib import patches
@@ -127,6 +127,33 @@ def test_extents_with_ignored_codes(ignored_code):
                  [1, 1],
                  [2, 2]], [Path.MOVETO, Path.MOVETO, ignored_code])
     assert np.all(path.get_extents().extents == (0., 0., 1., 1.))
+
+
+@pytest.mark.parametrize("path, expected", [
+    # codes=None: every vertex is used
+    (Path([[0, 0], [1, 2], [3, 1]]), [[0, 0], [1, 2], [3, 1]]),
+    # straight path: all MOVETO/LINETO vertices are on the path
+    (Path([[0, 0], [1, 1], [2, 0]], [Path.MOVETO, Path.LINETO, Path.LINETO]),
+     [[0, 0], [1, 1], [2, 0]]),
+    # STOP/CLOSEPOLY carry placeholder vertices that must not affect extents
+    (Path([[0, 0], [1, 1], [5, 5]], [Path.MOVETO, Path.LINETO, Path.STOP]),
+     [[0, 0], [1, 1]]),
+    (Path([[0, 0], [1, 1], [5, 5]], [Path.MOVETO, Path.LINETO, Path.CLOSEPOLY]),
+     [[0, 0], [1, 1]]),
+])
+def test_extent_vertices_straight(path, expected):
+    assert_allclose(path._extent_vertices(), expected)
+
+
+def test_extent_vertices_curve():
+    # A cubic whose control points overshoot the drawn curve: the returned
+    # vertices must capture the true interior extrema (xmax 0.75), not the
+    # control-point hull (xmax 1.0).
+    path = Path([[0, 0], [1, 0], [1, 1], [0, 1]],
+                [Path.MOVETO, Path.CURVE4, Path.CURVE4, Path.CURVE4])
+    xys = path._extent_vertices()
+    assert_allclose([xys[:, 0].min(), xys[:, 1].min(),
+                     xys[:, 0].max(), xys[:, 1].max()], [0, 0, 0.75, 1])
 
 
 def test_point_in_path_nan():


### PR DESCRIPTION
## PR summary
`add_patch` is currently very slow since it does bezier checks on all lines, but we can fast-path this for the common straight line case. In the below test script, `add_patch` dropped from 139 seconds to 50 _milliseconds_ (~2700x improvement).


```python
import numpy as np
import matplotlib.pyplot as plt
from matplotlib.path import Path
from matplotlib.patches import PathPatch

np.random.seed(0)
n = 100000
verts = np.random.rand(n, 2)
codes = np.full(n, Path.LINETO, dtype=np.uint8)
codes[0] = Path.MOVETO
p = Path(verts, codes)

fig, ax = plt.subplots()
for _ in range(10):
    ax.add_patch(PathPatch(p))
plt.close(fig)

```

## AI Disclosure
Manually identified, claude suggested edits, manually reviewed / edited.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
