### PR TITLE
Raise NotImplementedError in MovieWriter._args instead of returning it

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -356,7 +356,7 @@ class MovieWriter(AbstractMovieWriter):
 
     def _args(self):
         """Assemble list of encoder-specific command-line arguments."""
-        return NotImplementedError("args needs to be implemented by subclass.")
+        raise NotImplementedError("args needs to be implemented by subclass.")
 
     @classmethod
     def bin_path(cls):

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -135,6 +135,17 @@ def test_movie_writer_dpi_default():
     assert writer.dpi == fig.dpi
 
 
+def test_movie_writer_args_not_implemented():
+    # MovieWriter._args is a placeholder that subclasses must override; it
+    # must *raise* NotImplementedError rather than merely returning it, so a
+    # subclass that forgets to override it fails loudly instead of passing an
+    # exception instance on as if it were the command-line arguments.
+    writer = animation.MovieWriter.__new__(animation.MovieWriter)
+    with pytest.raises(NotImplementedError,
+                       match="args needs to be implemented by subclass"):
+        writer._args()
+
+
 @animation.writers.register('null')
 class RegisteredNullMovieWriter(NullMovieWriter):
 


### PR DESCRIPTION
## PR summary
`MovieWriter._args()` is a placeholder meant to be overridden by concrete
subclasses. It used `return NotImplementedError(...)` instead of `raise`, so a
`MovieWriter` subclass that forgot to override it would not fail loudly:
`_run()` does `command = self._args()`, which would silently bind an *exception
instance* and pass it downstream as if it were the command-line argument list,
producing a confusing error instead of the intended "args needs to be
implemented by subclass" message. This changes `return` to `raise` and adds a
regression test.

Minimal reproduction of the previous behavior:

```python
from matplotlib.animation import MovieWriter
# _args() returned the exception object instead of raising it:
result = MovieWriter._args(MovieWriter.__new__(MovieWriter))
assert isinstance(result, NotImplementedError)  # bug: returned, not raised
```

Note (per review discussion): making `_args` an `@abc.abstractmethod` was
considered but rejected — `HTMLWriter` is a non-subprocess `MovieWriter` that
never calls `_run`/`_args` and has no `_args`, so an abstractmethod would make
it un-instantiable (18 test failures). A proper fix is the `_run`/`_args` mixin
refactor already flagged by the source TODO, which is out of scope for this
one-line bugfix.

## AI Disclosure
This PR was authored with substantial AI assistance (Claude). AI was used to
localize the issue in `MovieWriter._args`, write the one-line fix, and generate
the regression test in `test_animation.py`. All changes were run and verified
locally: the new test fails without the fix and passes with it, and the full
`test_animation.py` suite passes (48 passed / 23 skipped / 0 failed).

## PR checklist
- [N/A] "closes #0000" — no pre-existing issue was filed for this
- [x] new and changed code is tested (regression test in `test_animation.py`)
- [N/A] *Plotting related* features demonstrated in an example — bugfix, no new feature
- [N/A] *New Features* / *API Changes* release note — behavior-only bugfix, no API change
- [x] Documentation complies with guidelines (no doc changes needed)
