### PR TITLE
Fix SubFigure wspace/hspace None defaulting to subplot rc spacing

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -1648,6 +1648,15 @@ default: %(va)s
             relative height of ``height_ratios[i] / sum(height_ratios)``.
             If not given, all rows will have the same height.
         """
+        # Without a layout engine, unspecified spacing is documented as zero.
+        # GridSpec falls back to figure.subplot.{w,h}space (rc default 0.2)
+        # when given None, so coerce missing values here (issue #32076).
+        if self.get_layout_engine() is None:
+            if wspace is None:
+                wspace = 0.0
+            if hspace is None:
+                hspace = 0.0
+
         gs = GridSpec(nrows=nrows, ncols=ncols, figure=self,
                       wspace=wspace, hspace=hspace,
                       width_ratios=width_ratios,

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -1569,6 +1569,62 @@ def test_subfigures_wspace_hspace():
     np.testing.assert_allclose(sub_figs[1, 2].bbox.max, [w, h * 0.4])
 
 
+def test_subfigures_partial_spacing_none_is_zero():
+    """Unspecified wspace/hspace is zero when no layout engine is active.
+
+    Regression for #32076: passing only one of wspace/hspace used to fall
+    back to figure.subplot.* rc defaults (0.2) for the unspecified axis.
+    """
+    fig = plt.figure(figsize=(6, 4), dpi=100)
+    # Both None: no spacing (tile the figure).
+    sfs = fig.subfigures(2, 2, wspace=None, hspace=None)
+    for row in sfs:
+        for sf in row:
+            sf.add_subplot().plot([0, 1], [0, 1])
+    fig.canvas.draw()
+    # Display coords at dpi=100, figsize 6x4 → 600x400.
+    np.testing.assert_allclose(sfs[0, 0].bbox.bounds, [0.0, 200.0, 300.0, 200.0])
+    np.testing.assert_allclose(sfs[0, 1].bbox.bounds, [300.0, 200.0, 300.0, 200.0])
+    np.testing.assert_allclose(sfs[1, 0].bbox.bounds, [0.0, 0.0, 300.0, 200.0])
+    np.testing.assert_allclose(sfs[1, 1].bbox.bounds, [300.0, 0.0, 300.0, 200.0])
+    plt.close(fig)
+
+    fig = plt.figure(figsize=(6, 4), dpi=100)
+    # Only wspace set: horizontal gap, no vertical gap.
+    sfs = fig.subfigures(2, 2, wspace=0.2, hspace=None)
+    for row in sfs:
+        for sf in row:
+            sf.add_subplot().plot([0, 1], [0, 1])
+    fig.canvas.draw()
+    # cell_w = 1 / (2 + 0.2) = 1/2.2; sep = 0.2/2.2
+    cell = 1 / 2.2
+    sep = 0.2 * cell
+    w_px, h_px = 600.0, 400.0
+    np.testing.assert_allclose(
+        sfs[0, 0].bbox.bounds, [0.0, h_px / 2, cell * w_px, h_px / 2], rtol=1e-5)
+    np.testing.assert_allclose(
+        sfs[0, 1].bbox.bounds,
+        [(cell + sep) * w_px, h_px / 2, cell * w_px, h_px / 2], rtol=1e-5)
+    np.testing.assert_allclose(
+        sfs[1, 0].bbox.bounds, [0.0, 0.0, cell * w_px, h_px / 2], rtol=1e-5)
+    # Heights must be half the figure (no vertical spacing).
+    assert sfs[0, 0].bbox.height == pytest.approx(h_px / 2)
+    assert sfs[1, 0].bbox.y1 == pytest.approx(sfs[0, 0].bbox.y0)
+    plt.close(fig)
+
+    fig = plt.figure(figsize=(6, 4), dpi=100)
+    # Only hspace set: vertical gap, no horizontal gap.
+    sfs = fig.subfigures(2, 2, wspace=None, hspace=0.2)
+    for row in sfs:
+        for sf in row:
+            sf.add_subplot().plot([0, 1], [0, 1])
+    fig.canvas.draw()
+    assert sfs[0, 0].bbox.width == pytest.approx(w_px / 2)
+    assert sfs[0, 1].bbox.x0 == pytest.approx(sfs[0, 0].bbox.x1)
+    assert sfs[0, 0].bbox.height == pytest.approx(cell * h_px, rel=1e-5)
+    plt.close(fig)
+
+
 def test_subfigure_remove():
     fig = plt.figure()
     sfs = fig.subfigures(2, 2)


### PR DESCRIPTION
## PR summary

Without a layout engine, `Figure.subfigures` documents that unspecified `wspace` / `hspace` means **zero**. `GridSpec` still substitutes `figure.subplot.{w,h}space` rc defaults (typically `0.2`) when given `None`, so:

- `subfigures(..., wspace=0.2, hspace=None)` incorrectly added a vertical gap
- `subfigures(..., wspace=None, hspace=0.2)` incorrectly added a horizontal gap

This is the regression reported in #32076 (related to the post-#25960 path).

**Why this change:** the docstring already promises “zero if not using a layout engine.” Passing only one spacing currently violates that for the unspecified axis. Explicit `hspace=0` works as a workaround (as @rcomer noted on the issue), but the documented default should hold without requiring both arguments.

**Implementation:** when `self.get_layout_engine() is None`, coerce missing `wspace`/`hspace` to `0.0` before constructing the `GridSpec`. Layout-engine paths are unchanged (they still infer from rc / the engine).

**Minimal example (bug on main):**

```python
import matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt

fig = plt.figure(figsize=(6, 4), dpi=100)
sfs = fig.subfigures(2, 2, wspace=0.2, hspace=None)
for row in sfs:
    for sf in row:
        sf.add_subplot().plot([0, 1], [0, 1])
fig.canvas.draw()
print(sfs[0, 0].bbox.height)  # ~181.82 on main; 200.0 with this fix
```

Closes #32076.

## AI Disclosure

I used generative AI assistance for:

- Exploring the `subfigures` / `GridSpec` call path and drafting an initial patch sketch
- Drafting parts of the regression test and PR wording

I personally reproduced the bug on main (Agg), chose the coerce-to-`0.0` location to match the existing docstring, wrote/adjusted the regression test (`test_subfigures_partial_spacing_none_is_zero`), and verified red→green locally (height 181.82 → 200.0 for the issue reproducer; existing `test_subfigures_wspace_hspace` still passes). I am responsible for the change and can follow up on review.

Policy read: https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai

## PR checklist

- [x] "closes #32076" is in the body of the PR description to link the related issue
- [x] new and changed code is tested
- [N/A] *Plotting related* features are demonstrated in an example (bugfix; covered by unit test)
- [N/A] *New Features* and *API Changes* are noted with a directive and release note (restores documented behavior)
- [N/A] Documentation complies with general and docstring guidelines (docstring already correct; code now matches it)