### PR TITLE
Fix rendering bug for small Chinese characters by adding FT_LOAD_NO_B…

### DIFF
--- a/lib/matplotlib/tests/test_text.py
+++ b/lib/matplotlib/tests/test_text.py
@@ -1317,3 +1317,8 @@ def test_draw_text_as_path_fallback(monkeypatch):
     _test_complex_shaping(subfig[0])
     _test_text_features(subfig[1])
     _test_text_language(subfig[2])
+def test_small_chinese_character_rendering():
+    fig, ax = plt.subplots()
+    ax.text(0.5, 0.5, '字体', fontsize=6)
+    # Smoke test to ensure it renders without crashing
+    fig.canvas.draw()

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -639,7 +639,7 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
 
 void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
 {
-    // Yahan flags ke aage | FT_LOAD_NO_BITMAP add kar diya hai
+    // Force vector outlines by ignoring embedded bitmaps to fix small character rendering
     FT_CHECK(FT_Load_Glyph, face, glyph_index, flags | FT_LOAD_NO_BITMAP);
     FT_Glyph thisGlyph;
     FT_CHECK(FT_Get_Glyph, face->glyph, &thisGlyph);

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -639,7 +639,8 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
 
 void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
 {
-    FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
+    // Yahan flags ke aage | FT_LOAD_NO_BITMAP add kar diya hai
+    FT_CHECK(FT_Load_Glyph, face, glyph_index, flags | FT_LOAD_NO_BITMAP);
     FT_Glyph thisGlyph;
     FT_CHECK(FT_Get_Glyph, face->glyph, &thisGlyph);
     glyphs.push_back(thisGlyph);


### PR DESCRIPTION
## PR summary

- **Why is this change necessary? / What problem does it solve?** 
  Fixes a rendering issue where small Chinese characters were loaded as pixelated embedded bitmaps instead of smooth vector outlines.
- **What is the reasoning for this implementation?** 
  Adding the `FT_LOAD_NO_BITMAP` flag to `FT_Load_Glyph` forces the FreeType engine to ignore embedded bitmaps and use vector outlines, ensuring high-quality rendering at small font sizes.
- **Closes #32063**

## AI Disclosure
Yes, generative AI was used to assist in troubleshooting the FreeType flag and setting up the local build environment.

## PR checklist
- [x] "closes #32063" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New Features and API Changes are noted with a directive and release note
- [x] Documentation complies with general and docstring guidelines