### PR TITLE
Keep RangeSlider values within bounds when valstep is set

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1397,6 +1397,21 @@ def test_range_slider_same_init_values(orientation):
     assert_allclose(box.get_points().flatten()[idx], [0, 0.25, 0, 0.75])
 
 
+def test_range_slider_valstep_bounds():
+    # Regression test: with a valstep whose grid extends past valmax, the
+    # value must be snapped to the grid *and* kept within [valmin, valmax],
+    # matching the single Slider (which steps before clamping). Here the grid
+    # is 0, 6, 12, ... and valmax is 10.
+    fig, ax = plt.subplots()
+    slider = widgets.RangeSlider(ax=ax, label="", valmin=0.0, valmax=10.0,
+                                 valstep=6.0, valinit=(0.0, 10.0))
+    # valinit is clamped through the same path as set_val.
+    assert_allclose(slider.val, (0.0, 10.0))
+    slider.set_val((0.0, 9.0))
+    assert_allclose(slider.val, (0.0, 10.0))
+    assert slider.valmin <= slider.val[0] <= slider.val[1] <= slider.valmax
+
+
 def check_polygon_selector(events, expected, selections_count, **kwargs):
     """
     Helper function to test Polygon Selector.

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -873,6 +873,7 @@ class RangeSlider(SliderBase):
 
     def _min_in_bounds(self, min):
         """Ensure the new min value is between valmin and self.val[1]."""
+        min = self._stepped_value(min)
         if min <= self.valmin:
             if not self.closedmin:
                 return self.val[0]
@@ -880,10 +881,11 @@ class RangeSlider(SliderBase):
 
         if min > self.val[1]:
             min = self.val[1]
-        return self._stepped_value(min)
+        return min
 
     def _max_in_bounds(self, max):
         """Ensure the new max value is between valmax and self.val[0]."""
+        max = self._stepped_value(max)
         if max >= self.valmax:
             if not self.closedmax:
                 return self.val[1]
@@ -891,7 +893,7 @@ class RangeSlider(SliderBase):
 
         if max <= self.val[0]:
             max = self.val[0]
-        return self._stepped_value(max)
+        return max
 
     def _value_in_bounds(self, vals):
         """Clip min, max values to the bounds."""


### PR DESCRIPTION
### Bug summary

`RangeSlider` can end up with a value outside `[valmin, valmax]` when `valstep` is set. `_min_in_bounds`/`_max_in_bounds` clamp to the range first and only then snap to the `valstep` grid, so the snap can move the value back out of bounds.

```python
import matplotlib.pyplot as plt
from matplotlib.widgets import RangeSlider

fig, ax = plt.subplots()
sax = fig.add_axes([0.2, 0.1, 0.6, 0.03])
rs = RangeSlider(sax, "", valmin=0, valmax=10, valstep=6, valinit=(0, 6))
rs.set_val((0, 10))
print(rs.val)   # (0, 12)  -> upper value is above valmax=10
```

The upper handle is drawn past the end of the track and `on_changed` callbacks receive `(0, 12)`. The same happens for `valinit`, since `__init__` clamps it through `_value_in_bounds` too.

The single `Slider` doesn't have this issue: `Slider._value_in_bounds` snaps to the grid *before* clamping to the bounds.

### Fix

Snap before clamping in `_min_in_bounds`/`_max_in_bounds`, matching `Slider`. Added a regression test. Existing `RangeSlider` tests use `valstep=None` (where snapping is a no-op) and are unaffected.
