### PR TITLE
Bump minimum macOS version to 10.14

### DIFF
--- a/doc/install/dependencies.rst
+++ b/doc/install/dependencies.rst
@@ -73,7 +73,7 @@ and the capabilities they provide.
   from https://wxpython.org/pages/downloads/.
 * Tornado_ (>= 5): for the WebAgg backend.
 * ipykernel_: for the nbagg backend.
-* macOS (>= 10.13): for the macosx backend.
+* macOS (>= 10.14): for the macosx backend.
 
 .. _Tk: https://docs.python.org/3/library/tk.html
 .. _PyQt5: https://pypi.org/project/PyQt5/

--- a/doc/release/next_whats_new/minimum_macos.rst
+++ b/doc/release/next_whats_new/minimum_macos.rst
@@ -1,4 +1,4 @@
 New minimum macOS version
 -------------------------
 
-The macosx backend now requires macOS >= 10.13.
+The macosx backend now requires macOS >= 10.14.


### PR DESCRIPTION
- Why is this change necessary?

The minimum version of macOS is now 10.14 as our ARC changes require a compiler with `objc_arc_fields` support.


## AI Disclosure

None.

## PR checklist
<!-- Please mark any checkboxes that do not apply to this PR as [N/A].-->

- [N/A] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [N/A] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [X] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features) (*They are now!*)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines