### PR TITLE
Fix crash on prime after single-character superscript

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2607,6 +2607,10 @@ class Parser:
         if napostrophes:
             if super is None:
                 super = Hlist([])
+            elif not isinstance(super, Hlist):
+                # A single-char superscript is a bare Char; wrap it so the
+                # prime glyphs can be appended.
+                super = Hlist([super])
             for i in range(napostrophes):
                 super.children.extend(self.symbol(s, loc, {"sym": "\\prime"}))
             # kern() and hpack() needed to get the metrics right after

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -569,6 +569,13 @@ def test_mathtext_operators():
     fig.draw_without_rendering()
 
 
+@pytest.mark.parametrize("expr", [r"$x^2'$", r"$x^a'$", r"$x^2''$", r"$x^\alpha'$"])
+def test_mathtext_single_char_super_with_prime(expr):
+    # Regression test for a crash: prime after a single-char superscript.
+    parser = mathtext.MathTextParser('agg')
+    parser.parse(expr)
+
+
 @check_figures_equal()
 def test_boldsymbol(fig_test, fig_ref):
     fig_test.text(0.1, 0.2, r"$\boldsymbol{\mathrm{abc0123\alpha}}$")


### PR DESCRIPTION
A prime (apostrophe) following a single-character superscript such as ``$x^2'$`` raised ``AttributeError: 'Char' object has no attribute 'children'``. A single-character superscript is parsed as a bare ``Char``, whereas the apostrophe handling in ``Parser.subsuper`` assumed the superscript was an ``Hlist`` and called ``super.children.extend(...)``. The braced form ``$x^{2}'$`` already produced an ``Hlist`` and worked.

The fix wraps a non-``Hlist`` superscript in an ``Hlist`` before appending the prime glyphs, matching the braced case.

## PR summary

Minimal reproduction (crashes on current `main` / released matplotlib):

```python
import matplotlib.pyplot as plt
fig = plt.figure()
fig.text(0.1, 0.5, r"$x^2'$")   # prime after single-char superscript
fig.savefig("out.png")          # -> AttributeError: 'Char' object has no attribute 'children'
```

With this PR the expression renders correctly, matching the already-working braced form `$x^{2}'$`.

## AI Disclosure

This PR was authored with substantial AI assistance (Claude). AI was used to localize the bug in `Parser.subsuper`, write the fix, and generate the parametrized regression tests in `test_mathtext.py`. All changes were run and verified locally: the new tests fail without the fix and pass with it, and the full `test_mathtext.py` suite passes (732 passed / 0 failed).

## PR checklist

- [N/A] "closes #0000" — no pre-existing issue was filed for this crash
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) (4 parametrized cases in `test_mathtext.py`)
- [N/A] *Plotting related* features are demonstrated in an example — bugfix, no new feature
- [N/A] *New Features* and *API Changes* are noted in a [release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features) — behavior-only bugfix, none needed
- [x] Documentation complies with [guidelines](https://matplotlib.org/devdocs/devel/document.html) — no doc changes needed
