### PR TITLE
DOC: Remove warning about macosx backend

### DIFF
--- a/galleries/users_explain/animations/blitting.py
+++ b/galleries/users_explain/animations/blitting.py
@@ -42,11 +42,6 @@ drawn on top of the static artists.
 Not all backends support blitting.  You can check if a given canvas does via
 the `.FigureCanvasBase.supports_blit` property.
 
-.. warning::
-
-   This code does not work with the macosx backend (but does work with other
-   GUI backends on Mac).
-
 Minimal example
 ---------------
 


### PR DESCRIPTION
As far as I can tell, this was fixed in #21790 . I tested the example on main last week and everything works correctly (although each backend varies the timing slightly)

## AI Disclosure

Nope!

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [X] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines