### PR TITLE
CI: Implement conditional verbose logging [verbose]

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -51,6 +51,11 @@ init:
   - micromamba config set always_yes true
   - micromamba config prepend channels conda-forge
   - micromamba info
+  - ps: |
+      if ($env:APPVEYOR_REPO_COMMIT_MESSAGE -like "*[verbose]*") {
+          $env:PYTEST_ARGS += " -vv"
+          echo "Verbose logging enabled via commit message."
+      }
 
 install:
   - set EXTRA_PACKAGES=pywin32 codecov

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -316,6 +316,10 @@ jobs:
         if: matrix.delete-font-cache
 
       - name: Run pytest
+        env:
+          PYTEST_ADDOPTS: >-
+            ${{ (contains(github.event.pull_request.labels.*.name, 'ci:verbose') ||
+                 contains(github.event.head_commit.message, '[verbose]')) && '-vv' || '' }}
         run: |
           if [[ "${{ matrix.python-version }}" == '3.14t' ]]; then
             export PYTHON_GIL=0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,6 +92,15 @@ stages:
             displayName: 'print pip'
 
           - bash: |
+              echo "##vso[task.setvariable variable=PYTEST_ADDOPTS]-vv"
+            displayName: 'Enable verbose logging'
+            condition: |
+              or(
+                contains(variables['Build.SourceVersionMessage'], '[verbose]'),
+                contains(variables['System.PullRequest.Labels'], 'ci:verbose')
+              )
+
+          - bash: |
               set -e
               SESSION_ID=$(python -c "import uuid; print(uuid.uuid4(), end='')")
               echo "Coverage session ID: ${SESSION_ID}"


### PR DESCRIPTION
<!--
Thank you so much for your PR!  To help us review your contribution, please check
out the development guide https://matplotlib.org/devdocs/devel/index.html
-->

This PR is a follow up to the discussion in #31087 and the disscusion regarding my GSOC proposal on discoourse (https://discourse.matplotlib.org/t/gsoc-2026-intro-aaratrika-shelly-indirecttransforms-test-hardening/26173/10)

## PR summary

<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs: Additionally, please summarize the changes in the title, for example "Raise ValueError on
non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
issue #8576".

If possible, please provide a minimum self-contained example.
-->

This PR implements the verbose toggle for the Matplotlib CI pipelines (Github Actions, Azure Pipelines and AppVeyor).

- Why is this change necessary?
Right now the logs dont provide much information while debugging test flakiness. This makes finding the issue really difficult. To get the logs, we need to manually edit the config files, which is time consuming.
- What problem does it solve?
This PR helps automate the process by introducting pytest -vv command. This command lets aanyone (maintainer or contributer) trigger the verbose logs without making permanent config changes. It helps  to get logs for each run, which in turn helps diagnose the flaky tests I identified during my GSOC 2026 research.
- What is the reasoning for this implementation?
I used PYTEST_ADDOPTS as an environment variable since it is a native functionality of pytest.
-I introduced two triggers to cater to 2 different users.
Commit Message- for contributors/
Github Label(ci:verbose) for maintainers: They can turn on verbosity for PR without  creation of a new commit
Consistency across Platforms: By making it available via GitHub Actions (Linux/macOS), Azure Pipelines (Windows) and AppVeyor (Legacy Windows), I was able to provide consistency of debugging experience for the community members, whatever platform they use when encountering a problem.



I have opened this as a **Draft** to verify the trigger logic across all CI runners. I've included `[verbose]` in this commit to verify the behavior in the logs

## AI Disclosure
<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
Read our policy at
https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
-->
Proofreading PR desciption.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [ x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)(verifed via ci logs inn this Pr.
- [NA ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

<!--We understand that PRs can sometimes be overwhelming, especially as the
reviews start coming in.  Please let us know if the reviews are unclear or
the recommended next step seems overly demanding, if you would like help in
addressing a reviewer's comments, or if you have been waiting too long to hear
back on your PR.-->
cc: @rcomer, @story645, @timhoffm