### PR TITLE
Cairo: Switch back to character codes for mathtext

### DIFF
--- a/lib/matplotlib/backends/backend_cairo.py
+++ b/lib/matplotlib/backends/backend_cairo.py
@@ -8,7 +8,6 @@ This backend depends on cairocffi or pycairo.
 
 import functools
 import gzip
-import itertools
 import math
 
 import numpy as np
@@ -249,15 +248,12 @@ class RendererCairo(RendererBase):
         if angle:
             ctx.rotate(np.deg2rad(-angle))
 
-        for (font, fontsize), font_glyphs in itertools.groupby(
-                glyphs, key=lambda info: (info[0], info[1])):
+        for font, fontsize, ccode, _glyph_index, ox, oy in glyphs:
             ctx.new_path()
+            ctx.move_to(ox, -oy)
             ctx.select_font_face(*_cairo_font_args_from_font_prop(ttfFontProperty(font)))
             ctx.set_font_size(self.points_to_pixels(fontsize))
-            ctx.show_glyphs([
-                (glyph_index, ox, -oy)
-                for _font, _size, _ccode, glyph_index, ox, oy in font_glyphs
-            ])
+            ctx.show_text(chr(ccode))
 
         for ox, oy, w, h in rects:
             ctx.new_path()


### PR DESCRIPTION
## PR summary

Since f630b483e86d703afa37f5eaa25c88b8c753c639, the Cairo backend was switched to use glyph indices for mathtext, just as the Agg backend.

Unfortunately, neither Pycairo nor cairocffi expose anything other than the toy font face API. This means the Cairo backend can only access fonts by family name and not explicit path. Apparently, the version of DejaVu Sans that we ship may differ from the system copy WRT glyph indices, so we need to switch back to character codes, which are standardized and won't cause the wrong glyph to be rendered accidentally.

I can't really add a test, as in order to break, this requires a system-installed copy of DejaVu Sans of the right version that it has different glyph indices.

Fixes #32084

## AI Disclosure
None

## PR checklist
- [x] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [ ] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines