### PR TITLE
Fix occasional misalignment in reported mouse position (also fixes a bug with canvas height)

### DIFF
--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2060,7 +2060,9 @@ class FigureCanvasBase:
             The size of the figure, in points or pixels, depending on the
             backend.
         """
-        return tuple(int(size / (1 if physical else self.device_pixel_ratio))
+        # Due to floating-point precision, round up width or height if either is very
+        # close to the next pixel
+        return tuple(int(size / (1 if physical else self.device_pixel_ratio) + 1e-8)
                      for size in self.figure.bbox.max)
 
     @classmethod

--- a/lib/matplotlib/backend_bases.py
+++ b/lib/matplotlib/backend_bases.py
@@ -2059,9 +2059,15 @@ class FigureCanvasBase:
         width, height : int
             The size of the figure, in points or pixels, depending on the
             backend.
+
+        Notes
+        -----
+        This method normally truncates the height/width to remove any fractional pixel.
+        However, if the height/width is extremely close to the integer pixel (within
+        1e-8 pixel), the height/width is instead rounded up to account for
+        floating-point precision effects.
         """
-        # Due to floating-point precision, round up width or height if either is very
-        # close to the next pixel
+        # The tolerance of 1e-8 covers a floating-point tick for even 100,000 pixels
         return tuple(int(size / (1 if physical else self.device_pixel_ratio) + 1e-8)
                      for size in self.figure.bbox.max)
 

--- a/lib/matplotlib/backends/_backend_gtk.py
+++ b/lib/matplotlib/backends/_backend_gtk.py
@@ -275,7 +275,7 @@ class _NavigationToolbar2GTK(NavigationToolbar2):
         self.message.set_markup(f'<small>{escaped}</small>')
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        height = self.canvas.figure.bbox.height
+        height = self.canvas.get_width_height(physical=True)[1]
         y1 = height - y1
         y0 = height - y0
         rect = [int(val) for val in (x0, y0, x1 - x0, y1 - y0)]

--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -327,9 +327,10 @@ class FigureCanvasTk(FigureCanvasBase):
     def _event_mpl_coords(self, event):
         # calling canvasx/canvasy allows taking scrollbars into account (i.e.
         # the top of the widget may have been scrolled out of view).
+        height = self.get_width_height(physical=True)[1]
         return (self._tkcanvas.canvasx(event.x),
                 # flipy so y=0 is bottom of canvas
-                self.figure.bbox.height - self._tkcanvas.canvasy(event.y))
+                height - self._tkcanvas.canvasy(event.y))
 
     def motion_notify_event(self, event):
         MouseEvent("motion_notify_event", self,
@@ -389,7 +390,7 @@ class FigureCanvasTk(FigureCanvasBase):
         if w != self._tkcanvas:
             return
         x = self._tkcanvas.canvasx(event.x_root - w.winfo_rootx())
-        y = (self.figure.bbox.height
+        y = (self.get_width_height(physical=True)[1]
              - self._tkcanvas.canvasy(event.y_root - w.winfo_rooty()))
         step = event.delta / 120
         MouseEvent("scroll_event", self,
@@ -676,7 +677,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
         if window is None:
             window = canvas.get_tk_widget().master
         tk.Frame.__init__(self, master=window, borderwidth=2,
-                          width=int(canvas.figure.bbox.width), height=50)
+                          width=canvas.get_width_height()[0], height=50)
         # Avoid message_label expanding the toolbar size, and in turn expanding the
         # canvas size.
         # Without pack_propagate(False), when the user defines a small figure size
@@ -774,7 +775,7 @@ class NavigationToolbar2Tk(NavigationToolbar2, tk.Frame):
             self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_white)
         if self.canvas._rubberband_rect_black:
             self.canvas._tkcanvas.delete(self.canvas._rubberband_rect_black)
-        height = self.canvas.figure.bbox.height
+        height = self.canvas.get_width_height(physical=True)[1]
         y0 = height - y0
         y1 = height - y1
         self.canvas._rubberband_rect_black = (

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -441,7 +441,7 @@ class FigureCanvasAgg(FigureCanvasBase):
             super().draw()
 
     def get_renderer(self):
-        w, h = self.figure.bbox.size
+        w, h = self.get_width_height(physical=True)
         key = w, h, self.figure.dpi
         reuse_renderer = (self._lastKey == key)
         if not reuse_renderer:

--- a/lib/matplotlib/backends/backend_gtk3.py
+++ b/lib/matplotlib/backends/backend_gtk3.py
@@ -119,7 +119,7 @@ class FigureCanvasGTK3(_FigureCanvasGTK, Gtk.DrawingArea):
             x, y = event.x, event.y
         x = x * self.device_pixel_ratio
         # flip y so y=0 is bottom of canvas
-        y = self.figure.bbox.height - y * self.device_pixel_ratio
+        y = self.get_width_height(physical=True)[1] - y * self.device_pixel_ratio
         return x, y
 
     def scroll_event(self, widget, event):

--- a/lib/matplotlib/backends/backend_gtk4.py
+++ b/lib/matplotlib/backends/backend_gtk4.py
@@ -117,7 +117,7 @@ class FigureCanvasGTK4(_FigureCanvasGTK, Gtk.DrawingArea):
             x, y = xy
         x = x * self.device_pixel_ratio
         # flip y so y=0 is bottom of canvas
-        y = self.figure.bbox.height - y * self.device_pixel_ratio
+        y = self.get_width_height(physical=True)[1] - y * self.device_pixel_ratio
         return x, y
 
     def scroll_event(self, controller, dx, dy):

--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -305,7 +305,7 @@ class FigureCanvasQT(FigureCanvasBase, QtWidgets.QWidget):
         # (otherwise, it's already a QPoint)
         x = pos.x()
         # flip y so y=0 is bottom of canvas
-        y = self.figure.bbox.height / self.device_pixel_ratio - pos.y()
+        y = self.get_width_height()[1] - pos.y()
         return x * self.device_pixel_ratio, y * self.device_pixel_ratio
 
     def enterEvent(self, event):
@@ -918,7 +918,7 @@ class NavigationToolbar2QT(NavigationToolbar2, QtWidgets.QToolBar):
             self.locLabel.setText(s)
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        height = self.canvas.figure.bbox.height
+        height = self.canvas.get_width_height(physical=True)[1]
         y1 = height - y1
         y0 = height - y0
         rect = [int(val) for val in (x0, y0, x1 - x0, y1 - y0)]

--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -9,8 +9,7 @@ from ._backend_tk import _BackendTk, FigureCanvasTk
 
 class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
     def draw(self):
-        width = int(self.figure.bbox.width)
-        height = int(self.figure.bbox.height)
+        width, height = self.get_width_height(physical=True)
         surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_context(cairo.Context(surface))
         self._renderer.dpi = self.figure.dpi

--- a/lib/matplotlib/backends/backend_webagg_core.py
+++ b/lib/matplotlib/backends/backend_webagg_core.py
@@ -492,7 +492,7 @@ class FigureManagerWebAgg(backend_bases.FigureManagerBase):
         assert hasattr(web_socket, 'send_binary')
         assert hasattr(web_socket, 'send_json')
         self.web_sockets.add(web_socket)
-        self.resize(*self.canvas.figure.bbox.size)
+        self.resize(*self.canvas.get_width_height(physical=True))
         self._send_event('refresh')
 
     def remove_web_socket(self, web_socket):

--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -746,9 +746,9 @@ class _FigureCanvasWxBase(FigureCanvasBase, wx.Panel):
         # flip y so y=0 is bottom of canvas
         if not wx.Platform == '__WXMSW__':
             scale = self.GetDPIScaleFactor()
-            return x*scale, self.figure.bbox.height - y*scale
+            return x*scale, self.get_width_height(physical=True)[1] - y*scale
         else:
-            return x, self.figure.bbox.height - y
+            return x, self.get_width_height(physical=True)[1] - y
 
     def _on_key_down(self, event):
         """Capture key press."""
@@ -1169,7 +1169,7 @@ class NavigationToolbar2Wx(NavigationToolbar2, wx.ToolBar):
                 dialog.Destroy()
 
     def draw_rubberband(self, event, x0, y0, x1, y1):
-        height = self.canvas.figure.bbox.height
+        height = self.canvas.get_width_height(physical=True)[1]
         sf = 1 if wx.Platform == '__WXMSW__' else self.canvas.GetDPIScaleFactor()
         self.canvas._rubberband_rect = (x0/sf, (height - y0)/sf,
                                         x1/sf, (height - y1)/sf)

--- a/lib/matplotlib/backends/backend_wxcairo.py
+++ b/lib/matplotlib/backends/backend_wxcairo.py
@@ -8,8 +8,8 @@ from .backend_wx import (  # noqa: F401 # pylint: disable=W0611
 
 class FigureCanvasWxCairo(FigureCanvasCairo, _FigureCanvasWxBase):
     def draw(self, drawDC=None):
-        size = self.figure.bbox.size.astype(int)
-        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, *size)
+        width, height = self.get_width_height(physical=True)
+        surface = cairo.ImageSurface(cairo.FORMAT_ARGB32, width, height)
         self._renderer.set_context(cairo.Context(surface))
         self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -387,3 +387,10 @@ def test_non_tuple_rgbaface():
     fig.add_subplot(projection="3d").scatter(
         [0, 1, 2], [0, 1, 2], path_effects=[patheffects.Stroke(linewidth=4)])
     fig.canvas.draw()
+
+
+def test_rendered_height_floating_point_precision():
+    fig = plt.figure(figsize=(1, 2.03), dpi=100)
+    assert fig.bbox.height < 203  # due to floating-point precision
+    fig.canvas.draw()
+    assert fig.canvas.buffer_rgba().shape == (203, 100, 4)

--- a/lib/matplotlib/tests/test_backend_bases.py
+++ b/lib/matplotlib/tests/test_backend_bases.py
@@ -581,3 +581,9 @@ def test_interactive_pan_zoom_events(tool, button, patch_vis, forward_nav, t_s):
     # Check if twin-axes are properly triggered
     assert ax_t.get_xlim() == pytest.approx(ax_t_twin.get_xlim(), abs=0.15)
     assert ax_b.get_xlim() == pytest.approx(ax_b_twin.get_xlim(), abs=0.15)
+
+
+def test_get_width_height_floating_point_precision():
+    fig = plt.figure(figsize=(1, 2.03), dpi=100)
+    assert fig.bbox.height < 203  # due to floating-point precision
+    assert fig.canvas.get_width_height() == (100, 203)


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

## PR summary
<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:

- Why is this change necessary?
- What problem does it solve?
- What is the reasoning for this implementation?

Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

Due to floating-point precision, a figure may self-report a height that is slightly below an integer (by one floating-point tick).  When this happens, there are (at least) two bugs:

* The reported mouse position in GUI events is inconsistent between pixel coordinates and data coordinates (see #27570).
* The rendered Agg/Cairo output is too short by a pixel (see also #15363):
```python
>>> import matplotlib.pyplot as plt
>>> fig = plt.figure(figsize=(1, 2.03), dpi=100)
>>> print(*fig.bbox.size)
100.0 202.99999999999997
>>> fig.canvas.draw()
>>> print(fig.canvas.buffer_rgba().shape[1::-1])
(100, 202)
```

This PR:

* Fixes `FigureCanvasBase.get_width_height()` so that it accounts for floating-point precision before truncating to integers so that the canvas will be the intended size.
* Switch backends to expressly request the canvas size in integral pixels (where appropriate) rather than internally calculate it from the figure size.

Fixes #27570
Fixes #15363

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->

No AI was used

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
