### PR TITLE
TYP: Hint Figure.subfigures the same way as Figure.subplots

### DIFF
--- a/lib/matplotlib/figure.pyi
+++ b/lib/matplotlib/figure.pyi
@@ -194,15 +194,15 @@ class FigureBase(Artist):
     @overload
     def subfigures(
         self,
-        nrows: int,
-        ncols: int,
-        squeeze: Literal[False],
+        nrows: Literal[1] = ...,
+        ncols: Literal[1] = ...,
+        squeeze: Literal[True] = ...,
         wspace: float | None = ...,
         hspace: float | None = ...,
         width_ratios: ArrayLike | None = ...,
         height_ratios: ArrayLike | None = ...,
         **kwargs
-    ) -> np.ndarray: ...
+    ) -> SubFigure: ...
     @overload
     def subfigures(
         self,
@@ -221,13 +221,13 @@ class FigureBase(Artist):
         self,
         nrows: int = ...,
         ncols: int = ...,
-        squeeze: Literal[True] = ...,
+        squeeze: bool = ...,
         wspace: float | None = ...,
         hspace: float | None = ...,
         width_ratios: ArrayLike | None = ...,
         height_ratios: ArrayLike | None = ...,
         **kwargs
-    ) -> np.ndarray | SubFigure: ...
+    ) -> Any: ...
     def add_subfigure(self, subplotspec: SubplotSpec, **kwargs) -> SubFigure: ...
     def sca(self, a: Axes) -> Axes: ...
     def gca(self) -> Axes: ...


### PR DESCRIPTION
## PR summary

Specifically, add an overload for the (nrows=1, ncols=1, squeeze=True) case, and set the generic one to return `Any`.

## AI Disclosure
None

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines