### PR TITLE
wasm: Switch to -fwasm-exceptions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -431,11 +431,13 @@ test-command = [
 	-k 'not test_complex_shaping'""",
 ]
 [tool.cibuildwheel.pyodide.environment]
-# Exceptions are needed for pybind11:
+# Exception handling is needed for pybind11:
 # https://github.com/pybind/pybind11/pull/5298
-CFLAGS = "-fexceptions"
-CXXFLAGS = "-fexceptions"
-LDFLAGS = "-fexceptions"
+# And the pyemscripten_2025_0 platform and above uses -fwasm-exceptions for this.
+# https://pyodide.org/en/stable/development/abi/313.html
+CFLAGS = "-fwasm-exceptions"
+CXXFLAGS = "-fwasm-exceptions"
+LDFLAGS = "-fwasm-exceptions"
 
 [tool.cibuildwheel.windows]
 before-build = [


### PR DESCRIPTION
## PR summary

As of the `pyemscripten_2025_0` platform [1], pyodide builds with `-fwasm-exceptions` instead of `-fexceptions`. This is the default platform for Python 3.13. Since we've dropped Python 3.12 wasm wheels, we should switch to this new exception handling.

[1] https://pyodide.org/en/stable/development/abi/313.html

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines