### PR TITLE
DOC: Fixing typo in units documentation for pyplot figuresize units

### DIFF
--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -943,9 +943,9 @@ def figure(
     figsize : (float, float) or (float, float, str), default: :rc:`figure.figsize`
         The figure dimensions. This can be
 
-        - a tuple ``(width, height, unit)``, where *unit* is one of "inch", "cm",
+        - a tuple ``(width, height, unit)``, where *unit* is one of "in", "cm",
           "px".
-        - a tuple ``(x, y)``, which is interpreted as ``(x, y, "inch")``.
+        - a tuple ``(x, y)``, which is interpreted as ``(x, y, "in")``.
 
         One of *width* or *height* may be ``None``; the respective value is taken
         from :rc:`figure.figsize`.


### PR DESCRIPTION
## PR summary

This change updates the documentation of the units for figure sizes to match the source code. Previous to this change, the documentation specifies "inches" as an argument whereas the actual argument is "in". This change updates the documentation to use "in".


## AI Disclosure
I did not use AI for this change.

## PR checklist
- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ x ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines

