### PR TITLE
Bump minimum macOS to 10.13

### DIFF
--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -73,7 +73,7 @@ and the capabilities they provide.
   from https://wxpython.org/pages/downloads/.
 * Tornado_ (>= 5): for the WebAgg backend.
 * ipykernel_: for the nbagg backend.
-* macOS (>= 10.12): for the macosx backend.
+* macOS (>= 10.13): for the macosx backend.
 
 .. _Tk: https://docs.python.org/3/library/tk.html
 .. _PyQt5: https://pypi.org/project/PyQt5/

--- a/doc/release/next_whats_new/minimum_macos.rst
+++ b/doc/release/next_whats_new/minimum_macos.rst
@@ -1,0 +1,4 @@
+New minimum macOS version
+-------------------------
+
+The macosx backend now requires macOS >= 10.13.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -412,7 +412,7 @@ test-command = [
 test-environment = "PIP_PREFER_BINARY=true"
 
 [tool.cibuildwheel.macos.environment]
-MACOSX_DEPLOYMENT_TARGET = "10.12"
+MACOSX_DEPLOYMENT_TARGET = "10.13"
 
 [tool.cibuildwheel.pyodide]
 test-requires = "pytest"


### PR DESCRIPTION
## PR summary

cibuildwheel is now warning on _all_ Python versions that it is bumping the deployment target, as [Python 3.12 requires 10.13](https://cibuildwheel.pypa.io/en/stable/platforms/#macos-version-compatibility). Since we dropped Python 3.11, we can at least bump the deployment target to match.

Depending on how #31855 goes, we might bump this further, but this is the minimal change possible _right now_.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines