### PR TITLE
Fix CompositeGenericTransform.contains_branch_separately ignoring first child

### DIFF
--- a/lib/matplotlib/tests/test_transforms.py
+++ b/lib/matplotlib/tests/test_transforms.py
@@ -700,6 +700,18 @@ class TestBasicTransform:
         assert x is sx is False
         assert y is sy is True
 
+        # A branch that lives in the first child of a composite, or that spans
+        # the boundary between its two children, must be reported in both
+        # dimensions, consistently with contains_branch (issue #32099).
+        assert self.stack2.contains_branch(self.stack2_subset)
+        assert (self.stack2.contains_branch_separately(self.stack2_subset)
+                == (True, True))
+        assert (self.stack1.contains_branch_separately(self.ta2 + self.ta3)
+                == (True, True))
+        # A transform that is not a branch stays False in both dimensions.
+        assert (self.stack2.contains_branch_separately(self.tn1)
+                == (False, False))
+
     def test_affine_simplification(self):
         # tests that a transform stack only calls as much is absolutely
         # necessary "non-affine" allowing the best possible optimization with

--- a/lib/matplotlib/transforms.py
+++ b/lib/matplotlib/transforms.py
@@ -2454,7 +2454,18 @@ class CompositeGenericTransform(Transform):
                              'transforms with 2 output dimensions')
         if self == other_transform:
             return (True, True)
-        return self._b.contains_branch_separately(other_transform)
+        # The second (suffix) child may report per-dimension results when it
+        # is a blended transform, so query it separately first.
+        x, y = self._b.contains_branch_separately(other_transform)
+        if not (x and y):
+            # Otherwise the branch may lie in the first child or span the
+            # boundary between the two children.  Such a branch is a suffix of
+            # the whole composite and therefore matches in both dimensions, so
+            # fall back to the (non-per-dimension) whole-transform check.
+            in_branch = self.contains_branch(other_transform)
+            x = x or in_branch
+            y = y or in_branch
+        return (x, y)
 
     depth = property(lambda self: self._a.depth + self._b.depth)
     is_affine = property(lambda self: self._a.is_affine and self._b.is_affine)


### PR DESCRIPTION
# Fix CompositeGenericTransform.contains_branch_separately ignoring the first child (closes #32099)

## PR summary
`CompositeGenericTransform.contains_branch_separately` only inspected the
second (suffix) child, `self._b`, so any branch located in the first child
`self._a` — or one that spans the boundary between the two children — was
reported as absent. This made the per-dimension result inconsistent with
`contains_branch`, which correctly detects such branches.

### Reproduction (matplotlib 3.10.9)
```python
import numpy as np
import matplotlib.transforms as mt

class NonAffineForTest(mt.Transform):
    is_affine = False; input_dims = output_dims = 2
    def __init__(self, real, *a, **k):
        self.real_trans = real; super().__init__(*a, **k)
    def transform_non_affine(self, v): return self.real_trans.transform(v)
    def transform_path_non_affine(self, p): return self.real_trans.transform_path(p)

ta1 = mt.Affine2D().rotate(np.pi/2); ta2 = mt.Affine2D().translate(10, 0)
ta3 = mt.Affine2D().scale(1, 2); tn1 = NonAffineForTest(mt.Affine2D().translate(1, 2))
stack  = ta1 + tn1 + ta2 + ta3        # CompositeGenericTransform
subset = tn1 + ta2 + ta3              # a genuine suffix branch

stack.contains_branch(subset)             # -> True
stack.contains_branch_separately(subset)  # -> (False, False)   BUG (inconsistent)
```

### Fix
Query the suffix child first (so a blended child can still report distinct
per-dimension results), and when it does not already contain the branch in both
dimensions, fall back to the whole-transform `contains_branch` check. A branch
found that way is a complete suffix of the composite and therefore applies to
both dimensions.

```python
x, y = self._b.contains_branch_separately(other_transform)
if not (x and y):
    in_branch = self.contains_branch(other_transform)
    x = x or in_branch
    y = y or in_branch
return (x, y)
```

A naive alternative — ORing `self._a` and `self._b`'s separate results — does
**not** work, because a branch that straddles the split point (e.g. `subset`
above) is a suffix of neither child individually; only the whole-transform
check catches it.

After the fix the reproduction returns `(True, True)`, matching
`contains_branch`.

## Behaviour preserved
- Blended per-dimension results are unchanged: the existing
  `test_contains_branch` case `stack_blend.contains_branch_separately(...)`
  still returns `(False, True)`.
- Non-branch transforms still return `(False, False)` — no over-reporting.

## Tests
Extended `TestBasicTransform.test_contains_branch` in
`lib/matplotlib/tests/test_transforms.py` with cases for a branch in the first
child, a branch spanning the child boundary, and a non-branch. These fail on
`main` and pass with this change.

## AI Disclosure
AI assistance was used to investigate the codebase and draft this change and
its tests; the logic was verified manually against the released build.

## PR checklist
- [x] "closes #32099" is in the body
- [x] new and changed code is tested
- [N/A] Plotting-related features demonstrated in an example
- [N/A] New Features / API Changes noted with a directive and release note
- [x] Documentation complies with guidelines (behavior-only fix; docstring inherited)
