### PR TITLE
MNT: Fix handling of ints in hsv_to_rgb()

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3729,11 +3729,10 @@ def hsv_to_rgb(hsv):
                          f"shape {hsv.shape} was found.")
 
     in_shape = hsv.shape
-    hsv = np.array(
-        hsv, copy=False,
-        dtype=np.promote_types(hsv.dtype, np.float32),  # Don't work on ints.
-        ndmin=2,  # In case input was 1D.
-    )
+    # ensure numerics are done at least on float32; ints are cast as well
+    hsv = np.asarray(hsv, dtype=np.promote_types(hsv.dtype, np.float32))
+    if hsv.ndim == 1:
+        hsv = np.expand_dims(hsv, axis=0)  # ensure hsv is 2D
 
     h = hsv[..., 0]
     s = hsv[..., 1]

--- a/lib/matplotlib/tests/test_colors.py
+++ b/lib/matplotlib/tests/test_colors.py
@@ -946,6 +946,11 @@ def test_rgb_to_hsv_int():
     assert_array_equal(mcolors.rgb_to_hsv((0, 1, 0)), (1/3, 1, 1))  # green
 
 
+def test_hsv_to_rgb_int():
+    # Test that int hsv values (still range 0-1) are processed correctly.
+    assert_array_equal(mcolors.hsv_to_rgb((0, 1, 1)), (1, 0, 0))  # red
+
+
 def test_autoscale_masked():
     # Test for #2336. Previously fully masked data would trigger a ValueError.
     data = np.ma.masked_all((12, 20))


### PR DESCRIPTION
## PR summary

On NumPy 2.0, `hsv_to_rgb()` raises `ValueError: Unable to avoid copy while creating an array as requested` for integer input, for example:

```python
import numpy as np
import matplotlib.colors as mcolors
mcolors.hsv_to_rgb(np.array([0, 1, 1]))  # ValueError on NumPy 2.0
```

The function built its working array with `np.array(hsv, copy=False, dtype=np.promote_types(...))`. When the input dtype differs from the target (as with integer input), NumPy 2.0 needs a copy to perform the cast and `copy=False` forbids it, so the call raises. The "Don't work on ints" comment shows integer input is meant to be promoted to float, so this is a regression rather than intended behavior.

This is the same NumPy 2.0 regression that #30815 fixed in the twin function `rgb_to_hsv()`, but the same fix was never applied to `hsv_to_rgb()`. This mirrors it: use `np.asarray()` for the dtype promotion and expand a 1D input to 2D explicitly. Behavior for float and 2D input is unchanged. Adds `test_hsv_to_rgb_int()`.

## AI Disclosure

AI (Claude Code) was used to locate the missing twin fix. I drafted the change, wrote the regression test, reviewed and verified the change, including reproducing the crash and confirming the fix returns the correct colors.

## PR checklist

- [N/A] "closes #0000" is in the body of the PR description (no separate issue; this is the counterpart to #30815)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines