### PR TITLE
MAINT: Add PR template content check action

### DIFF
--- a/.github/workflows/verify_pr_template.yml
+++ b/.github/workflows/verify_pr_template.yml
@@ -1,0 +1,75 @@
+---
+name: 'Verify if PR Template is filled out'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  pull_request_target:
+    types: [opened, edited, reopened, ready_for_review]
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  GH_REPO: ${{ github.repository }}
+  PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+
+jobs:
+  verify-pr-template:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Read PR Template
+        id: template
+        uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18  # v1.1.8
+        with:
+          path: ./.github/PULL_REQUEST_TEMPLATE.md
+      # This step is required because the PR body is CRLF (Windows-style line ending)
+      - name: Clean PR content
+        shell: bash
+        id: clean
+        env:
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          {
+            echo 'cleaned<<EOF'
+            echo "${PR_BODY}" | tr -d '\r'
+            echo EOF
+          } >> "$GITHUB_OUTPUT"
+      - name: Flag as autoclose candidate
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TEMPLATE: ${{ steps.template.outputs.content }}
+          PR_BODY_CLEAN: ${{ steps.clean.outputs.cleaned }}
+        run: |
+          label="status: autoclose candidate"
+          needs_label=false
+
+          # Condition 1: body identical to template (not filled out)
+          if [ "$TEMPLATE" = "$PR_BODY_CLEAN" ]; then
+            echo "PR body is identical to the template."
+            needs_label=true
+          fi
+
+          # Condition 2: any template markdown header missing from the body
+          template_headers=$(printf '%s\n' "$TEMPLATE"     | { grep -E '^#{1,6}[[:space:]]' || true; } | sort -u)
+          body_headers=$(printf '%s\n'     "$PR_BODY_CLEAN" | { grep -E '^#{1,6}[[:space:]]' || true; } | sort -u)
+
+          while IFS= read -r header; do
+            [ -z "$header" ] && continue
+            if ! printf '%s\n' "$body_headers" | grep -qxF -- "$header"; then
+              echo "Missing template header: $header"
+              needs_label=true
+            fi
+          done <<< "$template_headers"
+
+          if [ "$needs_label" = true ]; then
+            gh pr edit "$PULL_REQUEST_NUMBER" --add-label "$label"
+            echo "PR template checks failed. Added label: $label"
+          else
+            echo "PR template checks passed."
+          fi

--- a/.github/workflows/verify_pr_template.yml
+++ b/.github/workflows/verify_pr_template.yml
@@ -13,6 +13,7 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   GH_REPO: ${{ github.repository }}
   PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number }}
+  CREATED_AT: ${{ github.event.pull_request.created_at }}
 
 jobs:
   verify-pr-template:
@@ -35,6 +36,14 @@ jobs:
         run: |
           # This step is required because the PR body is CRLF (Windows-style line ending)
           PR_BODY_CLEAN=$(printf '%s' "$PR_BODY" | tr -d '\r')
+
+          # Only act on PRs opened on/after this cutoff (avoids retroactively
+          # labeling old PRs when they get edited/reopened)
+          CUTOFF="2026-08-05T00:00:00Z"
+          if [ "$(date -d "$CREATED_AT" +%s)" -lt "$(date -d "$CUTOFF" +%s)" ]; then
+            echo "PR opened $CREATED_AT, before cutoff $CUTOFF — skipping."
+            exit 0
+          fi
 
           label="status: autoclose candidate"
           needs_label=false

--- a/.github/workflows/verify_pr_template.yml
+++ b/.github/workflows/verify_pr_template.yml
@@ -20,32 +20,22 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         with:
-          fetch-depth: 0
           persist-credentials: false
       - name: Read PR Template
         id: template
         uses: juliangruber/read-file-action@271ff311a4947af354c6abcd696a306553b9ec18  # v1.1.8
         with:
           path: ./.github/PULL_REQUEST_TEMPLATE.md
-      # This step is required because the PR body is CRLF (Windows-style line ending)
-      - name: Clean PR content
-        shell: bash
-        id: clean
-        env:
-          PR_BODY: ${{ github.event.pull_request.body }}
-        run: |
-          {
-            echo 'cleaned<<EOF'
-            echo "${PR_BODY}" | tr -d '\r'
-            echo EOF
-          } >> "$GITHUB_OUTPUT"
       - name: Flag as autoclose candidate
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
           TEMPLATE: ${{ steps.template.outputs.content }}
-          PR_BODY_CLEAN: ${{ steps.clean.outputs.cleaned }}
+          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
+          # This step is required because the PR body is CRLF (Windows-style line ending)
+          PR_BODY_CLEAN=$(printf '%s' "$PR_BODY" | tr -d '\r')
+
           label="status: autoclose candidate"
           needs_label=false
 

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -9,6 +9,7 @@ rules:
       - conflictcheck.yml:3
       - labeler.yml:3
       - pr_welcome.yml:4
+      - verify_pr_template.yml:8
   cache-poisoning:
     ignore:
       # cygwin.yml is a test-only workflow; no artifacts are published.


### PR DESCRIPTION
## PR summary

Here is an idea of an action to check completeness of the PR template. If it is not filled, or any of the sections are deleted from it, the PR adds the `status: autoclose candidate` label to it. We could add a path to remove the autoclose candidate label if the PR template is corrected, but I think that may be best left to maintainers.

Tested it locally with [`nektos/act`](https://github.com/nektos/act). For example, the action would label https://github.com/matplotlib/matplotlib/pull/32028 and https://github.com/matplotlib/matplotlib/pull/32006, and not https://github.com/matplotlib/matplotlib/pull/32081. 

Should we do this only on PR open, or on any changes to the PR?

## AI Disclosure

Used claude to verify the bash part of the PR.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [X] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines