### PR TITLE
MNT: Simplify PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,25 +1,20 @@
-<!-- 👉 Thank you for your PR! Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
+<!-- Thank you for your contribution! -->
+<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
+<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->
 
 ## PR summary
-<!-- 👉 Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
+<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
+<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
 
 
 ## AI Disclosure
-<!-- 👉 Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
+<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
 
 
 ## PR quality check
-<!-- 👉 Please follow our project standards: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines 
+<!-- ✍️ Please check the relevant boxes below: "x" to indicate compleation, "N/A" if the item is not applicable -->
 
-    PR description:
-    - Use an expressive title, e.g. "Fix title font property precedence"
-    - Use "Closes #0000" is in the PR summary to link the related issue
-
-    PR content: Please check the relevant boxes below, using
-    - "x" to indicate completion
-    - "N/A" if the item is not applicable
--->
-
+- [ ] Use an expressive title, e.g. "Fix title font property precedence"
 - [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
 - [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
 - [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,39 +1,26 @@
-<!--
-Thank you so much for your PR!  To help us review your contribution, please check
-out the development guide https://matplotlib.org/devdocs/devel/index.html
--->
+<!-- 👉 Thank you for your PR! Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
 
 ## PR summary
-<!-- Please describe the pull request, using the questions below as guidance, and link to any relevant issues and PRs:
+<!-- 👉 Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
 
-- Why is this change necessary?
-- What problem does it solve?
-- What is the reasoning for this implementation?
-
-Additionally, please summarize the changes in the title, for example "Raise ValueError on
-non-numeric input to set_xlim" and avoid non-descriptive titles such as "Addresses
-issue #8576".
-
-If possible, please provide a minimum self-contained example.
--->
 
 ## AI Disclosure
-<!-- Please tell us whether you used AI in writing this PR, and if so briefly describe how.
-Read our policy at
-https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai
+<!-- 👉 Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
+
+
+## PR quality check
+<!-- 👉 Please follow our project standards: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines 
+
+    PR description:
+    - Use an expressive title, e.g. "Fix title font property precedence"
+    - Use "Closes #0000" is in the PR summary to link the related issue
+
+    PR content: Please check the relevant boxes below, using
+    - "x" to indicate completion
+    - "N/A" if the item is not applicable
 -->
 
-## PR checklist
-<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->
-
-- [ ] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
-- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
-- [ ] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
-- [ ] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
+- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
+- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
+- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
 - [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
-
-<!--We understand that PRs can sometimes be overwhelming, especially as the
-reviews start coming in.  Please let us know if the reviews are unclear or
-the recommended next step seems overly demanding, if you would like help in
-addressing a reviewer's comments, or if you have been waiting too long to hear
-back on your PR.-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,7 +12,7 @@
 
 
 ## PR quality check
-<!-- ✍️ Please check the relevant boxes below: "x" to indicate compleation, "N/A" if the item is not applicable -->
+<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->
 
 - [ ] Use an expressive title, e.g. "Fix title font property precedence"
 - [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)


### PR DESCRIPTION
Closes #32093.

This is radically reduced to the essence.

We many discuss the single quality check box. But I felt ticking one box may still be a reasonable checkpoint to rethink the PR. If quality check was only informative text, it would likely be ignored much more. My fear is rather that people do not understand that they should tick the box.

Note: this is a template I myself would be willing to use :)

