### PR TITLE
PERF: Let FreeType read font data from memory instead of through Python

### DIFF
--- a/extern/meson.build
+++ b/extern/meson.build
@@ -16,7 +16,6 @@ else
       'brotli=disabled',
       'bzip2=disabled',
       get_option('system-libraqm') ? 'harfbuzz=disabled' : 'harfbuzz=static',
-      'mmap=auto',
       'png=disabled',
       'tests=disabled',
       'zlib=internal',

--- a/extern/meson.build
+++ b/extern/meson.build
@@ -16,6 +16,7 @@ else
       'brotli=disabled',
       'bzip2=disabled',
       get_option('system-libraqm') ? 'harfbuzz=disabled' : 'harfbuzz=static',
+      'mmap=disabled',
       'png=disabled',
       'tests=disabled',
       'zlib=internal',

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -2,6 +2,7 @@ import itertools
 import io
 import os
 import shutil
+import sys
 from pathlib import Path
 from typing import cast
 
@@ -169,6 +170,16 @@ def test_ft2font_unicode_path(tmp_path):
     font = ft2font.FT2Font(file_bytes)
     font.set_text('foo')
     assert font.fname == file_bytes
+
+
+def test_ft2font_no_mmap(monkeypatch):
+    # Simulate platforms without the mmap module (e.g. WASI), which should fall
+    # back to reading the whole file into memory.
+    monkeypatch.setitem(sys.modules, 'mmap', None)
+    file = fm.findfont('DejaVu Sans')
+    font = ft2font.FT2Font(file)
+    font.set_text('foo')
+    assert font.fname == file
 
 
 def test_ft2font_invalid_args(tmp_path):

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1,6 +1,7 @@
 import itertools
 import io
 import os
+import shutil
 from pathlib import Path
 from typing import cast
 
@@ -153,6 +154,20 @@ def test_ft2font_valid_args():
     font = ft2font.FT2Font(PathLikeClass(file_str))
     assert font.fname == file_str
     font = ft2font.FT2Font(PathLikeClass(file_bytes))
+    assert font.fname == file_bytes
+
+
+def test_ft2font_unicode_path(tmp_path):
+    file = tmp_path / 'DéjàVu-Sans-日本語.ttf'
+    shutil.copyfile(fm.findfont('DejaVu Sans'), file)
+
+    font = ft2font.FT2Font(str(file))
+    font.set_text('foo')
+    assert font.fname == str(file)
+
+    file_bytes = os.fsencode(file)
+    font = ft2font.FT2Font(file_bytes)
+    font.set_text('foo')
     assert font.fname == file_bytes
 
 

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -174,12 +174,21 @@ def test_ft2font_unicode_path(tmp_path):
 
 def test_ft2font_no_mmap(monkeypatch):
     # Simulate platforms without the mmap module (e.g. WASI), which should fall
-    # back to reading the whole file into memory.
+    # back to streaming reads through the Python file object.
     monkeypatch.setitem(sys.modules, 'mmap', None)
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file)
     font.set_text('foo')
     assert font.fname == file
+
+
+def test_ft2font_unmappable_file(tmp_path):
+    # An empty file cannot be mmapped and falls back to streaming reads, which
+    # should then raise the usual FreeType error for an invalid font.
+    file = tmp_path / 'empty.ttf'
+    file.touch()
+    with pytest.raises(RuntimeError):
+        ft2font.FT2Font(str(file))
 
 
 def test_ft2font_invalid_args(tmp_path):

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -286,6 +286,9 @@ class PyFT2Font final : public FT2Font
     using FT2Font::FT2Font;
 
     py::object py_file;
+    // Font data buffer read by FreeType when constructed from a path, holding
+    // either an mmap of the file or a bytes fallback.
+    py::buffer_info mem;
     FT_StreamRec stream;
     py::list fallbacks;
 
@@ -293,7 +296,7 @@ class PyFT2Font final : public FT2Font
     {
         // Because destructors are called from subclass up to base class, we need to
         // explicitly close the font here. Otherwise, the instance attributes here will
-        // be destroyed before the font itself, but those are used in the close callback.
+        // be destroyed before the font itself, but those are referenced by FreeType.
         close();
     }
 
@@ -364,21 +367,6 @@ read_from_file_callback(FT_Stream stream, unsigned long offset, unsigned char *b
     return (unsigned long)n_read;
 }
 
-static void
-close_file_callback(FT_Stream stream)
-{
-    PyObject *type, *value, *traceback;
-    PyErr_Fetch(&type, &value, &traceback);
-    PyFT2Font *self = (PyFT2Font *)stream->descriptor.pointer;
-    try {
-        self->py_file.attr("close")();
-    } catch (py::error_already_set &eas) {
-        eas.discard_as_unraisable(__func__);
-    }
-    self->py_file = py::object();
-    PyErr_Restore(type, value, traceback);
-}
-
 const char *PyFT2Font_init__doc__ = R"""(
     Parameters
     ----------
@@ -444,22 +432,37 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
     }
 
     memset(&self->stream, 0, sizeof(FT_StreamRec));
-    self->stream.base = nullptr;
-    self->stream.size = 0x7fffffff;  // Unknown size.
-    self->stream.pos = 0;
-    self->stream.descriptor.pointer = self;
-    self->stream.read = &read_from_file_callback;
     FT_Open_Args open_args;
     memset((void *)&open_args, 0, sizeof(FT_Open_Args));
-    open_args.flags = FT_OPEN_STREAM;
-    open_args.stream = &self->stream;
 
     auto PathLike = py::module_::import("os").attr("PathLike");
     if (py::isinstance<py::bytes>(filename) || py::isinstance<py::str>(filename) ||
         py::isinstance(filename, PathLike))
     {
+        // Open with Python so path errors raise the usual exceptions, and
+        // retain the closed object to back fname.
         self->py_file = py::module_::import("io").attr("open")(filename, "rb");
-        self->stream.close = &close_file_callback;
+        // Give FreeType the whole file as an in-memory buffer, so that glyph
+        // loads read from it directly rather than routing through the Python
+        // file object.
+        py::object data;
+        try {
+            auto mmap_module = py::module_::import("mmap");
+            data = mmap_module.attr("mmap")(
+                self->py_file.attr("fileno")(), 0,
+                "access"_a=mmap_module.attr("ACCESS_READ"));
+        } catch (py::error_already_set &eas) {
+            if (!eas.matches(PyExc_ValueError) && !eas.matches(PyExc_OSError)) {
+                throw;
+            }
+            // Zero-length or otherwise unmappable files fall back to a copy.
+            data = self->py_file.attr("read")();
+        }
+        self->py_file.attr("close")();
+        self->mem = py::buffer(data).request();
+        open_args.flags = FT_OPEN_MEMORY;
+        open_args.memory_base = static_cast<const FT_Byte *>(self->mem.ptr);
+        open_args.memory_size = static_cast<FT_Long>(self->mem.size);
     } else {
         try {
             // This will catch various issues:
@@ -472,7 +475,11 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
                 "First argument must be a path to a font file or a binary-mode file object");
         }
         self->py_file = filename;
-        self->stream.close = nullptr;
+        self->stream.size = 0x7fffffff;  // Unknown size.
+        self->stream.descriptor.pointer = self;
+        self->stream.read = &read_from_file_callback;
+        open_args.flags = FT_OPEN_STREAM;
+        open_args.stream = &self->stream;
     }
 
     self->open(ft2Library, open_args, face_index);
@@ -483,10 +490,10 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
 static py::object
 PyFT2Font_fname(PyFT2Font *self)
 {
-    if (self->stream.close) {  // User passed a filename to the constructor.
-        return self->py_file.attr("name");
-    } else {
+    if (self->stream.read) {  // User passed a file-like object to the constructor.
         return self->py_file;
+    } else {
+        return self->py_file.attr("name");
     }
 }
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -286,11 +286,10 @@ class PyFT2Font final : public FT2Font
     using FT2Font::FT2Font;
 
     py::object py_file;
-    // Font data buffer read by FreeType when constructed from a path, holding
-    // either an mmap of the file or a bytes fallback.
-    py::buffer_info mem;
+    py::buffer_info mem;  // mmap of the font file, if it can be mapped
     FT_StreamRec stream;
     py::list fallbacks;
+    bool from_path = false;
 
     ~PyFT2Font()
     {
@@ -367,6 +366,20 @@ read_from_file_callback(FT_Stream stream, unsigned long offset, unsigned char *b
     return (unsigned long)n_read;
 }
 
+static void
+close_file_callback(FT_Stream stream)
+{
+    PyObject *type, *value, *traceback;
+    PyErr_Fetch(&type, &value, &traceback);
+    PyFT2Font *self = (PyFT2Font *)stream->descriptor.pointer;
+    try {
+        self->py_file.attr("close")();
+    } catch (py::error_already_set &eas) {
+        eas.discard_as_unraisable(__func__);
+    }
+    PyErr_Restore(type, value, traceback);
+}
+
 const char *PyFT2Font_init__doc__ = R"""(
     Parameters
     ----------
@@ -439,12 +452,10 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
     if (py::isinstance<py::bytes>(filename) || py::isinstance<py::str>(filename) ||
         py::isinstance(filename, PathLike))
     {
-        // Open with Python so path errors raise the usual exceptions, and
-        // retain the closed object to back fname.
+        // Open with Python so path errors raise the usual exceptions.
         self->py_file = py::module_::import("io").attr("open")(filename, "rb");
-        // Give FreeType the whole file as an in-memory buffer, so that glyph
-        // loads read from it directly rather than routing through the Python
-        // file object.
+        self->from_path = true;
+        // Try to mmap the file so that glyph loads skip the Python layer.
         py::object data;
         py::object mmap_module;
         try {
@@ -467,15 +478,22 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
                 // Zero-length or otherwise unmappable file.
             }
         }
-        if (!data) {
-            // Fall back to a copy of the whole file into memory.
-            data = self->py_file.attr("read")();
+        if (data) {
+            self->py_file.attr("close")();
+            self->mem = py::buffer(data).request();
+            open_args.flags = FT_OPEN_MEMORY;
+            open_args.memory_base = static_cast<const FT_Byte *>(self->mem.ptr);
+            open_args.memory_size = static_cast<FT_Long>(self->mem.size);
+        } else {
+            // Fall back to streaming reads through the Python file object,
+            // as for file-like objects below.
+            self->stream.size = 0x7fffffff;  // Unknown size.
+            self->stream.descriptor.pointer = self;
+            self->stream.read = &read_from_file_callback;
+            self->stream.close = &close_file_callback;
+            open_args.flags = FT_OPEN_STREAM;
+            open_args.stream = &self->stream;
         }
-        self->py_file.attr("close")();
-        self->mem = py::buffer(data).request();
-        open_args.flags = FT_OPEN_MEMORY;
-        open_args.memory_base = static_cast<const FT_Byte *>(self->mem.ptr);
-        open_args.memory_size = static_cast<FT_Long>(self->mem.size);
     } else {
         try {
             // This will catch various issues:
@@ -503,10 +521,10 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
 static py::object
 PyFT2Font_fname(PyFT2Font *self)
 {
-    if (self->stream.read) {  // User passed a file-like object to the constructor.
-        return self->py_file;
-    } else {
+    if (self->from_path) {
         return self->py_file.attr("name");
+    } else {  // User passed a file-like object to the constructor.
+        return self->py_file;
     }
 }
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -446,16 +446,29 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
         // loads read from it directly rather than routing through the Python
         // file object.
         py::object data;
+        py::object mmap_module;
         try {
-            auto mmap_module = py::module_::import("mmap");
-            data = mmap_module.attr("mmap")(
-                self->py_file.attr("fileno")(), 0,
-                "access"_a=mmap_module.attr("ACCESS_READ"));
+            mmap_module = py::module_::import("mmap");
         } catch (py::error_already_set &eas) {
-            if (!eas.matches(PyExc_ValueError) && !eas.matches(PyExc_OSError)) {
+            if (!eas.matches(PyExc_ImportError)) {
                 throw;
             }
-            // Zero-length or otherwise unmappable files fall back to a copy.
+            // Some platforms (e.g. WASI) don't provide the mmap module.
+        }
+        if (mmap_module) {
+            try {
+                data = mmap_module.attr("mmap")(
+                    self->py_file.attr("fileno")(), 0,
+                    "access"_a=mmap_module.attr("ACCESS_READ"));
+            } catch (py::error_already_set &eas) {
+                if (!eas.matches(PyExc_ValueError) && !eas.matches(PyExc_OSError)) {
+                    throw;
+                }
+                // Zero-length or otherwise unmappable file.
+            }
+        }
+        if (!data) {
+            // Fall back to a copy of the whole file into memory.
             data = self->py_file.attr("read")();
         }
         self->py_file.attr("close")();

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -448,6 +448,17 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
     FT_Open_Args open_args;
     memset((void *)&open_args, 0, sizeof(FT_Open_Args));
 
+    // Stream font data through the Python file object.  `close` is set for a
+    // file we opened, and nullptr for a caller-owned one.
+    auto stream_font_via_python = [&](FT_Stream_CloseFunc close) {
+        self->stream.size = 0x7fffffff;  // Unknown size.
+        self->stream.descriptor.pointer = self;
+        self->stream.read = &read_from_file_callback;
+        self->stream.close = close;
+        open_args.flags = FT_OPEN_STREAM;
+        open_args.stream = &self->stream;
+    };
+
     auto PathLike = py::module_::import("os").attr("PathLike");
     if (py::isinstance<py::bytes>(filename) || py::isinstance<py::str>(filename) ||
         py::isinstance(filename, PathLike))
@@ -485,14 +496,8 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
             open_args.memory_base = static_cast<const FT_Byte *>(self->mem.ptr);
             open_args.memory_size = static_cast<FT_Long>(self->mem.size);
         } else {
-            // Fall back to streaming reads through the Python file object,
-            // as for file-like objects below.
-            self->stream.size = 0x7fffffff;  // Unknown size.
-            self->stream.descriptor.pointer = self;
-            self->stream.read = &read_from_file_callback;
-            self->stream.close = &close_file_callback;
-            open_args.flags = FT_OPEN_STREAM;
-            open_args.stream = &self->stream;
+            // Fall back to streaming reads, closing the file we opened.
+            stream_font_via_python(&close_file_callback);
         }
     } else {
         try {
@@ -506,11 +511,7 @@ PyFT2Font_init(FT_Library ft2Library, py::object filename,
                 "First argument must be a path to a font file or a binary-mode file object");
         }
         self->py_file = filename;
-        self->stream.size = 0x7fffffff;  // Unknown size.
-        self->stream.descriptor.pointer = self;
-        self->stream.read = &read_from_file_callback;
-        open_args.flags = FT_OPEN_STREAM;
-        open_args.stream = &self->stream;
+        stream_font_via_python(nullptr);  // Don't close the caller's file object.
     }
 
     self->open(ft2Library, open_args, face_index);


### PR DESCRIPTION
## PR summary

`FT2Font` currently re-reads data from the font file on every glyph load, costing 10 lseek and 4 read syscalls per glyph on every `FT2Font.set_text` call. This is still *relatively* fast on a local filesystem, but imposes huge IO strain on remote filesystems (WSL's /mnt/c bridge to windows in my particular case, but also network mounts).

This PR mmaps the font file and hands the buffer to FreeType, so glyph loads skip the Python layer and only touch the filesystem once. Python still handles opening the file for unicode path handling, with a test added for that.

Note that we build freetype with meson's `auto_features=disabled`, so its `mmap=auto` line was a noop and removed in this PR. It doesn't matter here since we're handing freetype the data instead of a path.

Measuring syscalls directly on the font file for 30 glyphs across 10 `set_text` calls, we drop from ~2900 lseeks and ~1200 reads to 1 lseek and 1 mmap. When using the local linux filesystem on my machine, `set_text` is ~15x faster and a savefig on an empty plot is ~1.5x faster. When I cross the WSL filesystem boundary, the speedups are ~1000x for `set_text` and ~10x for savefig.


```python
import matplotlib.pyplot as plt
for _ in range(50):
    fig, ax = plt.subplots()
    fig.savefig("/dev/null", format="png")
    plt.close(fig)
```

Before (Across WSL filesystem boundary):

<img width="1964" height="587" alt="image" src="https://github.com/user-attachments/assets/c5fbb16c-7e29-43dd-a68b-142942f2cddb" />


After:
<img width="1917" height="535" alt="image" src="https://github.com/user-attachments/assets/f38b8f08-9373-4db5-9814-1895bd50089d" />


## AI Disclosure
Discovered myself, investigated and prototyped with claude code, manually reviewed / edited.

## PR checklist

- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
