### PR TITLE
DOC: clarify source of Cn colors

### DIFF
--- a/galleries/users_explain/colors/colors.py
+++ b/galleries/users_explain/colors/colors.py
@@ -63,7 +63,12 @@ Matplotlib recognizes the following formats to specify a color.
 | precedes a number acting as an index | - ``'C1'``                           |
 | into the default property cycle.     +--------------------------------------+
 |                                      | :rc:`axes.prop_cycle`                |
-| .. note:: Matplotlib indexes color   |                                      |
+| .. note:: The cycle comes from the   |                                      |
+|           global                     |                                      |
+|           :rc:`axes.prop_cycle`, not |                                      |
+|           an Axes-local cycle set by |                                      |
+|           `~.Axes.set_prop_cycle`.   |                                      |
+|           Matplotlib indexes color   |                                      |
 |           at draw time and defaults  |                                      |
 |           to black if cycle does not |                                      |
 |           include color.             |                                      |

--- a/galleries/users_explain/colors/colors.py
+++ b/galleries/users_explain/colors/colors.py
@@ -61,8 +61,9 @@ Matplotlib recognizes the following formats to specify a color.
 +--------------------------------------+--------------------------------------+
 | "CN" color spec where ``'C'``        | - ``'C0'``                           |
 | precedes a number acting as an index | - ``'C1'``                           |
-| into the default property cycle.     +--------------------------------------+
-|                                      | :rc:`axes.prop_cycle`                |
+| into the default property cycle      |                                      |
+| (:rc:`axes.prop_cycle`).             |                                      |
+|                                      |                                      |
 | .. note:: The cycle comes from the   |                                      |
 |           global                     |                                      |
 |           :rc:`axes.prop_cycle`, not |                                      |

--- a/galleries/users_explain/colors/colors.py
+++ b/galleries/users_explain/colors/colors.py
@@ -61,8 +61,7 @@ Matplotlib recognizes the following formats to specify a color.
 +--------------------------------------+--------------------------------------+
 | "CN" color spec where ``'C'``        | - ``'C0'``                           |
 | precedes a number acting as an index | - ``'C1'``                           |
-| into the default property cycle      |                                      |
-| (:rc:`axes.prop_cycle`).             |                                      |
+| into the default property cycle.     |                                      |
 |                                      |                                      |
 | .. note:: The cycle comes from the   |                                      |
 |           global                     |                                      |


### PR DESCRIPTION
## PR summary

Clarify that `Cn` colors are resolved from the global `rcParams['axes.prop_cycle']`, not an Axes-local cycle configured with `Axes.set_prop_cycle`.

The existing phrase “default property cycle” was ambiguous because an Axes can have its own property cycle. This expands the existing note in the Color formats table.

Closes #32004

## AI Disclosure

I used an AI-assisted coding tool to help draft the documentation wording and PR description. I reviewed the final diff and validation evidence and take responsibility for the contribution.

## PR checklist

- [x] "closes #32004" is in the body of the PR description
- [N/A] new and changed code is tested — documentation-only change
- [N/A] Plotting-related features are demonstrated in an example — no feature or behavior change
- [N/A] New Features and API Changes are noted with a directive and release note
- [x] Documentation complies with the general documentation guidelines
