### PR TITLE
Don't pre-allocate the Type1 /Subrs array from the declared count

### DIFF
--- a/lib/matplotlib/_type1font.py
+++ b/lib/matplotlib/_type1font.py
@@ -612,8 +612,13 @@ class Type1Font:
                 f"Token following /Subrs must be a number, was {count_token}"
             )
         count = count_token.value()
-        array = [None] * count
         next(t for t in tokens if t.is_keyword('array'))
+        # Accumulate the parsed subrs into a dict and only allocate the result
+        # list once the body has been read. Allocating ``[None] * count`` up
+        # front lets a malformed font declare a huge count in a few bytes and
+        # force a large allocation before it is rejected; _parse_charstrings
+        # already avoids this by accumulating into a dict.
+        entries = {}
         for _ in range(count):
             next(t for t in tokens if t.is_keyword('dup'))
             index_token = next(tokens)
@@ -635,7 +640,11 @@ class Type1Font:
                     f"was {token}"
                 )
             binary_token = tokens.send(1+nbytes_token.value())
-            array[index_token.value()] = binary_token.value()
+            entries[index_token.value()] = binary_token.value()
+
+        array = [None] * count
+        for index, value in entries.items():
+            array[index] = value
 
         return array, next(tokens).endpos()
 

--- a/lib/matplotlib/_type1font.py
+++ b/lib/matplotlib/_type1font.py
@@ -646,9 +646,14 @@ class Type1Font:
                 "Malformed Type1 font file: Incomplete /Subrs"
             ) from None
 
-        array = [None] * count
-        for index, value in entries.items():
-            array[index] = value
+        # The indices must cover 0 to count-1 exactly. Compare the length first
+        # so that a bogus count cannot force a large range() to be built here.
+        if len(entries) != count or sorted(entries) != list(range(count)):
+            raise RuntimeError(
+                "Malformed Type1 font file: /Subrs indices do not cover "
+                f"0 to {count - 1}"
+            )
+        array = [entries[index] for index in range(count)]
 
         return array, next(tokens).endpos()
 

--- a/lib/matplotlib/_type1font.py
+++ b/lib/matplotlib/_type1font.py
@@ -616,31 +616,35 @@ class Type1Font:
         # Accumulate the parsed subrs into a dict and only allocate the result
         # list once the body has been read. Allocating ``[None] * count`` up
         # front lets a malformed font declare a huge count in a few bytes and
-        # force a large allocation before it is rejected; _parse_charstrings
-        # already avoids this by accumulating into a dict.
+        # force a large allocation before it is rejected.
         entries = {}
-        for _ in range(count):
-            next(t for t in tokens if t.is_keyword('dup'))
-            index_token = next(tokens)
-            if not index_token.is_number():
-                raise RuntimeError(
-                    "Token following dup in Subrs definition must be a "
-                    f"number, was {index_token}"
-                )
-            nbytes_token = next(tokens)
-            if not nbytes_token.is_number():
-                raise RuntimeError(
-                    "Second token following dup in Subrs definition must "
-                    f"be a number, was {nbytes_token}"
-                )
-            token = next(tokens)
-            if not token.is_keyword(self._abbr['RD']):
-                raise RuntimeError(
-                    f"Token preceding subr must be {self._abbr['RD']}, "
-                    f"was {token}"
-                )
-            binary_token = tokens.send(1+nbytes_token.value())
-            entries[index_token.value()] = binary_token.value()
+        try:
+            for _ in range(count):
+                next(t for t in tokens if t.is_keyword('dup'))
+                index_token = next(tokens)
+                if not index_token.is_number():
+                    raise RuntimeError(
+                        "Token following dup in Subrs definition must be a "
+                        f"number, was {index_token}"
+                    )
+                nbytes_token = next(tokens)
+                if not nbytes_token.is_number():
+                    raise RuntimeError(
+                        "Second token following dup in Subrs definition must "
+                        f"be a number, was {nbytes_token}"
+                    )
+                token = next(tokens)
+                if not token.is_keyword(self._abbr['RD']):
+                    raise RuntimeError(
+                        f"Token preceding subr must be {self._abbr['RD']}, "
+                        f"was {token}"
+                    )
+                binary_token = tokens.send(1+nbytes_token.value())
+                entries[index_token.value()] = binary_token.value()
+        except StopIteration:
+            raise RuntimeError(
+                "Malformed Type1 font file: Incomplete /Subrs"
+            ) from None
 
         array = [None] * count
         for index, value in entries.items():

--- a/lib/matplotlib/_type1font.py
+++ b/lib/matplotlib/_type1font.py
@@ -646,9 +646,9 @@ class Type1Font:
                 "Malformed Type1 font file: Incomplete /Subrs"
             ) from None
 
-        # The indices must cover 0 to count-1 exactly. Compare the length first
-        # so that a bogus count cannot force a large range() to be built here.
-        if len(entries) != count or sorted(entries) != list(range(count)):
+        # The indices must cover 0 to count-1 exactly.
+        if (len(entries) != count
+                or (count and (min(entries), max(entries)) != (0, count - 1))):
             raise RuntimeError(
                 "Malformed Type1 font file: /Subrs indices do not cover "
                 f"0 to {count - 1}"

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -158,3 +158,27 @@ def test_encrypt_decrypt_roundtrip():
     decrypted = t1f.Type1Font._decrypt(encrypted, 'eexec')
     assert encrypted != decrypted
     assert data == decrypted
+
+
+def test_Subrs_no_preallocation(tmp_path):
+    # Regression test for #31962: a font declaring a huge /Subrs count must not
+    # cause a large allocation sized from that (untrusted) count before the
+    # body is parsed. Here the body is empty, so parsing must fail without
+    # first allocating a count-sized array.
+    import tracemalloc
+    count = 5_000_000
+    plaintext = (b'/FontName /X def\n/FontBBox [0 0 1 1] def\n'
+                 + f'/Subrs {count} array\n'.encode())
+    enc = t1f.Type1Font._encrypt(plaintext, 'eexec').hex().encode()
+    pfa = (b'%!PS-AdobeFont-1.0: X 001.000\neexec\n' + enc + b'\n'
+           + b'0' * 512 + b'\ncleartomark\n')
+    path = tmp_path / 'x.pfa'
+    path.write_bytes(pfa)
+
+    tracemalloc.start()
+    with pytest.raises(StopIteration):
+        t1f.Type1Font(str(path))
+    _, peak = tracemalloc.get_traced_memory()
+    tracemalloc.stop()
+    # The pre-allocation regressed to ~40 MB ([None] * count) before failing.
+    assert peak < 5 * 1024 * 1024

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -160,25 +160,53 @@ def test_encrypt_decrypt_roundtrip():
     assert data == decrypted
 
 
+def _write_pfa(path, private):
+    """Write a minimal font whose eexec-encrypted part is *private*."""
+    plaintext = b'/FontName /X def\n/FontBBox [0 0 1 1] def\n' + private
+    enc = t1f.Type1Font._encrypt(plaintext, 'eexec').hex().encode()
+    path.write_bytes(b'%!PS-AdobeFont-1.0: X 001.000\neexec\n' + enc + b'\n'
+                     + b'0' * 512 + b'\ncleartomark\n')
+    return str(path)
+
+
 def test_Subrs_no_preallocation(tmp_path):
     # Regression test for #31962: a font declaring a huge /Subrs count must not
     # cause a large allocation sized from that (untrusted) count before the
     # body is parsed. Here the body is empty, so parsing must fail without
     # first allocating a count-sized array.
     import tracemalloc
-    count = 5_000_000
-    plaintext = (b'/FontName /X def\n/FontBBox [0 0 1 1] def\n'
-                 + f'/Subrs {count} array\n'.encode())
-    enc = t1f.Type1Font._encrypt(plaintext, 'eexec').hex().encode()
-    pfa = (b'%!PS-AdobeFont-1.0: X 001.000\neexec\n' + enc + b'\n'
-           + b'0' * 512 + b'\ncleartomark\n')
-    path = tmp_path / 'x.pfa'
-    path.write_bytes(pfa)
+    path = _write_pfa(tmp_path / 'x.pfa', b'/Subrs 5000000 array\n')
 
     tracemalloc.start()
     with pytest.raises(RuntimeError, match='Incomplete /Subrs'):
-        t1f.Type1Font(str(path))
+        t1f.Type1Font(path)
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()
     # The pre-allocation regressed to ~40 MB ([None] * count) before failing.
     assert peak < 5 * 1024 * 1024
+
+
+def _write_subrs_pfa(path, indices):
+    """Write a font with a two-element /Subrs array declared at *indices*."""
+    return _write_pfa(path, (
+        b'/Subrs 2 array\n'
+        + b''.join(b'dup %d 5 RD \x00\x01\x02\x03\x04 NP\n' % index
+                   for index in indices)
+        + b'ND\n'
+        b'/CharStrings 1 begin\n'
+        b'/.notdef 5 RD \x00\x01\x02\x03\x04 ND\n'
+        b'end\n'
+    ))
+
+
+def test_Subrs_indices(tmp_path):
+    font = t1f.Type1Font(_write_subrs_pfa(tmp_path / 'x.pfa', (0, 1)))
+    assert len(font.prop['Subrs']) == 2
+
+
+@pytest.mark.parametrize('indices', [(0, 5), (0, 0)])
+def test_Subrs_bad_indices(tmp_path, indices):
+    # The declared indices must cover 0 to count-1 exactly, so neither an index
+    # past the end nor a duplicate may reach the returned array.
+    with pytest.raises(RuntimeError, match='indices do not cover'):
+        t1f.Type1Font(_write_subrs_pfa(tmp_path / 'x.pfa', indices))

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -204,7 +204,7 @@ def test_Subrs_indices(tmp_path):
     assert len(font.prop['Subrs']) == 2
 
 
-@pytest.mark.parametrize('indices', [(0, 5), (0, 0)])
+@pytest.mark.parametrize('indices', [(0, 5), (0, 0), (-1, 1)])
 def test_Subrs_bad_indices(tmp_path, indices):
     # The declared indices must cover 0 to count-1 exactly, so neither an index
     # past the end nor a duplicate may reach the returned array.

--- a/lib/matplotlib/tests/test_type1font.py
+++ b/lib/matplotlib/tests/test_type1font.py
@@ -176,7 +176,7 @@ def test_Subrs_no_preallocation(tmp_path):
     path.write_bytes(pfa)
 
     tracemalloc.start()
-    with pytest.raises(StopIteration):
+    with pytest.raises(RuntimeError, match='Incomplete /Subrs'):
         t1f.Type1Font(str(path))
     _, peak = tracemalloc.get_traced_memory()
     tracemalloc.stop()


### PR DESCRIPTION
Fixes #31962.

When parsing a Type1 font, `_parse_subrs` read the declared `/Subrs` count and immediately did `array = [None] * count`, before reading the body. The count comes straight from the font file, so a malformed font can declare a huge count in a handful of bytes and force a large allocation before anything is validated. `_parse_charstrings` already avoids this by accumulating into a dict, so this just brings `_parse_subrs` in line.

The change accumulates the parsed entries into a dict and only allocates the `count`-sized result list once the body has actually been read.

The regression test builds a tiny font that declares `/Subrs 5000000 array` with an empty body. On master that allocates ~40 MB (`[None] * 5000000`) before the parse fails; with the change the parse still fails the same way but peak allocation stays small. The test uses tracemalloc and asserts the peak stays under 5 MB.
