### PR TITLE
Add test: propagate warnings to sphinx

### DIFF
--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -585,7 +585,7 @@ def _run_code(code, code_path, ns=None, function_name=None):
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
 
-    with (warnings.catch_warnings() as caught_warnings,
+    with (warnings.catch_warnings(record=True) as caught_warnings,
         cbook._setattr_cm(
             sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
             contextlib.redirect_stdout(StringIO())):
@@ -611,6 +611,7 @@ def _run_code(code, code_path, ns=None, function_name=None):
             raise PlotError(traceback.format_exc()) from err
         finally:
             os.chdir(pwd)
+
         for warn in caught_warnings:
             _log.warning(
                 "[plot] Python warning during plot execution: %s (%s)",

--- a/lib/matplotlib/sphinxext/plot_directive.py
+++ b/lib/matplotlib/sphinxext/plot_directive.py
@@ -196,6 +196,7 @@ import shutil
 import sys
 import textwrap
 import traceback
+import warnings
 
 from docutils.parsers.rst import directives, Directive
 from docutils.parsers.rst.directives.images import Image
@@ -584,9 +585,10 @@ def _run_code(code, code_path, ns=None, function_name=None):
         dirname = os.path.abspath(os.path.dirname(code_path))
         os.chdir(dirname)
 
-    with cbook._setattr_cm(
+    with (warnings.catch_warnings() as caught_warnings,
+        cbook._setattr_cm(
             sys, argv=[code_path], path=[os.getcwd(), *sys.path]), \
-            contextlib.redirect_stdout(StringIO()):
+            contextlib.redirect_stdout(StringIO())):
         try:
             if ns is None:
                 ns = {}
@@ -609,6 +611,12 @@ def _run_code(code, code_path, ns=None, function_name=None):
             raise PlotError(traceback.format_exc()) from err
         finally:
             os.chdir(pwd)
+        for warn in caught_warnings:
+            _log.warning(
+                "[plot] Python warning during plot execution: %s (%s)",
+                warn.message,
+                warn.category.__name__
+            )
     return ns
 
 

--- a/lib/matplotlib/tests/test_sphinxext.py
+++ b/lib/matplotlib/tests/test_sphinxext.py
@@ -59,6 +59,24 @@ def test_plot_directive_exception_fails_build(tmp_path):
     assert "RuntimeError: plot directive failure" in proc.stderr
 
 
+def test_plot_directive_warning_propagation(tmp_path):
+    shutil.copyfile(tinypages / 'conf.py', tmp_path / 'conf.py')
+    shutil.copytree(tinypages / '_static', tmp_path / '_static')
+    (tmp_path / 'index.rst').write_text("""
+.. plot::
+
+    import warnings
+    warnings.warn("A warning occurred")
+
+""")
+
+    proc = build_sphinx_html(
+        tmp_path, tmp_path / 'doctrees', tmp_path / '_build' / 'html',
+        expected_returncode=1)
+
+    assert "Python warning during plot execution: A warning occurred (UserWarning)" in proc.stderr
+
+
 def test_tinypages(tmp_path):
     shutil.copytree(tinypages, tmp_path, dirs_exist_ok=True,
                     ignore=shutil.ignore_patterns('_build', 'doctrees',


### PR DESCRIPTION
## PR summary
Adds a test to make sure that warnings are propagated to sphinx. 
Builds on [https://github.com/matplotlib/matplotlib/pull/30931](url)
Closes #15715

## AI Disclosure
None

## PR checklist

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
