### PR TITLE
FIX: remove warning when clearing axes with shared axis

### DIFF
--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1354,10 +1354,9 @@ class _AxesBase(martist.Artist):
         xaxis_visible = self.xaxis.get_visible()
         yaxis_visible = self.yaxis.get_visible()
 
-        for axis in self._axis_map.values():
+        for name, axis in self._axis_map.items():
             axis.clear()  # Also resets the scale to linear.
             # need to do any shared axis scales as well
-            name = axis._get_axis_name()
             for other in axis._get_shared_axes():
                 if other is self.axes:
                     continue

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1356,6 +1356,12 @@ class _AxesBase(martist.Artist):
 
         for axis in self._axis_map.values():
             axis.clear()  # Also resets the scale to linear.
+            # also need to do any shared axes
+            name = axis._get_axis_name()
+            for other in axis._get_shared_axes():
+                if other is self.axes:
+                    continue
+                other._axis_map[name]._set_scale("linear")
         for spine in self.spines.values():
             spine._clear()  # Use _clear to not clear Axis again
 

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -1356,7 +1356,7 @@ class _AxesBase(martist.Artist):
 
         for axis in self._axis_map.values():
             axis.clear()  # Also resets the scale to linear.
-            # also need to do any shared axes
+            # need to do any shared axis scales as well
             name = axis._get_axis_name()
             for other in axis._get_shared_axes():
                 if other is self.axes:

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -832,7 +832,7 @@ class Axis(martist.Artist):
         """Return this Axis' scale (as a str)."""
         return self._scale.name
 
-    def _set_scale(self, value, *, emit=False, **kwargs):
+    def _set_scale(self, value, **kwargs):
         if not isinstance(value, mscale.ScaleBase):
             self._scale = mscale.scale_factory(value, self, **kwargs)
         else:
@@ -843,19 +843,6 @@ class Axis(martist.Artist):
         self.isDefault_minloc = True
         self.isDefault_majfmt = True
         self.isDefault_minfmt = True
-
-        if emit:
-            # Call all of the other Axes that are shared with this one
-            name = self._get_axis_name()
-            # TODO: is there a scale_changed callback?
-            for other in self._get_shared_axes():
-                if other is self.axes:
-                    continue
-                other._axis_map[name]._set_scale(value, emit=False, **kwargs)
-                # TODO: ditto
-                if ((other_fig := other.get_figure(root=False)) !=
-                        self.get_figure(root=False)):
-                    other_fig.canvas.draw_idle()
 
     # This method is directly wrapped by Axes.set_{x,y}scale.
     def _set_axes_scale(self, value, **kwargs):

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -973,7 +973,7 @@ class Axis(martist.Artist):
 
         self._init()
 
-        self._set_scale('linear', emit=True)
+        self._set_scale('linear')
 
         # Clear the callback registry for this axis, or it may "leak"
         self.callbacks = cbook.CallbackRegistry(signals=["units"])

--- a/lib/matplotlib/axis.py
+++ b/lib/matplotlib/axis.py
@@ -832,7 +832,7 @@ class Axis(martist.Artist):
         """Return this Axis' scale (as a str)."""
         return self._scale.name
 
-    def _set_scale(self, value, **kwargs):
+    def _set_scale(self, value, *, emit=False, **kwargs):
         if not isinstance(value, mscale.ScaleBase):
             self._scale = mscale.scale_factory(value, self, **kwargs)
         else:
@@ -843,6 +843,19 @@ class Axis(martist.Artist):
         self.isDefault_minloc = True
         self.isDefault_majfmt = True
         self.isDefault_minfmt = True
+
+        if emit:
+            # Call all of the other Axes that are shared with this one
+            name = self._get_axis_name()
+            # TODO: is there a scale_changed callback?
+            for other in self._get_shared_axes():
+                if other is self.axes:
+                    continue
+                other._axis_map[name]._set_scale(value, emit=False, **kwargs)
+                # TODO: ditto
+                if ((other_fig := other.get_figure(root=False)) !=
+                        self.get_figure(root=False)):
+                    other_fig.canvas.draw_idle()
 
     # This method is directly wrapped by Axes.set_{x,y}scale.
     def _set_axes_scale(self, value, **kwargs):
@@ -960,7 +973,7 @@ class Axis(martist.Artist):
 
         self._init()
 
-        self._set_scale('linear')
+        self._set_scale('linear', emit=True)
 
         # Clear the callback registry for this axis, or it may "leak"
         self.callbacks = cbook.CallbackRegistry(signals=["units"])

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -37,6 +37,7 @@ import matplotlib.path as mpath
 from matplotlib.projections.geo import HammerAxes
 from matplotlib.projections.polar import PolarAxes
 import matplotlib.pyplot as plt
+import matplotlib.scale as mscales
 import matplotlib.text as mtext
 import matplotlib.ticker as mticker
 import matplotlib.transforms as mtransforms
@@ -9306,6 +9307,23 @@ def test_shared_axes_clear(fig_test, fig_ref):
     for ax in axs.flat:
         ax.clear()
         ax.plot(x, y)
+
+
+def test_shared_axes_clear_scale():
+    _, axs = plt.subplots(1, 2, sharey=True)
+    x = range(1, 10)
+    axs[0].loglog(x, x)
+    axs[1].loglog(x, x)
+    axs[0].clear()
+
+    # the cleared axes has linear on both axis
+    for axis in axs[0]._axis_map.values():
+        assert isinstance(axis._scale, mscales.LinearScale)
+
+    # the linked axes becomes linear on the shared y-axis
+    assert isinstance(axs[1].xaxis._scale, mscales.LogScale)
+    assert isinstance(axs[1].yaxis._scale, mscales.LinearScale)
+
 
 
 def test_shared_axes_retick():

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9327,7 +9327,6 @@ def test_shared_axes_clear_scale(recwarn):
     assert isinstance(axs[1].yaxis._scale, mscales.LinearScale)
 
 
-
 def test_shared_axes_retick():
     fig, axs = plt.subplots(2, 2, sharex='all', sharey='all')
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -9309,12 +9309,14 @@ def test_shared_axes_clear(fig_test, fig_ref):
         ax.plot(x, y)
 
 
-def test_shared_axes_clear_scale():
+def test_shared_axes_clear_scale(recwarn):
     _, axs = plt.subplots(1, 2, sharey=True)
     x = range(1, 10)
     axs[0].loglog(x, x)
     axs[1].loglog(x, x)
     axs[0].clear()
+
+    assert len(recwarn) == 0
 
     # the cleared axes has linear on both axis
     for axis in axs[0]._axis_map.values():


### PR DESCRIPTION
## PR summary
- Fixes #9970, building on #30843
Previously:
```python
fig, (ax1, ax2) = plt.subplots(1, 2, sharex=True)
x = range(1, 10)
ax1.semilogx(x, x)
ax2.semilogx(x, x)
fig.clf()
```
Would result in the following warning:
```
/Users/ben2/a/scratch.py:8: UserWarning: Attempt to set non-positive xlim on a log-scaled axis will be ignored.
  fig.clf()
```


## AI Disclosure
No AI was used

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines