### PR TITLE
DOC : clarify event_loop_is_running docstring

### DIFF
--- a/src/_macosx.m
+++ b/src/_macosx.m
@@ -2045,7 +2045,10 @@ static struct PyModuleDef moduledef = {
          (PyCFunction)event_loop_is_running,
          METH_NOARGS,
          PyDoc_STR(
-            "Return whether the macosx backend has set up the NSApp main event loop.")},
+           "Return whether the macosx backend has been initialized.\n"
+           "\n"
+           "Note: this function name is currently imprecise and does not "
+           "reflect if the main event loop is running or not.")},
         {"wake_on_fd_write",
          (PyCFunction)wake_on_fd_write,
          METH_VARARGS,


### PR DESCRIPTION
## Summary

This PR clarifies the docstring for `event_loop_is_running()` in the macOS backend.

The previous docstring described what the function returns, but did not clarify that its name is intentionally imprecise. This update explains that the function reports whether the macOS backend has initialized the NSApp main event loop, rather than determining whether an arbitrary event loop is running.

Closes #32041