### PR TITLE
PERF: Text rendering speedups

### DIFF
--- a/lib/matplotlib/_text_helpers.py
+++ b/lib/matplotlib/_text_helpers.py
@@ -24,8 +24,8 @@ def layout(string: str, font: FT2Font, *,
     """
     Render *string* with *font*.
 
-    For each character in *string*, yield a LayoutItem instance. When such an instance
-    is yielded, the font's glyph is set to the corresponding character.
+    For each character in *string*, yield a LayoutItem instance.  Callers that
+    need the outline must load the glyph themselves.
 
     Parameters
     ----------
@@ -43,8 +43,5 @@ def layout(string: str, font: FT2Font, *,
     ------
     LayoutItem
     """
-    for raqm_item in font._layout(string, LoadFlags.NO_HINTING,
-                                  features=features, language=language):
-        raqm_item.ft_object.load_glyph(raqm_item.glyph_index,
-                                       flags=LoadFlags.NO_HINTING)
-        yield raqm_item
+    yield from font._layout(string, LoadFlags.NO_HINTING,
+                            features=features, language=language)

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -33,7 +33,7 @@ from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, RendererBase)
 from matplotlib.dviread import Dvi
 from matplotlib.font_manager import fontManager as _fontManager, get_font
-from matplotlib.ft2font import LoadFlags, RenderMode
+from matplotlib.ft2font import LoadFlags, RenderMode, _render_glyph_run
 from matplotlib.mathtext import MathTextParser
 from matplotlib.path import Path
 from matplotlib.transforms import Bbox, BboxBase
@@ -174,36 +174,11 @@ class RendererAgg(RendererBase):
 
     def _draw_text_glyphs_and_boxes(self, gc, x, y, angle, glyphs, boxes):
         # y is downwards.
-        cos = math.cos(math.radians(angle))
-        sin = math.sin(math.radians(angle))
-        load_flags = get_hinting_flag()
         antialiased = gc.get_antialiased()
-        render_mode = RenderMode.NORMAL if antialiased else RenderMode.MONO
-        sized = None
-        for font, size, glyph_index, slant, extend, dx, dy in glyphs:  # dy is upwards.
-            if sized != (font, size):
-                # set_size recurses into the fallbacks, so only call it on a change.
-                font.set_size(size, self.dpi)
-                sized = (font, size)
-            font._set_transform(
-                # 0x10000 * rotation @ [[extend, extend * slant], [0, 1]].
-                [[round(0x10000 * extend * cos),
-                  round(0x10000 * (extend * slant * cos - sin))],
-                 [round(0x10000 * extend * sin),
-                  round(0x10000 * (extend * slant * sin + cos))]],
-                [round(0x40 * (x + dx * cos - dy * sin)),
-                 # FreeType's y is upwards.
-                 round(0x40 * (self.height - y + dx * sin + dy * cos))]
-            )
-            bitmap = font._render_glyph(glyph_index, load_flags, render_mode)
-            buffer = bitmap.buffer
-            if not antialiased:
-                buffer *= 0xff
-            # draw_text_image's y is downwards & the bitmap bottom side.
-            self._renderer.draw_text_image(
-                buffer,
-                bitmap.left, int(self.height) - bitmap.top + buffer.shape[0],
-                0, gc)
+        buffer, positions = _render_glyph_run(
+            list(glyphs), self.dpi, x, y, angle, self.height, get_hinting_flag(),
+            RenderMode.NORMAL if antialiased else RenderMode.MONO)
+        self._renderer.draw_text_images(buffer, positions, gc)
 
         rgba = gc.get_rgb()
         if len(rgba) == 3 or gc.get_forced_alpha():

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -177,20 +177,27 @@ class RendererAgg(RendererBase):
         cos = math.cos(math.radians(angle))
         sin = math.sin(math.radians(angle))
         load_flags = get_hinting_flag()
+        antialiased = gc.get_antialiased()
+        render_mode = RenderMode.NORMAL if antialiased else RenderMode.MONO
+        sized = None
         for font, size, glyph_index, slant, extend, dx, dy in glyphs:  # dy is upwards.
-            font.set_size(size, self.dpi)
+            if sized != (font, size):
+                # set_size recurses into the fallbacks, so only call it on a change.
+                font.set_size(size, self.dpi)
+                sized = (font, size)
             font._set_transform(
-                (0x10000 * np.array([[cos, -sin], [sin, cos]])
-                 @ [[extend, extend * slant], [0, 1]]).round().astype(int),
+                # 0x10000 * rotation @ [[extend, extend * slant], [0, 1]].
+                [[round(0x10000 * extend * cos),
+                  round(0x10000 * (extend * slant * cos - sin))],
+                 [round(0x10000 * extend * sin),
+                  round(0x10000 * (extend * slant * sin + cos))]],
                 [round(0x40 * (x + dx * cos - dy * sin)),
                  # FreeType's y is upwards.
                  round(0x40 * (self.height - y + dx * sin + dy * cos))]
             )
-            bitmap = font._render_glyph(
-                glyph_index, load_flags,
-                RenderMode.NORMAL if gc.get_antialiased() else RenderMode.MONO)
+            bitmap = font._render_glyph(glyph_index, load_flags, render_mode)
             buffer = bitmap.buffer
-            if not gc.get_antialiased():
+            if not antialiased:
                 buffer *= 0xff
             # draw_text_image's y is downwards & the bitmap bottom side.
             self._renderer.draw_text_image(

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -36,7 +36,7 @@ from matplotlib.backend_bases import (
     _Backend, FigureCanvasBase, FigureManagerBase, GraphicsContextBase, RendererBase)
 from matplotlib.dviread import Dvi
 from matplotlib.font_manager import fontManager as _fontManager, get_font
-from matplotlib.ft2font import LoadFlags, RenderMode
+from matplotlib.ft2font import LoadFlags, RenderMode, _render_glyph_run
 from matplotlib.mathtext import MathTextParser
 from matplotlib.path import Path
 from matplotlib.transforms import Bbox, BboxBase
@@ -190,36 +190,11 @@ class RendererAgg(RendererBase):
 
     def _draw_text_glyphs_and_boxes(self, gc, x, y, angle, glyphs, boxes):
         # y is downwards.
-        cos = math.cos(math.radians(angle))
-        sin = math.sin(math.radians(angle))
-        load_flags = get_hinting_flag()
         antialiased = gc.get_antialiased()
-        render_mode = RenderMode.NORMAL if antialiased else RenderMode.MONO
-        sized = None
-        for font, size, glyph_index, slant, extend, dx, dy in glyphs:  # dy is upwards.
-            if sized != (font, size):
-                # set_size recurses into the fallbacks, so only call it on a change.
-                font.set_size(size, self.dpi)
-                sized = (font, size)
-            font._set_transform(
-                # 0x10000 * rotation @ [[extend, extend * slant], [0, 1]].
-                [[round(0x10000 * extend * cos),
-                  round(0x10000 * (extend * slant * cos - sin))],
-                 [round(0x10000 * extend * sin),
-                  round(0x10000 * (extend * slant * sin + cos))]],
-                [round(0x40 * (x + dx * cos - dy * sin)),
-                 # FreeType's y is upwards.
-                 round(0x40 * (self.height - y + dx * sin + dy * cos))]
-            )
-            bitmap = font._render_glyph(glyph_index, load_flags, render_mode)
-            buffer = bitmap.buffer
-            if not antialiased:
-                buffer *= 0xff
-            # draw_text_image's y is downwards & the bitmap bottom side.
-            self._renderer.draw_text_image(
-                buffer,
-                bitmap.left, int(self.height) - bitmap.top + buffer.shape[0],
-                0, gc)
+        buffer, positions = _render_glyph_run(
+            list(glyphs), self.dpi, x, y, angle, self.height, get_hinting_flag(),
+            RenderMode.NORMAL if antialiased else RenderMode.MONO)
+        self._renderer.draw_text_images(buffer, positions, gc)
 
         rgba = gc.get_rgb()
         if len(rgba) == 3 or gc.get_forced_alpha():

--- a/lib/matplotlib/backends/backend_agg.py
+++ b/lib/matplotlib/backends/backend_agg.py
@@ -193,20 +193,27 @@ class RendererAgg(RendererBase):
         cos = math.cos(math.radians(angle))
         sin = math.sin(math.radians(angle))
         load_flags = get_hinting_flag()
+        antialiased = gc.get_antialiased()
+        render_mode = RenderMode.NORMAL if antialiased else RenderMode.MONO
+        sized = None
         for font, size, glyph_index, slant, extend, dx, dy in glyphs:  # dy is upwards.
-            font.set_size(size, self.dpi)
+            if sized != (font, size):
+                # set_size recurses into the fallbacks, so only call it on a change.
+                font.set_size(size, self.dpi)
+                sized = (font, size)
             font._set_transform(
-                (0x10000 * np.array([[cos, -sin], [sin, cos]])
-                 @ [[extend, extend * slant], [0, 1]]).round().astype(int),
+                # 0x10000 * rotation @ [[extend, extend * slant], [0, 1]].
+                [[round(0x10000 * extend * cos),
+                  round(0x10000 * (extend * slant * cos - sin))],
+                 [round(0x10000 * extend * sin),
+                  round(0x10000 * (extend * slant * sin + cos))]],
                 [round(0x40 * (x + dx * cos - dy * sin)),
                  # FreeType's y is upwards.
                  round(0x40 * (self.height - y + dx * sin + dy * cos))]
             )
-            bitmap = font._render_glyph(
-                glyph_index, load_flags,
-                RenderMode.NORMAL if gc.get_antialiased() else RenderMode.MONO)
+            bitmap = font._render_glyph(glyph_index, load_flags, render_mode)
             buffer = bitmap.buffer
-            if not gc.get_antialiased():
+            if not antialiased:
                 buffer *= 0xff
             # draw_text_image's y is downwards & the bitmap bottom side.
             self._renderer.draw_text_image(

--- a/lib/matplotlib/testing/conftest.py
+++ b/lib/matplotlib/testing/conftest.py
@@ -158,6 +158,15 @@ def text_placeholders(monkeypatch):
         """
         return None
 
+    def patched_get_font_height_metrics(font, fontsize, dpi):
+        """
+        Replace ``_get_font_height_metrics`` with empty results.
+
+        It caches what it reads from the tables emptied out above, so patching
+        those alone would leave a font measured earlier with its real metrics.
+        """
+        return None, None, None
+
     def patched_get_text_metrics_with_cache(renderer, text, fontprop, ismath, dpi):
         """
         Replace ``_get_text_metrics_with_cache`` with fixed results.
@@ -194,6 +203,8 @@ def text_placeholders(monkeypatch):
 
     monkeypatch.setattr('matplotlib.ft2font.FT2Font.get_sfnt_table',
                         patched_get_sfnt_table)
+    monkeypatch.setattr('matplotlib.text._get_font_height_metrics',
+                        patched_get_font_height_metrics)
     monkeypatch.setattr('matplotlib.text._get_text_metrics_with_cache',
                         patched_get_text_metrics_with_cache)
     monkeypatch.setattr('matplotlib.text.Text.draw', patched_text_draw)

--- a/lib/matplotlib/tests/test_agg.py
+++ b/lib/matplotlib/tests/test_agg.py
@@ -432,3 +432,23 @@ def test_path_autosnap(fig_test, fig_ref):
 
     axt.autoscale_view()
     axr.autoscale_view()
+
+
+def test_draw_text_images_bounds():
+    # Positions must describe bitmaps inside the buffer, as the renderer indexes
+    # into it without checking.
+    fig = plt.figure(figsize=(1, 1), dpi=40)
+    fig.canvas.draw()
+    renderer = fig.canvas.get_renderer()
+    gc = renderer.new_gc()
+    buffer = np.zeros(16, dtype=np.uint8)
+
+    for positions in [[[1 << 20, 4, 4, 5, 20]],  # Offset past the end.
+                      [[0, 400, 400, 5, 39]],  # Larger than the buffer.
+                      [[0, -4, 4, 5, 20]]]:  # Negative size.
+        with pytest.raises(ValueError, match='outside of buffer'):
+            renderer._renderer.draw_text_images(
+                buffer, np.array(positions, dtype=np.intp), gc)
+
+    renderer._renderer.draw_text_images(
+        buffer, np.array([[0, 2, 2, 1, 3]], dtype=np.intp), gc)

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1059,3 +1059,50 @@ def test_render_glyph_cache():
     # The size is part of the key.
     ft.set_size(24, 100)
     assert render().buffer.shape != reference.shape
+
+
+def test_layout_cache():
+    # A cached layout must match a fresh one, and the size is part of the key.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+
+    def xs():
+        return [item.x for item in ft._layout('hello world',
+                                              ft2font.LoadFlags.DEFAULT)]
+
+    first = xs()
+    assert xs() == first
+    ft.set_size(24, 100)
+    assert xs() != first
+
+
+def test_layout_cache_transform():
+    # The transform is part of the key, as it changes the shaped positions.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+
+    def xs():
+        return [item.x for item in ft._layout('hello world',
+                                              ft2font.LoadFlags.DEFAULT)]
+
+    first = xs()
+    ft._set_transform([[0x20000, 0], [0, 0x10000]], [0, 0])
+    assert xs() != first
+
+
+def test_layout_cache_fallback_size():
+    # Shaping reads the fallback faces, so resizing one must invalidate the cache.
+    ft = fm.get_font(fm.fontManager._find_fonts_by_props(
+        fm.FontProperties(family=['cmr10', 'DejaVu Sans'])))
+    ft.set_size(12, 100)
+
+    def items():
+        return ft._layout('AV \N{CIRCLED LATIN CAPITAL LETTER A} ffi',
+                          ft2font.LoadFlags.DEFAULT)
+
+    first = [item.x for item in items()]
+    for item in items():
+        if item.ft_object is not ft:
+            item.ft_object.set_size(40, 100)
+            break
+    assert [item.x for item in items()] != first

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1034,3 +1034,28 @@ def test__layout():
                 assert Path(item.ft_object.fname).name == 'DejaVuSans.ttf'
             else:
                 assert Path(item.ft_object.fname).name == 'cmr10.ttf'
+
+
+def test_render_glyph_cache():
+    # Reusing a cached outline must not change what is rendered.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+    index = ft.get_char_index(ord('e'))
+    identity = [[0x10000, 0], [0, 0x10000]]
+
+    def render(delta=(0, 0)):
+        ft._set_transform(identity, list(delta))
+        return ft._render_glyph(index, ft2font.LoadFlags.DEFAULT,
+                                ft2font.RenderMode.NORMAL)
+
+    first = render()
+    reference = first.buffer.copy()
+    # A whole-pixel shift reuses the outline and only moves the glyph.
+    shifted = render(delta=(0x40 * 3, 0x40 * 5))
+    assert np.array_equal(shifted.buffer, reference)
+    assert (shifted.left, shifted.top) == (first.left + 3, first.top + 5)
+    # A fractional shift must reach the rasterizer rather than be rounded away.
+    assert not np.array_equal(render(delta=(0x20, 0x20)).buffer, reference)
+    # The size is part of the key.
+    ft.set_size(24, 100)
+    assert render().buffer.shape != reference.shape

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1100,3 +1100,50 @@ def test_render_glyph_cache():
     # The size is part of the key.
     ft.set_size(24, 100)
     assert render().buffer.shape != reference.shape
+
+
+def test_layout_cache():
+    # A cached layout must match a fresh one, and the size is part of the key.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+
+    def xs():
+        return [item.x for item in ft._layout('hello world',
+                                              ft2font.LoadFlags.DEFAULT)]
+
+    first = xs()
+    assert xs() == first
+    ft.set_size(24, 100)
+    assert xs() != first
+
+
+def test_layout_cache_transform():
+    # The transform is part of the key, as it changes the shaped positions.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+
+    def xs():
+        return [item.x for item in ft._layout('hello world',
+                                              ft2font.LoadFlags.DEFAULT)]
+
+    first = xs()
+    ft._set_transform([[0x20000, 0], [0, 0x10000]], [0, 0])
+    assert xs() != first
+
+
+def test_layout_cache_fallback_size():
+    # Shaping reads the fallback faces, so resizing one must invalidate the cache.
+    ft = fm.get_font(fm.fontManager._find_fonts_by_props(
+        fm.FontProperties(family=['cmr10', 'DejaVu Sans'])))
+    ft.set_size(12, 100)
+
+    def items():
+        return ft._layout('AV \N{CIRCLED LATIN CAPITAL LETTER A} ffi',
+                          ft2font.LoadFlags.DEFAULT)
+
+    first = [item.x for item in items()]
+    for item in items():
+        if item.ft_object is not ft:
+            item.ft_object.set_size(40, 100)
+            break
+    assert [item.x for item in items()] != first

--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -1075,3 +1075,28 @@ def test__layout():
                 assert Path(item.ft_object.fname).name == 'DejaVuSans.ttf'
             else:
                 assert Path(item.ft_object.fname).name == 'cmr10.ttf'
+
+
+def test_render_glyph_cache():
+    # Reusing a cached outline must not change what is rendered.
+    ft = fm.get_font(fm.findfont('DejaVu Sans'))
+    ft.set_size(12, 100)
+    index = ft.get_char_index(ord('e'))
+    identity = [[0x10000, 0], [0, 0x10000]]
+
+    def render(delta=(0, 0)):
+        ft._set_transform(identity, list(delta))
+        return ft._render_glyph(index, ft2font.LoadFlags.DEFAULT,
+                                ft2font.RenderMode.NORMAL)
+
+    first = render()
+    reference = first.buffer.copy()
+    # A whole-pixel shift reuses the outline and only moves the glyph.
+    shifted = render(delta=(0x40 * 3, 0x40 * 5))
+    assert np.array_equal(shifted.buffer, reference)
+    assert (shifted.left, shifted.top) == (first.left + 3, first.top + 5)
+    # A fractional shift must reach the rasterizer rather than be rounded away.
+    assert not np.array_equal(render(delta=(0x20, 0x20)).buffer, reference)
+    # The size is part of the key.
+    ft.set_size(24, 100)
+    assert render().buffer.shape != reference.shape

--- a/lib/matplotlib/tests/test_textpath.py
+++ b/lib/matplotlib/tests/test_textpath.py
@@ -1,6 +1,16 @@
 import copy
 
-from matplotlib.textpath import TextPath
+import matplotlib.font_manager as fm
+from matplotlib.textpath import TextPath, TextToPath
+
+
+def test_glyphs_load_their_own_outline():
+    # Laying out no longer leaves a glyph in the font's slot, so each outline
+    # must be loaded where it is read, not taken from whatever was there.
+    font = fm.get_font(fm.findfont('DejaVu Sans'))
+    _, glyph_map, _ = TextToPath().get_glyphs_with_font(font, 'lM')
+    (l_verts, _), (m_verts, _) = glyph_map.values()
+    assert len(l_verts) != len(m_verts)
 
 
 def test_copy():

--- a/lib/matplotlib/text.py
+++ b/lib/matplotlib/text.py
@@ -44,6 +44,36 @@ def _rotate_point(angle, x, y):
     return (cos * x - sin * y, sin * x + cos * y)
 
 
+def _get_font_height_metrics(font, fontsize, dpi,
+                             _cache=weakref.WeakKeyDictionary()):
+    """
+    Return the ascent, descent and line gap of *font*, in pixels, or
+    ``(None, None, None)`` if it carries neither metrics table.
+
+    Keyed on the font rather than on font properties, which resolve to a font
+    via the rcParams, and held weakly so that caching never keeps a font alive.
+    """
+    if (metrics := _cache.get(font)) is None:
+        metrics = _cache[font] = {}
+    if (key := (fontsize, dpi)) not in metrics:
+        possible = [
+            ('OS/2', 'sTypoLineGap', 'sTypoAscender', 'sTypoDescender'),
+            ('hhea', 'lineGap', 'ascent', 'descent')
+        ]
+        metrics[key] = (None, None, None)
+        for table_name, linegap_key, ascent_key, descent_key in possible:
+            table = font.get_sfnt_table(table_name)
+            if table is None:
+                continue
+            # Rescale to font size/DPI if the metrics were available.
+            units_per_em = font.get_sfnt_table('head')['unitsPerEm']
+            scale = 1 / units_per_em * fontsize * dpi / 72
+            metrics[key] = (table[ascent_key] * scale, -table[descent_key] * scale,
+                            table[linegap_key] * scale)
+            break
+    return metrics[key]
+
+
 def _get_text_metrics_with_cache(renderer, text, fontprop, ismath, dpi):
     """Call ``renderer.get_text_width_height_descent``, caching the results."""
 
@@ -444,22 +474,8 @@ class Text(Artist):
                     self._fontproperties)
             if min_ascent is None:
                 font = get_font(fontManager._find_fonts_by_props(self._fontproperties))
-                possible = [
-                    ('OS/2', 'sTypoLineGap', 'sTypoAscender', 'sTypoDescender'),
-                    ('hhea', 'lineGap', 'ascent', 'descent')
-                ]
-                for table_name, linegap_key, ascent_key, descent_key in possible:
-                    table = font.get_sfnt_table(table_name)
-                    if table is None:
-                        continue
-                    # Rescale to font size/DPI if the metrics were available.
-                    fontsize = self._fontproperties.get_size_in_points()
-                    units_per_em = font.get_sfnt_table('head')['unitsPerEm']
-                    scale = 1 / units_per_em * fontsize * dpi / 72
-                    line_gap = table[linegap_key] * scale
-                    min_ascent = table[ascent_key] * scale
-                    min_descent = -table[descent_key] * scale
-                    break
+                min_ascent, min_descent, line_gap = _get_font_height_metrics(
+                    font, self._fontproperties.get_size_in_points(), dpi)
         if None in (min_ascent, min_descent):
             # Fallback to font measurement.
             _, h, min_descent = _get_text_metrics_with_cache(

--- a/lib/matplotlib/textpath.py
+++ b/lib/matplotlib/textpath.py
@@ -155,6 +155,8 @@ class TextToPath:
             xpositions.append(item.x)
             ypositions.append(item.y)
             if glyph_repr not in glyph_map:
+                item.ft_object.load_glyph(item.glyph_index,
+                                          flags=LoadFlags.NO_HINTING)
                 glyph_map_new[glyph_repr] = item.ft_object.get_path()
 
         sizes = [1.] * len(xpositions)

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -152,6 +152,9 @@ class RendererAgg
     template <class ImageArray>
     void draw_text_image(GCAgg &gc, ImageArray &image, int x, int y, double angle);
 
+    template <class BufferArray, class PositionArray>
+    void draw_text_images(GCAgg &gc, BufferArray &buffer, PositionArray &positions);
+
     template <class ImageArray>
     void draw_image(GCAgg &gc,
                     double x,
@@ -242,6 +245,11 @@ class RendererAgg
 
     template <class R>
     void set_clipbox(const agg::rect_d &cliprect, R &rasterizer);
+
+    std::optional<agg::rect_i> text_clip_rect(const agg::rect_d &cliprect);
+
+    void blend_text_bitmap(GCAgg &gc, const agg::int8u *covers, int rows, int cols,
+                           int x, int y, const std::optional<agg::rect_i> &clip);
 
     bool render_clippath(mpl::PathIterator &clippath, const agg::trans_affine &clippath_trans, e_snap_mode snap_mode);
 
@@ -684,6 +692,42 @@ class font_to_rgba
     }
 };
 
+// An unset cliprect is all zeros, and clips nothing.
+inline std::optional<agg::rect_i> RendererAgg::text_clip_rect(const agg::rect_d &cliprect)
+{
+    if (cliprect.x1 == 0.0 && cliprect.y1 == 0.0 &&
+            cliprect.x2 == 0.0 && cliprect.y2 == 0.0) {
+        return std::nullopt;
+    }
+    agg::rect_i clip;
+    clip.init(mpl_round_to_int(cliprect.x1), mpl_round_to_int(height - cliprect.y2),
+              mpl_round_to_int(cliprect.x2), mpl_round_to_int(height - cliprect.y1));
+    return clip;
+}
+
+// Blit one coverage bitmap, laid out row-major, with *y* its bottom edge.
+inline void RendererAgg::blend_text_bitmap(
+    GCAgg &gc, const agg::int8u *covers, int rows, int cols, int x, int y,
+    const std::optional<agg::rect_i> &clip)
+{
+    agg::rect_i fig, text;
+    auto deltay = y - rows;
+    fig.init(0, 0, width, height);
+    text.init(x, deltay, x + cols, y);
+    text.clip(fig);
+    if (clip) {
+        text.clip(*clip);
+    }
+    if (text.x2 > text.x1) {
+        auto deltax = text.x2 - text.x1;
+        auto deltax2 = text.x1 - x;
+        for (auto yi = text.y1; yi < text.y2; ++yi) {
+            pixFmt.blend_solid_hspan(text.x1, yi, deltax, gc.color,
+                                     covers + (yi - deltay) * cols + deltax2);
+        }
+    }
+}
+
 template <class ImageArray>
 inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, int y, double angle)
 {
@@ -730,32 +774,34 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
         theRasterizer.add_path(rect2);
         agg::render_scanlines(theRasterizer, slineP8, ri);
     } else {
-        agg::rect_i fig, text;
+        blend_text_bitmap(gc, &image(0, 0), static_cast<int>(image.shape(0)),
+                          static_cast<int>(image.shape(1)), x, y,
+                          text_clip_rect(gc.cliprect));
+    }
+}
 
-        int deltay = y - image.shape(0);
+// Blit the glyph bitmaps packed by `ft2font._render_glyph_run`.
+template <class BufferArray, class PositionArray>
+inline void RendererAgg::draw_text_images(
+    GCAgg &gc, BufferArray &buffer, PositionArray &positions)
+{
+    if (positions.shape(0) == 0) {
+        return;
+    }
 
-        fig.init(0, 0, width, height);
-        text.init(x, deltay, x + image.shape(1), y);
-        text.clip(fig);
+    theRasterizer.reset_clipping();
+    rendererBase.reset_clipping(true);
 
-        if (gc.cliprect.x1 != 0.0 || gc.cliprect.y1 != 0.0 || gc.cliprect.x2 != 0.0 || gc.cliprect.y2 != 0.0) {
-            agg::rect_i clip;
-
-            clip.init(mpl_round_to_int(gc.cliprect.x1),
-                      mpl_round_to_int(height - gc.cliprect.y2),
-                      mpl_round_to_int(gc.cliprect.x2),
-                      mpl_round_to_int(height - gc.cliprect.y1));
-            text.clip(clip);
-        }
-
-        if (text.x2 > text.x1) {
-            int deltax = text.x2 - text.x1;
-            int deltax2 = text.x1 - x;
-            for (int yi = text.y1; yi < text.y2; ++yi) {
-                pixFmt.blend_solid_hspan(text.x1, yi, deltax, gc.color,
-                                         &image(yi - deltay, deltax2));
-            }
-        }
+    auto const& clip = text_clip_rect(gc.cliprect);
+    auto data = buffer.data(0);
+    for (py::ssize_t i = 0; i < positions.shape(0); i++) {
+        auto offset = positions(i, 0);
+        auto rows = static_cast<int>(positions(i, 1));
+        auto cols = static_cast<int>(positions(i, 2));
+        // Positions this far out are clipped away, so narrowing is safe.
+        auto x = static_cast<int>(positions(i, 3));
+        auto y = static_cast<int>(positions(i, 4));
+        blend_text_bitmap(gc, data + offset, rows, cols, x, y, clip);
     }
 
     pixFmt.comp_op(agg::comp_op_src_over);

--- a/src/_backend_agg.h
+++ b/src/_backend_agg.h
@@ -152,6 +152,9 @@ class RendererAgg
     template <class ImageArray>
     void draw_text_image(GCAgg &gc, ImageArray &image, int x, int y, double angle);
 
+    template <class BufferArray, class PositionArray>
+    void draw_text_images(GCAgg &gc, BufferArray &buffer, PositionArray &positions);
+
     template <class ImageArray>
     void draw_image(GCAgg &gc,
                     double x,
@@ -242,6 +245,11 @@ class RendererAgg
 
     template <class R>
     void set_clipbox(const agg::rect_d &cliprect, R &rasterizer);
+
+    std::optional<agg::rect_i> text_clip_rect(const agg::rect_d &cliprect);
+
+    void blend_text_bitmap(GCAgg &gc, const agg::int8u *covers, int rows, int cols,
+                           int x, int y, const std::optional<agg::rect_i> &clip);
 
     bool render_clippath(mpl::PathIterator &clippath, const agg::trans_affine &clippath_trans, e_snap_mode snap_mode);
 
@@ -675,6 +683,42 @@ class font_to_rgba
     }
 };
 
+// An unset cliprect is all zeros, and clips nothing.
+inline std::optional<agg::rect_i> RendererAgg::text_clip_rect(const agg::rect_d &cliprect)
+{
+    if (cliprect.x1 == 0.0 && cliprect.y1 == 0.0 &&
+            cliprect.x2 == 0.0 && cliprect.y2 == 0.0) {
+        return std::nullopt;
+    }
+    agg::rect_i clip;
+    clip.init(mpl_round_to_int(cliprect.x1), mpl_round_to_int(height - cliprect.y2),
+              mpl_round_to_int(cliprect.x2), mpl_round_to_int(height - cliprect.y1));
+    return clip;
+}
+
+// Blit one coverage bitmap, laid out row-major, with *y* its bottom edge.
+inline void RendererAgg::blend_text_bitmap(
+    GCAgg &gc, const agg::int8u *covers, int rows, int cols, int x, int y,
+    const std::optional<agg::rect_i> &clip)
+{
+    agg::rect_i fig, text;
+    auto deltay = y - rows;
+    fig.init(0, 0, width, height);
+    text.init(x, deltay, x + cols, y);
+    text.clip(fig);
+    if (clip) {
+        text.clip(*clip);
+    }
+    if (text.x2 > text.x1) {
+        auto deltax = text.x2 - text.x1;
+        auto deltax2 = text.x1 - x;
+        for (auto yi = text.y1; yi < text.y2; ++yi) {
+            pixFmt.blend_solid_hspan(text.x1, yi, deltax, gc.color,
+                                     covers + (yi - deltay) * cols + deltax2);
+        }
+    }
+}
+
 template <class ImageArray>
 inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, int y, double angle)
 {
@@ -719,32 +763,34 @@ inline void RendererAgg::draw_text_image(GCAgg &gc, ImageArray &image, int x, in
         theRasterizer.add_path(rect2);
         agg::render_scanlines(theRasterizer, slineP8, ri);
     } else {
-        agg::rect_i fig, text;
+        blend_text_bitmap(gc, &image(0, 0), static_cast<int>(image.shape(0)),
+                          static_cast<int>(image.shape(1)), x, y,
+                          text_clip_rect(gc.cliprect));
+    }
+}
 
-        int deltay = y - image.shape(0);
+// Blit the glyph bitmaps packed by `ft2font._render_glyph_run`.
+template <class BufferArray, class PositionArray>
+inline void RendererAgg::draw_text_images(
+    GCAgg &gc, BufferArray &buffer, PositionArray &positions)
+{
+    if (positions.shape(0) == 0) {
+        return;
+    }
 
-        fig.init(0, 0, width, height);
-        text.init(x, deltay, x + image.shape(1), y);
-        text.clip(fig);
+    theRasterizer.reset_clipping();
+    rendererBase.reset_clipping(true);
 
-        if (gc.cliprect.x1 != 0.0 || gc.cliprect.y1 != 0.0 || gc.cliprect.x2 != 0.0 || gc.cliprect.y2 != 0.0) {
-            agg::rect_i clip;
-
-            clip.init(mpl_round_to_int(gc.cliprect.x1),
-                      mpl_round_to_int(height - gc.cliprect.y2),
-                      mpl_round_to_int(gc.cliprect.x2),
-                      mpl_round_to_int(height - gc.cliprect.y1));
-            text.clip(clip);
-        }
-
-        if (text.x2 > text.x1) {
-            int deltax = text.x2 - text.x1;
-            int deltax2 = text.x1 - x;
-            for (int yi = text.y1; yi < text.y2; ++yi) {
-                pixFmt.blend_solid_hspan(text.x1, yi, deltax, gc.color,
-                                         &image(yi - deltay, deltax2));
-            }
-        }
+    auto const& clip = text_clip_rect(gc.cliprect);
+    auto data = buffer.data(0);
+    for (py::ssize_t i = 0; i < positions.shape(0); i++) {
+        auto offset = positions(i, 0);
+        auto rows = static_cast<int>(positions(i, 1));
+        auto cols = static_cast<int>(positions(i, 2));
+        // Positions this far out are clipped away, so narrowing is safe.
+        auto x = static_cast<int>(positions(i, 3));
+        auto y = static_cast<int>(positions(i, 4));
+        blend_text_bitmap(gc, data + offset, rows, cols, x, y, clip);
     }
 }
 

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -71,6 +71,36 @@ PyRendererAgg_draw_text_image(RendererAgg *self,
 }
 
 static void
+PyRendererAgg_draw_text_images(
+    RendererAgg *self,
+    py::array_t<agg::int8u, py::array::c_style | py::array::forcecast> buffer_obj,
+    py::array_t<py::ssize_t, py::array::c_style | py::array::forcecast> positions_obj,
+    GCAgg &gc)
+{
+    if (positions_obj.ndim() != 2 || positions_obj.shape(1) != 5) {
+        throw py::value_error("positions must be of shape (N, 5)");
+    }
+    auto buffer = buffer_obj.unchecked<1>();
+    auto positions = positions_obj.unchecked<2>();
+
+    // The renderer indexes into the buffer with these.
+    auto const& size = buffer.shape(0);
+    for (auto i = 0; i < positions.shape(0); i++) {
+        auto const& offset = positions(i, 0);
+        auto const& rows = positions(i, 1);
+        auto const& cols = positions(i, 2);
+        if (offset < 0 || rows < 0 || cols < 0 || offset > size ||
+                (rows > 0 && cols > (size - offset) / rows)) {
+            throw py::value_error(
+                "positions describes a bitmap outside of buffer at row " +
+                std::to_string(i));
+        }
+    }
+
+    self->draw_text_images(gc, buffer, positions);
+}
+
+static void
 PyRendererAgg_draw_markers(RendererAgg *self,
                            GCAgg &gc,
                            mpl::PathIterator marker_path,
@@ -206,6 +236,8 @@ PYBIND11_MODULE(_backend_agg, m, py::mod_gil_not_used())
              "face"_a = nullptr)
         .def("draw_text_image", &PyRendererAgg_draw_text_image,
              "image"_a, "x"_a, "y"_a, "angle"_a, "gc"_a)
+        .def("draw_text_images", &PyRendererAgg_draw_text_images,
+             "buffer"_a, "positions"_a, "gc"_a)
         .def("draw_image", &PyRendererAgg_draw_image,
              "gc"_a, "x"_a, "y"_a, "image"_a)
         .def("draw_path_collection", &PyRendererAgg_draw_path_collection,

--- a/src/_backend_agg_wrapper.cpp
+++ b/src/_backend_agg_wrapper.cpp
@@ -71,6 +71,36 @@ PyRendererAgg_draw_text_image(RendererAgg *self,
 }
 
 static void
+PyRendererAgg_draw_text_images(
+    RendererAgg *self,
+    py::array_t<agg::int8u, py::array::c_style | py::array::forcecast> buffer_obj,
+    py::array_t<py::ssize_t, py::array::c_style | py::array::forcecast> positions_obj,
+    GCAgg &gc)
+{
+    if (positions_obj.ndim() != 2 || positions_obj.shape(1) != 5) {
+        throw py::value_error("positions must be of shape (N, 5)");
+    }
+    auto buffer = buffer_obj.unchecked<1>();
+    auto positions = positions_obj.unchecked<2>();
+
+    // The renderer indexes into the buffer with these.
+    auto const& size = buffer.shape(0);
+    for (auto i = 0; i < positions.shape(0); i++) {
+        auto const& offset = positions(i, 0);
+        auto const& rows = positions(i, 1);
+        auto const& cols = positions(i, 2);
+        if (offset < 0 || rows < 0 || cols < 0 || offset > size ||
+                (rows > 0 && cols > (size - offset) / rows)) {
+            throw py::value_error(
+                "positions describes a bitmap outside of buffer at row " +
+                std::to_string(i));
+        }
+    }
+
+    self->draw_text_images(gc, buffer, positions);
+}
+
+static void
 PyRendererAgg_draw_markers(RendererAgg *self,
                            GCAgg &gc,
                            mpl::PathIterator marker_path,
@@ -207,6 +237,8 @@ PYBIND11_MODULE(_backend_agg, m, py::mod_gil_not_used())
              "face"_a = nullptr)
         .def("draw_text_image", &PyRendererAgg_draw_text_image,
              "image"_a, "x"_a, "y"_a, "angle"_a, "gc"_a)
+        .def("draw_text_images", &PyRendererAgg_draw_text_images,
+             "buffer"_a, "positions"_a, "gc"_a)
         .def("draw_image", &PyRendererAgg_draw_image,
              "gc"_a, "x"_a, "y"_a, "image"_a)
         .def("draw_path_collection", &PyRendererAgg_draw_path_collection,

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -183,6 +183,7 @@ FT2Font::get_path(std::vector<double> &vertices, std::vector<unsigned char> &cod
 FT2Font::FT2Font(std::vector<FT2Font *> &fallback_list, bool warn_if_used)
     : warn_if_used(warn_if_used), image({1, 1}), face(nullptr),
       char_size(0), char_dpi(0), glyph_matrix{0x10000, 0, 0, 0x10000}, glyph_delta{0, 0},
+      charmap_generation(0),
       fallbacks(fallback_list),
       // set default kerning factor to 0, i.e., no kerning manipulation
       kerning_factor(0)
@@ -219,6 +220,7 @@ void FT2Font::close()
     }
     glyphs.clear();
     clear_glyph_cache();
+    layout_cache.clear();
 
     if (face) {
         FT_Done_Face(face);
@@ -283,11 +285,24 @@ void FT2Font::set_charmap(int i)
         throw std::runtime_error("i exceeds the available number of char maps");
     }
     FT_CHECK(FT_Set_Charmap, face, face->charmaps[i]);
+    charmap_generation++;
 }
 
 void FT2Font::select_charmap(unsigned long i)
 {
     FT_CHECK(FT_Select_Charmap, face, (FT_Encoding)i);
+    charmap_generation++;
+}
+
+std::vector<FT2Font::FaceState> FT2Font::shaping_state() const
+{
+    // Shaping reads the fallback faces too, so their state is part of the key.
+    std::vector<FaceState> state{{char_size, char_dpi, charmap_generation}};
+    for (auto const& fallback : fallbacks) {
+        auto const& nested = fallback->shaping_state();
+        state.insert(state.end(), nested.begin(), nested.end());
+    }
+    return state;
 }
 
 int FT2Font::get_kerning(FT_UInt left, FT_UInt right, FT_Kerning_Mode mode)
@@ -318,6 +333,17 @@ std::vector<raqm_glyph_t> FT2Font::layout(
     std::set<FT_String*>& glyph_seen_fonts)
 {
     clear();
+
+    auto const& key = LayoutCacheKey{
+        std::u32string{text}, flags, features, languages, shaping_state(),
+        glyph_matrix.xx, glyph_matrix.xy, glyph_matrix.yx, glyph_matrix.yy};
+    if (auto const& cached = layout_cache.find(key); cached != layout_cache.end()) {
+        auto const& entry = cached->second;
+        glyph_seen_fonts.insert(entry.seen_fonts.begin(), entry.seen_fonts.end());
+        return entry.glyphs;
+    }
+    // Kept apart from the caller's set so that it can be replayed from the cache.
+    std::set<FT_String *> seen_fonts;
 
     auto rq = raqm_create();
     if (!rq) {
@@ -360,7 +386,7 @@ std::vector<raqm_glyph_t> FT2Font::layout(
     }
 
     std::vector<std::pair<size_t, const FT_Face&>> face_substitutions;
-    glyph_seen_fonts.insert(face->family_name);
+    seen_fonts.insert(face->family_name);
 
     // Attempt to use fallback fonts if necessary.
     for (auto const& fallback : fallbacks) {
@@ -399,7 +425,7 @@ std::vector<raqm_glyph_t> FT2Font::layout(
 
         // If a fallback was used, then re-attempt the layout with the new fonts.
         if (!fallback->warn_if_used) {
-            glyph_seen_fonts.insert(fallback->face->family_name);
+            seen_fonts.insert(fallback->face->family_name);
         }
 
         raqm_clear_contents(rq);
@@ -444,7 +470,16 @@ std::vector<raqm_glyph_t> FT2Font::layout(
     size_t num_glyphs = 0;
     auto const& rq_glyphs = raqm_get_glyphs(rq, &num_glyphs);
 
-    return std::vector<raqm_glyph_t>(rq_glyphs, rq_glyphs + num_glyphs);
+    if (layout_cache.size() >= layout_cache_max) {
+        layout_cache.clear();
+    }
+    auto const& entry = layout_cache.insert_or_assign(
+        key,
+        LayoutCacheEntry{
+            std::vector<raqm_glyph_t>(rq_glyphs, rq_glyphs + num_glyphs),
+            std::move(seen_fonts)}).first->second;
+    glyph_seen_fonts.insert(entry.seen_fonts.begin(), entry.seen_fonts.end());
+    return entry.glyphs;
 }
 
 void FT2Font::set_text(

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -230,8 +230,8 @@ void FT2Font::close()
 
 void FT2Font::clear_glyph_cache()
 {
-    for (auto & [key, glyph] : glyph_cache) {
-        FT_Done_Glyph(glyph);
+    for (auto & [key, cached] : glyph_cache) {
+        FT_Done_Glyph(cached.glyph);
     }
     glyph_cache.clear();
 }
@@ -518,16 +518,7 @@ void FT2Font::set_text(
         }
 
         // extract glyph image and store it in our table
-        FT_Error error;
-        error = FT_Load_Glyph(rglyph.ftface, rglyph.index, flags);
-        if (error) {
-            throw std::runtime_error("failed to load glyph");
-        }
-        FT_Glyph thisGlyph;
-        error = FT_Get_Glyph(rglyph.ftface->glyph, &thisGlyph);
-        if (error) {
-            throw std::runtime_error("failed to get glyph");
-        }
+        auto thisGlyph = wrapped_font->load_glyph_copy(rglyph.index, flags);
 
         pen.x += rglyph.x_offset;
         pen.y += rglyph.y_offset;
@@ -690,7 +681,7 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
     glyphs.push_back(thisGlyph);
 }
 
-FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
+FT2Font::CachedGlyph const *FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
 {
     // FreeType hints before transforming, so an outline loaded under a given
     // matrix can be reused at every position, translating it when rasterizing.
@@ -698,7 +689,7 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
         glyph_index, flags, char_size, char_dpi,
         glyph_matrix.xx, glyph_matrix.xy, glyph_matrix.yx, glyph_matrix.yy};
     if (auto const& cached = glyph_cache.find(key); cached != glyph_cache.end()) {
-        return cached->second;
+        return &cached->second;
     }
 
     // Load without the translation, so the outline sits at the origin.  The
@@ -712,14 +703,17 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
     if (face->glyph->format != FT_GLYPH_FORMAT_OUTLINE) {
         // Only outlines can be repositioned after loading.  A null glyph
         // records that, and the caller loads these itself.
+        auto const linear_hori_advance = face->glyph->linearHoriAdvance;
         FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
         if (glyph_cache.size() >= glyph_cache_max) {
             clear_glyph_cache();
         }
-        return glyph_cache[key] = nullptr;
+        return &(glyph_cache[key] = CachedGlyph{nullptr, linear_hori_advance});
     }
     FT_Glyph glyph = nullptr;
     auto const& glyph_error = FT_Get_Glyph(face->glyph, &glyph);
+    // Copied out of the glyph slot, which the next load overwrites.
+    auto const linear_hori_advance = face->glyph->linearHoriAdvance;
     FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
     if (glyph_error) {
         THROW_FT_ERROR("FT_Get_Glyph", glyph_error);
@@ -730,16 +724,48 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
     if (glyph_cache.size() >= glyph_cache_max) {
         clear_glyph_cache();
     }
-    glyph_cache[key] = glyph;
+    auto const& entry = &(glyph_cache[key] = CachedGlyph{glyph, linear_hori_advance});
     owned.release();  // The cache owns it now.
-    return glyph;
+    return entry;
+}
+
+FT_Glyph FT2Font::load_glyph_copy(
+    FT_UInt glyph_index, FT_Int32 flags, FT_Fixed *linear_hori_advance)
+{
+    auto const& cached = cache_glyph(glyph_index, flags);
+    FT_Glyph glyph = nullptr;
+    if (cached->glyph) {
+        FT_CHECK(FT_Glyph_Copy, cached->glyph, &glyph);
+    } else {  // Not an outline, so load it the slow way.
+        FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
+        FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+    }
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        glyph, &FT_Done_Glyph};
+    if (cached->glyph && (glyph_delta.x || glyph_delta.y)) {
+        FT_CHECK(FT_Glyph_Transform, glyph, nullptr, &glyph_delta);
+    }
+    if (linear_hori_advance) {
+        *linear_hori_advance = cached->linear_hori_advance;
+    }
+    return owned.release();
+}
+
+FT_Fixed FT2Font::load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags)
+{
+    FT_Fixed linear_hori_advance = 0;
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        load_glyph_copy(glyph_index, flags, &linear_hori_advance), &FT_Done_Glyph};
+    glyphs.push_back(owned.get());
+    owned.release();  // `glyphs` owns it now.
+    return linear_hori_advance;
 }
 
 FT_Glyph FT2Font::render_glyph(
     FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode)
 {
     auto const& cached = cache_glyph(glyph_index, flags);
-    if (!cached) {  // Not an outline, so load and rasterize it directly.
+    if (!cached->glyph) {  // Not an outline, so load and rasterize it directly.
         FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
         FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
         FT_Glyph glyph = nullptr;
@@ -749,7 +775,7 @@ FT_Glyph FT2Font::render_glyph(
 
     // With `destroy` false this translates the cached outline, rasterizes it,
     // and translates it back.
-    FT_Glyph glyph = cached;
+    FT_Glyph glyph = cached->glyph;
     FT_CHECK(FT_Glyph_To_Bitmap, &glyph, render_mode, &glyph_delta, false);
     return glyph;
 }

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -181,7 +181,9 @@ FT2Font::get_path(std::vector<double> &vertices, std::vector<unsigned char> &cod
 }
 
 FT2Font::FT2Font(std::vector<FT2Font *> &fallback_list, bool warn_if_used)
-    : warn_if_used(warn_if_used), image({1, 1}), face(nullptr), fallbacks(fallback_list),
+    : warn_if_used(warn_if_used), image({1, 1}), face(nullptr),
+      char_size(0), char_dpi(0), glyph_matrix{0x10000, 0, 0, 0x10000}, glyph_delta{0, 0},
+      fallbacks(fallback_list),
       // set default kerning factor to 0, i.e., no kerning manipulation
       kerning_factor(0)
 {
@@ -216,11 +218,20 @@ void FT2Font::close()
         FT_Done_Glyph(glyph);
     }
     glyphs.clear();
+    clear_glyph_cache();
 
     if (face) {
         FT_Done_Face(face);
         face = nullptr;
     }
+}
+
+void FT2Font::clear_glyph_cache()
+{
+    for (auto & [key, glyph] : glyph_cache) {
+        FT_Done_Glyph(glyph);
+    }
+    glyph_cache.clear();
 }
 
 void FT2Font::clear()
@@ -243,11 +254,12 @@ void FT2Font::clear()
 
 void FT2Font::set_size(double ptsize, double dpi)
 {
-    FT_CHECK(
-        FT_Set_Char_Size,
-        face, (FT_F26Dot6)(ptsize * 64), 0, (FT_UInt)dpi, (FT_UInt)dpi);
-    FT_Matrix transform = { 65536, 0, 0, 65536 };
-    FT_Set_Transform(face, &transform, nullptr);
+    char_size = (FT_F26Dot6)(ptsize * 64);
+    char_dpi = (FT_UInt)dpi;
+    FT_CHECK(FT_Set_Char_Size, face, char_size, 0, char_dpi, char_dpi);
+    glyph_matrix = { 65536, 0, 0, 65536 };
+    glyph_delta = { 0, 0 };
+    FT_Set_Transform(face, &glyph_matrix, nullptr);
 
     for (auto & fallback : fallbacks) {
         fallback->set_size(ptsize, dpi);
@@ -257,9 +269,9 @@ void FT2Font::set_size(double ptsize, double dpi)
 void FT2Font::_set_transform(
     std::array<std::array<FT_Fixed, 2>, 2> matrix, std::array<FT_Fixed, 2> delta)
 {
-    FT_Matrix m = {matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1]};
-    FT_Vector d = {delta[0], delta[1]};
-    FT_Set_Transform(face, &m, &d);
+    glyph_matrix = {matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1]};
+    glyph_delta = {delta[0], delta[1]};
+    FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
     for (auto & fallback : fallbacks) {
         fallback->_set_transform(matrix, delta);
     }
@@ -641,6 +653,70 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
     FT_Glyph thisGlyph;
     FT_CHECK(FT_Get_Glyph, face->glyph, &thisGlyph);
     glyphs.push_back(thisGlyph);
+}
+
+FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
+{
+    // FreeType hints before transforming, so an outline loaded under a given
+    // matrix can be reused at every position, translating it when rasterizing.
+    auto const& key = GlyphCacheKey{
+        glyph_index, flags, char_size, char_dpi,
+        glyph_matrix.xx, glyph_matrix.xy, glyph_matrix.yx, glyph_matrix.yy};
+    if (auto const& cached = glyph_cache.find(key); cached != glyph_cache.end()) {
+        return cached->second;
+    }
+
+    // Load without the translation, so the outline sits at the origin.  The
+    // face transform is restored either way, as other methods load through it.
+    FT_Set_Transform(face, &glyph_matrix, nullptr);
+    auto const& load_error = FT_Load_Glyph(face, glyph_index, flags);
+    if (load_error) {
+        FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+        THROW_FT_ERROR("FT_Load_Glyph", load_error);
+    }
+    if (face->glyph->format != FT_GLYPH_FORMAT_OUTLINE) {
+        // Only outlines can be repositioned after loading.  A null glyph
+        // records that, and the caller loads these itself.
+        FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+        if (glyph_cache.size() >= glyph_cache_max) {
+            clear_glyph_cache();
+        }
+        return glyph_cache[key] = nullptr;
+    }
+    FT_Glyph glyph = nullptr;
+    auto const& glyph_error = FT_Get_Glyph(face->glyph, &glyph);
+    FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+    if (glyph_error) {
+        THROW_FT_ERROR("FT_Get_Glyph", glyph_error);
+    }
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        glyph, &FT_Done_Glyph};
+
+    if (glyph_cache.size() >= glyph_cache_max) {
+        clear_glyph_cache();
+    }
+    glyph_cache[key] = glyph;
+    owned.release();  // The cache owns it now.
+    return glyph;
+}
+
+FT_Glyph FT2Font::render_glyph(
+    FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode)
+{
+    auto const& cached = cache_glyph(glyph_index, flags);
+    if (!cached) {  // Not an outline, so load and rasterize it directly.
+        FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
+        FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
+        FT_Glyph glyph = nullptr;
+        FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+        return glyph;
+    }
+
+    // With `destroy` false this translates the cached outline, rasterizes it,
+    // and translates it back.
+    FT_Glyph glyph = cached;
+    FT_CHECK(FT_Glyph_To_Bitmap, &glyph, render_mode, &glyph_delta, false);
+    return glyph;
 }
 
 FT_UInt FT2Font::get_char_index(FT_ULong charcode, bool fallback = false)

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -518,18 +518,20 @@ void FT2Font::set_text(
         }
 
         // extract glyph image and store it in our table
-        auto thisGlyph = wrapped_font->load_glyph_copy(rglyph.index, flags);
+        GlyphPtr thisGlyph{nullptr, &FT_Done_Glyph};
+        FT_Fixed linear_hori_advance = 0;  // Unused.
+        wrapped_font->load_glyph_copy(rglyph.index, flags, thisGlyph, linear_hori_advance);
 
         pen.x += rglyph.x_offset;
         pen.y += rglyph.y_offset;
 
-        FT_Glyph_Transform(thisGlyph, nullptr, &pen);
-        FT_Glyph_Transform(thisGlyph, &matrix, nullptr);
+        FT_Glyph_Transform(thisGlyph.get(), nullptr, &pen);
+        FT_Glyph_Transform(thisGlyph.get(), &matrix, nullptr);
         xys.push_back(pen.x);
         xys.push_back(pen.y);
 
         FT_BBox glyph_bbox;
-        FT_Glyph_Get_CBox(thisGlyph, FT_GLYPH_BBOX_SUBPIXELS, &glyph_bbox);
+        FT_Glyph_Get_CBox(thisGlyph.get(), FT_GLYPH_BBOX_SUBPIXELS, &glyph_bbox);
 
         bbox.xMin = std::min(bbox.xMin, glyph_bbox.xMin);
         bbox.xMax = std::max(bbox.xMax, glyph_bbox.xMax);
@@ -539,7 +541,8 @@ void FT2Font::set_text(
         pen.x += rglyph.x_advance - rglyph.x_offset;
         pen.y += rglyph.y_advance - rglyph.y_offset;
 
-        glyphs.push_back(thisGlyph);
+        glyphs.push_back(thisGlyph.get());
+        thisGlyph.release();  // `glyphs` owns it now.
     }
 
     FT_Vector_Transform(&pen, &matrix);
@@ -680,9 +683,11 @@ bool FT2Font::load_char_with_fallback(FT2Font *&ft_object_with_glyph,
 void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
 {
     FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
-    FT_Glyph thisGlyph;
-    FT_CHECK(FT_Get_Glyph, face->glyph, &thisGlyph);
-    glyphs.push_back(thisGlyph);
+    FT_Glyph glyph = nullptr;
+    FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+    GlyphPtr owned{glyph, &FT_Done_Glyph};
+    glyphs.push_back(owned.get());
+    owned.release();  // `glyphs` owns it now.
 }
 
 FT2Font::CachedGlyph const *FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
@@ -722,8 +727,7 @@ FT2Font::CachedGlyph const *FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 f
     if (glyph_error) {
         THROW_FT_ERROR("FT_Get_Glyph", glyph_error);
     }
-    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
-        glyph, &FT_Done_Glyph};
+    GlyphPtr owned{glyph, &FT_Done_Glyph};
 
     if (glyph_cache.size() >= glyph_cache_max) {
         clear_glyph_cache();
@@ -733,36 +737,33 @@ FT2Font::CachedGlyph const *FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 f
     return entry;
 }
 
-FT_Glyph FT2Font::load_glyph_copy(
-    FT_UInt glyph_index, FT_Int32 flags, FT_Fixed *linear_hori_advance)
+void FT2Font::load_glyph_copy(
+    FT_UInt glyph_index, FT_Int32 flags, GlyphPtr &glyph, FT_Fixed &linear_hori_advance)
 {
+    glyph.reset();
+    linear_hori_advance = 0;
     auto const& cached = cache_glyph(glyph_index, flags);
-    FT_Glyph glyph = nullptr;
+    FT_Glyph copy = nullptr;
     if (cached->glyph) {
-        FT_CHECK(FT_Glyph_Copy, cached->glyph, &glyph);
+        FT_CHECK(FT_Glyph_Copy, cached->glyph, &copy);
     } else {  // Not an outline, so load it the slow way.
         FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
-        FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+        FT_CHECK(FT_Get_Glyph, face->glyph, &copy);
     }
-    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
-        glyph, &FT_Done_Glyph};
+    glyph.reset(copy);
     if (cached->glyph && (glyph_delta.x || glyph_delta.y)) {
-        FT_CHECK(FT_Glyph_Transform, glyph, nullptr, &glyph_delta);
+        FT_CHECK(FT_Glyph_Transform, copy, nullptr, &glyph_delta);
     }
-    if (linear_hori_advance) {
-        *linear_hori_advance = cached->linear_hori_advance;
-    }
-    return owned.release();
+    linear_hori_advance = cached->linear_hori_advance;
 }
 
-FT_Fixed FT2Font::load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags)
+void FT2Font::load_glyph_cached(
+    FT_UInt glyph_index, FT_Int32 flags, FT_Fixed &linear_hori_advance)
 {
-    FT_Fixed linear_hori_advance = 0;
-    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
-        load_glyph_copy(glyph_index, flags, &linear_hori_advance), &FT_Done_Glyph};
-    glyphs.push_back(owned.get());
-    owned.release();  // `glyphs` owns it now.
-    return linear_hori_advance;
+    GlyphPtr glyph{nullptr, &FT_Done_Glyph};
+    load_glyph_copy(glyph_index, flags, glyph, linear_hori_advance);
+    glyphs.push_back(glyph.get());
+    glyph.release();  // `glyphs` owns it now.
 }
 
 FT_Glyph FT2Font::render_glyph(

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -181,7 +181,9 @@ FT2Font::get_path(std::vector<double> &vertices, std::vector<unsigned char> &cod
 }
 
 FT2Font::FT2Font(std::vector<FT2Font *> &fallback_list, bool warn_if_used)
-    : warn_if_used(warn_if_used), image({1, 1}), face(nullptr), fallbacks(fallback_list),
+    : warn_if_used(warn_if_used), image({1, 1}), face(nullptr),
+      char_size(0), char_dpi(0), glyph_matrix{0x10000, 0, 0, 0x10000}, glyph_delta{0, 0},
+      fallbacks(fallback_list),
       // set default kerning factor to 0, i.e., no kerning manipulation
       kerning_factor(0)
 {
@@ -216,11 +218,20 @@ void FT2Font::close()
         FT_Done_Glyph(glyph);
     }
     glyphs.clear();
+    clear_glyph_cache();
 
     if (face) {
         FT_Done_Face(face);
         face = nullptr;
     }
+}
+
+void FT2Font::clear_glyph_cache()
+{
+    for (auto & [key, glyph] : glyph_cache) {
+        FT_Done_Glyph(glyph);
+    }
+    glyph_cache.clear();
 }
 
 void FT2Font::clear()
@@ -243,11 +254,12 @@ void FT2Font::clear()
 
 void FT2Font::set_size(double ptsize, double dpi)
 {
-    FT_CHECK(
-        FT_Set_Char_Size,
-        face, (FT_F26Dot6)(ptsize * 64), 0, (FT_UInt)dpi, (FT_UInt)dpi);
-    FT_Matrix transform = { 65536, 0, 0, 65536 };
-    FT_Set_Transform(face, &transform, nullptr);
+    char_size = (FT_F26Dot6)(ptsize * 64);
+    char_dpi = (FT_UInt)dpi;
+    FT_CHECK(FT_Set_Char_Size, face, char_size, 0, char_dpi, char_dpi);
+    glyph_matrix = { 65536, 0, 0, 65536 };
+    glyph_delta = { 0, 0 };
+    FT_Set_Transform(face, &glyph_matrix, nullptr);
 
     for (auto & fallback : fallbacks) {
         fallback->set_size(ptsize, dpi);
@@ -257,9 +269,9 @@ void FT2Font::set_size(double ptsize, double dpi)
 void FT2Font::_set_transform(
     std::array<std::array<FT_Fixed, 2>, 2> matrix, std::array<FT_Fixed, 2> delta)
 {
-    FT_Matrix m = {matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1]};
-    FT_Vector d = {delta[0], delta[1]};
-    FT_Set_Transform(face, &m, &d);
+    glyph_matrix = {matrix[0][0], matrix[0][1], matrix[1][0], matrix[1][1]};
+    glyph_delta = {delta[0], delta[1]};
+    FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
     for (auto & fallback : fallbacks) {
         fallback->_set_transform(matrix, delta);
     }
@@ -645,6 +657,70 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
     FT_Glyph thisGlyph;
     FT_CHECK(FT_Get_Glyph, face->glyph, &thisGlyph);
     glyphs.push_back(thisGlyph);
+}
+
+FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
+{
+    // FreeType hints before transforming, so an outline loaded under a given
+    // matrix can be reused at every position, translating it when rasterizing.
+    auto const& key = GlyphCacheKey{
+        glyph_index, flags, char_size, char_dpi,
+        glyph_matrix.xx, glyph_matrix.xy, glyph_matrix.yx, glyph_matrix.yy};
+    if (auto const& cached = glyph_cache.find(key); cached != glyph_cache.end()) {
+        return cached->second;
+    }
+
+    // Load without the translation, so the outline sits at the origin.  The
+    // face transform is restored either way, as other methods load through it.
+    FT_Set_Transform(face, &glyph_matrix, nullptr);
+    auto const& load_error = FT_Load_Glyph(face, glyph_index, flags);
+    if (load_error) {
+        FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+        THROW_FT_ERROR("FT_Load_Glyph", load_error);
+    }
+    if (face->glyph->format != FT_GLYPH_FORMAT_OUTLINE) {
+        // Only outlines can be repositioned after loading.  A null glyph
+        // records that, and the caller loads these itself.
+        FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+        if (glyph_cache.size() >= glyph_cache_max) {
+            clear_glyph_cache();
+        }
+        return glyph_cache[key] = nullptr;
+    }
+    FT_Glyph glyph = nullptr;
+    auto const& glyph_error = FT_Get_Glyph(face->glyph, &glyph);
+    FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
+    if (glyph_error) {
+        THROW_FT_ERROR("FT_Get_Glyph", glyph_error);
+    }
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        glyph, &FT_Done_Glyph};
+
+    if (glyph_cache.size() >= glyph_cache_max) {
+        clear_glyph_cache();
+    }
+    glyph_cache[key] = glyph;
+    owned.release();  // The cache owns it now.
+    return glyph;
+}
+
+FT_Glyph FT2Font::render_glyph(
+    FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode)
+{
+    auto const& cached = cache_glyph(glyph_index, flags);
+    if (!cached) {  // Not an outline, so load and rasterize it directly.
+        FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
+        FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
+        FT_Glyph glyph = nullptr;
+        FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+        return glyph;
+    }
+
+    // With `destroy` false this translates the cached outline, rasterizes it,
+    // and translates it back.
+    FT_Glyph glyph = cached;
+    FT_CHECK(FT_Glyph_To_Bitmap, &glyph, render_mode, &glyph_delta, false);
+    return glyph;
 }
 
 FT_UInt FT2Font::get_char_index(FT_ULong charcode, bool fallback = false)

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -230,8 +230,8 @@ void FT2Font::close()
 
 void FT2Font::clear_glyph_cache()
 {
-    for (auto & [key, glyph] : glyph_cache) {
-        FT_Done_Glyph(glyph);
+    for (auto & [key, cached] : glyph_cache) {
+        FT_Done_Glyph(cached.glyph);
     }
     glyph_cache.clear();
 }
@@ -518,16 +518,7 @@ void FT2Font::set_text(
         }
 
         // extract glyph image and store it in our table
-        FT_Error error;
-        error = FT_Load_Glyph(rglyph.ftface, rglyph.index, flags);
-        if (error) {
-            throw std::runtime_error("failed to load glyph");
-        }
-        FT_Glyph thisGlyph;
-        error = FT_Get_Glyph(rglyph.ftface->glyph, &thisGlyph);
-        if (error) {
-            throw std::runtime_error("failed to get glyph");
-        }
+        auto thisGlyph = wrapped_font->load_glyph_copy(rglyph.index, flags);
 
         pen.x += rglyph.x_offset;
         pen.y += rglyph.y_offset;
@@ -694,7 +685,7 @@ void FT2Font::load_glyph(FT_UInt glyph_index, FT_Int32 flags)
     glyphs.push_back(thisGlyph);
 }
 
-FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
+FT2Font::CachedGlyph const *FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
 {
     // FreeType hints before transforming, so an outline loaded under a given
     // matrix can be reused at every position, translating it when rasterizing.
@@ -702,7 +693,7 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
         glyph_index, flags, char_size, char_dpi,
         glyph_matrix.xx, glyph_matrix.xy, glyph_matrix.yx, glyph_matrix.yy};
     if (auto const& cached = glyph_cache.find(key); cached != glyph_cache.end()) {
-        return cached->second;
+        return &cached->second;
     }
 
     // Load without the translation, so the outline sits at the origin.  The
@@ -716,14 +707,17 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
     if (face->glyph->format != FT_GLYPH_FORMAT_OUTLINE) {
         // Only outlines can be repositioned after loading.  A null glyph
         // records that, and the caller loads these itself.
+        auto const linear_hori_advance = face->glyph->linearHoriAdvance;
         FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
         if (glyph_cache.size() >= glyph_cache_max) {
             clear_glyph_cache();
         }
-        return glyph_cache[key] = nullptr;
+        return &(glyph_cache[key] = CachedGlyph{nullptr, linear_hori_advance});
     }
     FT_Glyph glyph = nullptr;
     auto const& glyph_error = FT_Get_Glyph(face->glyph, &glyph);
+    // Copied out of the glyph slot, which the next load overwrites.
+    auto const linear_hori_advance = face->glyph->linearHoriAdvance;
     FT_Set_Transform(face, &glyph_matrix, &glyph_delta);
     if (glyph_error) {
         THROW_FT_ERROR("FT_Get_Glyph", glyph_error);
@@ -734,16 +728,48 @@ FT_Glyph FT2Font::cache_glyph(FT_UInt glyph_index, FT_Int32 flags)
     if (glyph_cache.size() >= glyph_cache_max) {
         clear_glyph_cache();
     }
-    glyph_cache[key] = glyph;
+    auto const& entry = &(glyph_cache[key] = CachedGlyph{glyph, linear_hori_advance});
     owned.release();  // The cache owns it now.
-    return glyph;
+    return entry;
+}
+
+FT_Glyph FT2Font::load_glyph_copy(
+    FT_UInt glyph_index, FT_Int32 flags, FT_Fixed *linear_hori_advance)
+{
+    auto const& cached = cache_glyph(glyph_index, flags);
+    FT_Glyph glyph = nullptr;
+    if (cached->glyph) {
+        FT_CHECK(FT_Glyph_Copy, cached->glyph, &glyph);
+    } else {  // Not an outline, so load it the slow way.
+        FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
+        FT_CHECK(FT_Get_Glyph, face->glyph, &glyph);
+    }
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        glyph, &FT_Done_Glyph};
+    if (cached->glyph && (glyph_delta.x || glyph_delta.y)) {
+        FT_CHECK(FT_Glyph_Transform, glyph, nullptr, &glyph_delta);
+    }
+    if (linear_hori_advance) {
+        *linear_hori_advance = cached->linear_hori_advance;
+    }
+    return owned.release();
+}
+
+FT_Fixed FT2Font::load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags)
+{
+    FT_Fixed linear_hori_advance = 0;
+    auto owned = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>{
+        load_glyph_copy(glyph_index, flags, &linear_hori_advance), &FT_Done_Glyph};
+    glyphs.push_back(owned.get());
+    owned.release();  // `glyphs` owns it now.
+    return linear_hori_advance;
 }
 
 FT_Glyph FT2Font::render_glyph(
     FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode)
 {
     auto const& cached = cache_glyph(glyph_index, flags);
-    if (!cached) {  // Not an outline, so load and rasterize it directly.
+    if (!cached->glyph) {  // Not an outline, so load and rasterize it directly.
         FT_CHECK(FT_Load_Glyph, face, glyph_index, flags);
         FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
         FT_Glyph glyph = nullptr;
@@ -753,7 +779,7 @@ FT_Glyph FT2Font::render_glyph(
 
     // With `destroy` false this translates the cached outline, rasterizes it,
     // and translates it back.
-    FT_Glyph glyph = cached;
+    FT_Glyph glyph = cached->glyph;
     FT_CHECK(FT_Glyph_To_Bitmap, &glyph, render_mode, &glyph_delta, false);
     return glyph;
 }

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -10,6 +10,7 @@
 #include <pybind11/numpy.h>
 
 #include <map>
+#include <memory>
 #include <optional>
 #include <set>
 #include <string>
@@ -103,6 +104,7 @@ class FT2Font
   public:
     using LanguageRange = std::tuple<std::string, int, int>;
     using LanguageType = std::optional<std::vector<LanguageRange>>;
+    using GlyphPtr = std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>;
 
     FT2Font(std::vector<FT2Font *> &fallback_list, bool warn_if_used);
     virtual ~FT2Font();
@@ -134,9 +136,10 @@ class FT2Font
                                  FT_Error &glyph_error,
                                  std::set<FT_String*> &glyph_seen_fonts);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);
-    FT_Glyph load_glyph_copy(FT_UInt glyph_index, FT_Int32 flags,
-                             FT_Fixed *linear_hori_advance = nullptr);
-    FT_Fixed load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags);
+    void load_glyph_copy(FT_UInt glyph_index, FT_Int32 flags,
+                         GlyphPtr &glyph, FT_Fixed &linear_hori_advance);
+    void load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags,
+                           FT_Fixed &linear_hori_advance);
     FT_Glyph render_glyph(FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode);
     std::tuple<long, long> get_width_height();
     std::tuple<long, long> get_bitmap_offset();

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -134,6 +134,9 @@ class FT2Font
                                  FT_Error &glyph_error,
                                  std::set<FT_String*> &glyph_seen_fonts);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);
+    FT_Glyph load_glyph_copy(FT_UInt glyph_index, FT_Int32 flags,
+                             FT_Fixed *linear_hori_advance = nullptr);
+    FT_Fixed load_glyph_cached(FT_UInt glyph_index, FT_Int32 flags);
     FT_Glyph render_glyph(FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode);
     std::tuple<long, long> get_width_height();
     std::tuple<long, long> get_bitmap_offset();
@@ -186,7 +189,11 @@ class FT2Font
     using GlyphCacheKey = std::tuple<FT_UInt, FT_Int32, FT_F26Dot6, FT_UInt,
                                      FT_Fixed, FT_Fixed, FT_Fixed, FT_Fixed>;
     static constexpr size_t glyph_cache_max = 1024;
-    FT_Glyph cache_glyph(FT_UInt glyph_index, FT_Int32 flags);
+    struct CachedGlyph {
+        FT_Glyph glyph;
+        FT_Fixed linear_hori_advance;  // Unaffected by the transform.
+    };
+    CachedGlyph const *cache_glyph(FT_UInt glyph_index, FT_Int32 flags);
     void clear_glyph_cache();
 
     // The size and charmap of one face.  The charmap is a counter, as FreeType
@@ -211,7 +218,7 @@ class FT2Font
     FT_Face face;
     FT_Vector pen;    /* untransformed origin  */
     std::vector<FT_Glyph> glyphs;
-    std::map<GlyphCacheKey, FT_Glyph> glyph_cache;
+    std::map<GlyphCacheKey, CachedGlyph> glyph_cache;
     FT_F26Dot6 char_size;
     FT_UInt char_dpi;
     FT_Matrix glyph_matrix;

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -9,6 +9,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
 
+#include <map>
 #include <optional>
 #include <set>
 #include <string>
@@ -133,6 +134,7 @@ class FT2Font
                                  FT_Error &glyph_error,
                                  std::set<FT_String*> &glyph_seen_fonts);
     void load_glyph(FT_UInt glyph_index, FT_Int32 flags);
+    FT_Glyph render_glyph(FT_UInt glyph_index, FT_Int32 flags, FT_Render_Mode render_mode);
     std::tuple<long, long> get_width_height();
     std::tuple<long, long> get_bitmap_offset();
     long get_descent();
@@ -179,11 +181,24 @@ class FT2Font
   protected:
     virtual void ft_glyph_warn(FT_ULong charcode, std::set<FT_String*> family_names) = 0;
   private:
+    // Everything affecting a loaded outline, but not the translation, which is
+    // applied when rasterizing.
+    using GlyphCacheKey = std::tuple<FT_UInt, FT_Int32, FT_F26Dot6, FT_UInt,
+                                     FT_Fixed, FT_Fixed, FT_Fixed, FT_Fixed>;
+    static constexpr size_t glyph_cache_max = 1024;
+    FT_Glyph cache_glyph(FT_UInt glyph_index, FT_Int32 flags);
+    void clear_glyph_cache();
+
     bool warn_if_used;
     py::array_t<uint8_t, py::array::c_style> image;
     FT_Face face;
     FT_Vector pen;    /* untransformed origin  */
     std::vector<FT_Glyph> glyphs;
+    std::map<GlyphCacheKey, FT_Glyph> glyph_cache;
+    FT_F26Dot6 char_size;
+    FT_UInt char_dpi;
+    FT_Matrix glyph_matrix;
+    FT_Vector glyph_delta;
     std::vector<FT2Font *> fallbacks;
     std::unordered_map<long, FT2Font *> char_to_font;
     FT_BBox bbox;

--- a/src/ft2font.h
+++ b/src/ft2font.h
@@ -189,6 +189,23 @@ class FT2Font
     FT_Glyph cache_glyph(FT_UInt glyph_index, FT_Int32 flags);
     void clear_glyph_cache();
 
+    // The size and charmap of one face.  The charmap is a counter, as FreeType
+    // offers no cheap way to identify the selected one.
+    using FaceState = std::tuple<FT_F26Dot6, FT_UInt, unsigned long>;
+    std::vector<FaceState> shaping_state() const;
+
+    // Everything that affects the shaped output of layout().
+    using LayoutCacheKey = std::tuple<std::u32string, FT_Int32,
+                                      std::optional<std::vector<std::string>>,
+                                      LanguageType, std::vector<FaceState>,
+                                      FT_Fixed, FT_Fixed, FT_Fixed, FT_Fixed>;
+    struct LayoutCacheEntry {
+        std::vector<raqm_glyph_t> glyphs;
+        std::set<FT_String *> seen_fonts;
+    };
+    static constexpr size_t layout_cache_max = 256;
+    std::map<LayoutCacheKey, LayoutCacheEntry> layout_cache;
+
     bool warn_if_used;
     py::array_t<uint8_t, py::array::c_style> image;
     FT_Face face;
@@ -199,6 +216,7 @@ class FT2Font
     FT_UInt char_dpi;
     FT_Matrix glyph_matrix;
     FT_Vector glyph_delta;
+    unsigned long charmap_generation;
     std::vector<FT2Font *> fallbacks;
     std::unordered_map<long, FT2Font *> char_to_font;
     FT_BBox bbox;

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1371,7 +1371,9 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
     for (auto &glyph : glyphs) {
         auto ft_object = static_cast<PyFT2Font *>(glyph.ftface->generic.data);
 
-        ft_object->load_glyph(glyph.index, load_flags);
+        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
+        auto const& linear_hori_advance =
+            ft_object->load_glyph_cached(glyph.index, load_flags) / 1024.0;
 
         double prev_kern = 0.0;
         if (prev_advance) {
@@ -1389,8 +1391,7 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
         prev_x = x + glyph.x_offset;
         x += glyph.x_advance;
         y += glyph.y_advance;
-        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
-        prev_advance = ft_object->get_face()->glyph->linearHoriAdvance / 1024.0;
+        prev_advance = linear_hori_advance;
     }
 
     return items;

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1750,10 +1750,13 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
             [ft2Library](PyFT2Font *self, FT_UInt idx, LoadFlags flags,
                          FT_Render_Mode render_mode)
             {
-                auto face = self->get_face();
-                FT_CHECK(FT_Load_Glyph, face, idx, static_cast<FT_Int32>(flags));
-                FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
-                return PyPositionedBitmap{ft2Library, face->glyph};
+                auto const& glyph =
+                    std::unique_ptr<std::remove_pointer_t<FT_Glyph>,
+                                    decltype(&FT_Done_Glyph)>(
+                        self->render_glyph(idx, static_cast<FT_Int32>(flags), render_mode),
+                        &FT_Done_Glyph);
+                return PyPositionedBitmap{
+                    ft2Library, reinterpret_cast<FT_BitmapGlyph>(glyph.get())};
             })
         ;
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -9,9 +9,14 @@
 
 #include "ft2font.h"
 
+#include <cmath>
 #include <set>
 #include <sstream>
 #include <unordered_map>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338328
+#endif
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -1397,6 +1402,120 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
     return items;
 }
 
+const char *PyFT2Font_render_glyph_run__doc__ = R"""(
+    Render a run of glyphs, packed for a single blit by the renderer.
+
+    Every glyph in the run is positioned and rasterized here, so that drawing
+    text does not cross into Python once per glyph.
+
+    Parameters
+    ----------
+    glyphs : list of (FT2Font, float, int, float, float, float, float)
+        The font, size, glyph index, slant, extend and offsets of each glyph,
+        as produced by `.FT2Font._layout` or the mathtext parser.
+    dpi : float
+        The resolution to size the fonts at.
+    x, y : float
+        Where to place the run.  *y* is downwards.
+    angle : float
+        The rotation of the run, in degrees.
+    height : float
+        The height of the target canvas, as *y* is measured from its top.
+    flags : LoadFlags
+        The flags to load the glyphs with.
+    render_mode : RenderMode
+        The mode to rasterize the glyphs with.
+
+    Returns
+    -------
+    buffer : np.ndarray of uint8
+        The coverage bitmaps of every glyph, packed end to end.
+    positions : np.ndarray of int
+        One row per glyph, holding its offset into *buffer*, its number of rows
+        and columns, and the x and y to blit it at.
+)""";
+
+static py::tuple
+PyFT2Font_render_glyph_run(
+    FT_Library ft2Library, py::sequence glyphs, double dpi, double x, double y,
+    double angle, double height, LoadFlags flags, FT_Render_Mode render_mode)
+{
+    auto load_flags = static_cast<FT_Int32>(flags);
+    auto cos = std::cos(angle * (M_PI / 180.0));
+    auto sin = std::sin(angle * (M_PI / 180.0));
+    auto round = [](double value) { return (FT_Fixed)std::nearbyint(value); };
+
+    auto done_bitmap = [ft2Library](FT_Bitmap *b) { FT_Bitmap_Done(ft2Library, b); };
+
+    std::vector<uint8_t> buffer;
+    std::vector<py::ssize_t> positions;
+    PyFT2Font *sized_font = nullptr;
+    double sized_size = 0;
+
+    for (auto const& item : glyphs) {
+        auto const& glyph = item.cast<py::tuple>();
+        auto font = glyph[0].cast<PyFT2Font *>();
+        auto const& size = glyph[1].cast<double>();
+        auto const& glyph_index = glyph[2].cast<FT_UInt>();
+        auto const& slant = glyph[3].cast<double>();
+        auto const& extend = glyph[4].cast<double>();
+        auto const& dx = glyph[5].cast<double>();
+        auto const& dy = glyph[6].cast<double>();  // Upwards.
+
+        // set_size recurses into the fallbacks, so only call it on a change.
+        if (font != sized_font || size != sized_size) {
+            font->set_size(size, dpi);
+            sized_font = font;
+            sized_size = size;
+        }
+        font->_set_transform(
+            {{{round(0x10000 * extend * cos),
+               round(0x10000 * (extend * slant * cos - sin))},
+              {round(0x10000 * extend * sin),
+               round(0x10000 * (extend * slant * sin + cos))}}},
+            {round(0x40 * (x + dx * cos - dy * sin)),
+             // FreeType's y is upwards.
+             round(0x40 * (height - y + dx * sin + dy * cos))});
+
+        auto rendered =
+            std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>(
+                font->render_glyph(glyph_index, load_flags, render_mode), &FT_Done_Glyph);
+        auto bitmap_glyph = reinterpret_cast<FT_BitmapGlyph>(rendered.get());
+        FT_Bitmap bitmap;
+        FT_Bitmap_Init(&bitmap);
+        std::unique_ptr<FT_Bitmap, decltype(done_bitmap)> converted{&bitmap, done_bitmap};
+        FT_CHECK(FT_Bitmap_Convert, ft2Library, &bitmap_glyph->bitmap, &bitmap, 1);
+        auto rows = static_cast<py::ssize_t>(bitmap.rows);
+        auto cols = static_cast<py::ssize_t>(bitmap.width);
+
+        positions.push_back(static_cast<py::ssize_t>(buffer.size()));
+        positions.push_back(rows);
+        positions.push_back(cols);
+        positions.push_back(bitmap_glyph->left);
+        positions.push_back(static_cast<py::ssize_t>(height) - bitmap_glyph->top + rows);
+        for (auto row = 0; row < rows; row++) {
+            auto start = bitmap.buffer + row * bitmap.pitch;
+            buffer.insert(buffer.end(), start, start + cols);
+        }
+        if (render_mode == FT_RENDER_MODE_MONO) {
+            // Monochrome bitmaps convert to 0 and 1, but are blitted as coverage.
+            for (auto i = buffer.size() - rows * cols; i < buffer.size(); i++) {
+                buffer[i] *= 0xff;
+            }
+        }
+    }
+
+    auto n = static_cast<py::ssize_t>(positions.size() / 5);
+    return py::make_tuple(
+        py::array_t<uint8_t>{static_cast<py::ssize_t>(buffer.size()), buffer.data()},
+        py::array_t<py::ssize_t>{{n, static_cast<py::ssize_t>(5)}, positions.data()});
+}
+
+/**********************************************************************
+ * Deprecations
+ * */
+
+
 #ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 PYBIND11_MODULE(ft2font, m,
                 py::mod_gil_not_used(), py::multiple_interpreters::per_interpreter_gil())
@@ -1760,6 +1879,15 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
                     ft2Library, reinterpret_cast<FT_BitmapGlyph>(glyph.get())};
             })
         ;
+
+    m.def("_render_glyph_run",
+          [ft2Library](py::sequence glyphs, double dpi, double x, double y, double angle,
+                       double height, LoadFlags flags, FT_Render_Mode render_mode) {
+              return PyFT2Font_render_glyph_run(ft2Library, glyphs, dpi, x, y, angle,
+                                                height, flags, render_mode);
+          },
+          "glyphs"_a, "dpi"_a, "x"_a, "y"_a, "angle"_a, "height"_a, "flags"_a,
+          "render_mode"_a, PyFT2Font_render_glyph_run__doc__);
 
     // Ensure FreeType library is closed after all instances of FT2Font are gone by
     // tying a weak ref to the class itself.

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1785,10 +1785,13 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
             [ft2Library](PyFT2Font *self, FT_UInt idx, LoadFlags flags,
                          FT_Render_Mode render_mode)
             {
-                auto face = self->get_face();
-                FT_CHECK(FT_Load_Glyph, face, idx, static_cast<FT_Int32>(flags));
-                FT_CHECK(FT_Render_Glyph, face->glyph, render_mode);
-                return PyPositionedBitmap{ft2Library, face->glyph};
+                auto const& glyph =
+                    std::unique_ptr<std::remove_pointer_t<FT_Glyph>,
+                                    decltype(&FT_Done_Glyph)>(
+                        self->render_glyph(idx, static_cast<FT_Int32>(flags), render_mode),
+                        &FT_Done_Glyph);
+                return PyPositionedBitmap{
+                    ft2Library, reinterpret_cast<FT_BitmapGlyph>(glyph.get())};
             })
         ;
 

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -10,9 +10,14 @@
 #include "ft2font.h"
 #include "mplutils.h"
 
+#include <cmath>
 #include <set>
 #include <sstream>
 #include <unordered_map>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846264338328
+#endif
 
 namespace py = pybind11;
 using namespace pybind11::literals;
@@ -1432,6 +1437,120 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
     return items;
 }
 
+const char *PyFT2Font_render_glyph_run__doc__ = R"""(
+    Render a run of glyphs, packed for a single blit by the renderer.
+
+    Every glyph in the run is positioned and rasterized here, so that drawing
+    text does not cross into Python once per glyph.
+
+    Parameters
+    ----------
+    glyphs : list of (FT2Font, float, int, float, float, float, float)
+        The font, size, glyph index, slant, extend and offsets of each glyph,
+        as produced by `.FT2Font._layout` or the mathtext parser.
+    dpi : float
+        The resolution to size the fonts at.
+    x, y : float
+        Where to place the run.  *y* is downwards.
+    angle : float
+        The rotation of the run, in degrees.
+    height : float
+        The height of the target canvas, as *y* is measured from its top.
+    flags : LoadFlags
+        The flags to load the glyphs with.
+    render_mode : RenderMode
+        The mode to rasterize the glyphs with.
+
+    Returns
+    -------
+    buffer : np.ndarray of uint8
+        The coverage bitmaps of every glyph, packed end to end.
+    positions : np.ndarray of int
+        One row per glyph, holding its offset into *buffer*, its number of rows
+        and columns, and the x and y to blit it at.
+)""";
+
+static py::tuple
+PyFT2Font_render_glyph_run(
+    FT_Library ft2Library, py::sequence glyphs, double dpi, double x, double y,
+    double angle, double height, LoadFlags flags, FT_Render_Mode render_mode)
+{
+    auto load_flags = static_cast<FT_Int32>(flags);
+    auto cos = std::cos(angle * (M_PI / 180.0));
+    auto sin = std::sin(angle * (M_PI / 180.0));
+    auto round = [](double value) { return (FT_Fixed)std::nearbyint(value); };
+
+    auto done_bitmap = [ft2Library](FT_Bitmap *b) { FT_Bitmap_Done(ft2Library, b); };
+
+    std::vector<uint8_t> buffer;
+    std::vector<py::ssize_t> positions;
+    PyFT2Font *sized_font = nullptr;
+    double sized_size = 0;
+
+    for (auto const& item : glyphs) {
+        auto const& glyph = item.cast<py::tuple>();
+        auto font = glyph[0].cast<PyFT2Font *>();
+        auto const& size = glyph[1].cast<double>();
+        auto const& glyph_index = glyph[2].cast<FT_UInt>();
+        auto const& slant = glyph[3].cast<double>();
+        auto const& extend = glyph[4].cast<double>();
+        auto const& dx = glyph[5].cast<double>();
+        auto const& dy = glyph[6].cast<double>();  // Upwards.
+
+        // set_size recurses into the fallbacks, so only call it on a change.
+        if (font != sized_font || size != sized_size) {
+            font->set_size(size, dpi);
+            sized_font = font;
+            sized_size = size;
+        }
+        font->_set_transform(
+            {{{round(0x10000 * extend * cos),
+               round(0x10000 * (extend * slant * cos - sin))},
+              {round(0x10000 * extend * sin),
+               round(0x10000 * (extend * slant * sin + cos))}}},
+            {round(0x40 * (x + dx * cos - dy * sin)),
+             // FreeType's y is upwards.
+             round(0x40 * (height - y + dx * sin + dy * cos))});
+
+        auto rendered =
+            std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>(
+                font->render_glyph(glyph_index, load_flags, render_mode), &FT_Done_Glyph);
+        auto bitmap_glyph = reinterpret_cast<FT_BitmapGlyph>(rendered.get());
+        FT_Bitmap bitmap;
+        FT_Bitmap_Init(&bitmap);
+        std::unique_ptr<FT_Bitmap, decltype(done_bitmap)> converted{&bitmap, done_bitmap};
+        FT_CHECK(FT_Bitmap_Convert, ft2Library, &bitmap_glyph->bitmap, &bitmap, 1);
+        auto rows = static_cast<py::ssize_t>(bitmap.rows);
+        auto cols = static_cast<py::ssize_t>(bitmap.width);
+
+        positions.push_back(static_cast<py::ssize_t>(buffer.size()));
+        positions.push_back(rows);
+        positions.push_back(cols);
+        positions.push_back(bitmap_glyph->left);
+        positions.push_back(static_cast<py::ssize_t>(height) - bitmap_glyph->top + rows);
+        for (auto row = 0; row < rows; row++) {
+            auto start = bitmap.buffer + row * bitmap.pitch;
+            buffer.insert(buffer.end(), start, start + cols);
+        }
+        if (render_mode == FT_RENDER_MODE_MONO) {
+            // Monochrome bitmaps convert to 0 and 1, but are blitted as coverage.
+            for (auto i = buffer.size() - rows * cols; i < buffer.size(); i++) {
+                buffer[i] *= 0xff;
+            }
+        }
+    }
+
+    auto n = static_cast<py::ssize_t>(positions.size() / 5);
+    return py::make_tuple(
+        py::array_t<uint8_t>{static_cast<py::ssize_t>(buffer.size()), buffer.data()},
+        py::array_t<py::ssize_t>{{n, static_cast<py::ssize_t>(5)}, positions.data()});
+}
+
+/**********************************************************************
+ * Deprecations
+ * */
+
+
 #ifdef PYBIND11_HAS_SUBINTERPRETER_SUPPORT
 PYBIND11_MODULE(ft2font, m,
                 py::mod_gil_not_used(), py::multiple_interpreters::per_interpreter_gil())
@@ -1795,6 +1914,15 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
                     ft2Library, reinterpret_cast<FT_BitmapGlyph>(glyph.get())};
             })
         ;
+
+    m.def("_render_glyph_run",
+          [ft2Library](py::sequence glyphs, double dpi, double x, double y, double angle,
+                       double height, LoadFlags flags, FT_Render_Mode render_mode) {
+              return PyFT2Font_render_glyph_run(ft2Library, glyphs, dpi, x, y, angle,
+                                                height, flags, render_mode);
+          },
+          "glyphs"_a, "dpi"_a, "x"_a, "y"_a, "angle"_a, "height"_a, "flags"_a,
+          "render_mode"_a, PyFT2Font_render_glyph_run__doc__);
 
     // Ensure FreeType library is closed after all instances of FT2Font are gone by
     // tying a weak ref to the class itself.

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1411,9 +1411,8 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
     for (auto &glyph : glyphs) {
         auto ft_object = static_cast<PyFT2Font *>(glyph.ftface->generic.data);
 
-        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
-        auto const& linear_hori_advance =
-            ft_object->load_glyph_cached(glyph.index, load_flags) / 1024.0;
+        FT_Fixed linear_hori_advance = 0;
+        ft_object->load_glyph_cached(glyph.index, load_flags, linear_hori_advance);
 
         double prev_kern = 0.0;
         if (prev_advance) {
@@ -1431,7 +1430,8 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
         prev_x = x + glyph.x_offset;
         x += glyph.x_advance;
         y += glyph.y_advance;
-        prev_advance = linear_hori_advance;
+        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
+        prev_advance = linear_hori_advance / 1024.0;
     }
 
     return items;
@@ -1512,9 +1512,8 @@ PyFT2Font_render_glyph_run(
              // FreeType's y is upwards.
              round(0x40 * (height - y + dx * sin + dy * cos))});
 
-        auto rendered =
-            std::unique_ptr<std::remove_pointer_t<FT_Glyph>, decltype(&FT_Done_Glyph)>(
-                font->render_glyph(glyph_index, load_flags, render_mode), &FT_Done_Glyph);
+        FT2Font::GlyphPtr rendered{
+            font->render_glyph(glyph_index, load_flags, render_mode), &FT_Done_Glyph};
         auto bitmap_glyph = reinterpret_cast<FT_BitmapGlyph>(rendered.get());
         FT_Bitmap bitmap;
         FT_Bitmap_Init(&bitmap);
@@ -1905,11 +1904,9 @@ PYBIND11_MODULE(ft2font, m, py::mod_gil_not_used())
             [ft2Library](PyFT2Font *self, FT_UInt idx, LoadFlags flags,
                          FT_Render_Mode render_mode)
             {
-                auto const& glyph =
-                    std::unique_ptr<std::remove_pointer_t<FT_Glyph>,
-                                    decltype(&FT_Done_Glyph)>(
-                        self->render_glyph(idx, static_cast<FT_Int32>(flags), render_mode),
-                        &FT_Done_Glyph);
+                FT2Font::GlyphPtr glyph{
+                    self->render_glyph(idx, static_cast<FT_Int32>(flags), render_mode),
+                    &FT_Done_Glyph};
                 return PyPositionedBitmap{
                     ft2Library, reinterpret_cast<FT_BitmapGlyph>(glyph.get())};
             })

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -1406,7 +1406,9 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
     for (auto &glyph : glyphs) {
         auto ft_object = static_cast<PyFT2Font *>(glyph.ftface->generic.data);
 
-        ft_object->load_glyph(glyph.index, load_flags);
+        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
+        auto const& linear_hori_advance =
+            ft_object->load_glyph_cached(glyph.index, load_flags) / 1024.0;
 
         double prev_kern = 0.0;
         if (prev_advance) {
@@ -1424,8 +1426,7 @@ PyFT2Font_layout(PyFT2Font *self, std::u32string text, LoadFlags flags,
         prev_x = x + glyph.x_offset;
         x += glyph.x_advance;
         y += glyph.y_advance;
-        // Note, linearHoriAdvance is a 16.16 instead of 26.6 fixed-point value.
-        prev_advance = ft_object->get_face()->glyph->linearHoriAdvance / 1024.0;
+        prev_advance = linear_hori_advance;
     }
 
     return items;


### PR DESCRIPTION
## PR summary
Inspired by https://github.com/matplotlib/matplotlib/pull/32064, I dug into text rendering to try and see what we could speed up. Through a combination of caching, lazy loading, and combining runs of glyphs into a single rasterization pass, total figure draw time on my simple demo script below is sped up by 2.4x. This is separate from (and stacks on top of) the improvements in https://github.com/matplotlib/matplotlib/pull/32064. Beyond the immediate rendering, text is also handled in figure/subplot layout, so there are speedups across the entire call tree.

This is a big diff and stacked PRs aren't available yet, so is probably easiest to review by commit. Each is self contained, and here is a table describing them:

| # | Commit | Incremental Speedup | Total Speedup | Description |
|---|--------|----------|---------|-------------|
| 1 | [`d002b6c8b5`](https://github.com/matplotlib/matplotlib/commit/d002b6c8b5e0219df0e8b19825ef08c2676024eb) | 1.13x | 1.13x | Avoid per-glyph numpy overhead and repeated calcs. |
| 2 | [`93436b4048`](https://github.com/matplotlib/matplotlib/commit/93436b404831b2560c0a45b2e20fde03f728cf64) | 1.18x | 1.33x | Depending on the font, the hinting that snaps outlines to the pixel grid can cost more than rendering them. This caches the loaded outline to avoid that cost, keyed on everything except the translation, so a repeated glyph is only hinted once. |
| 3 | [`681b265ea1`](https://github.com/matplotlib/matplotlib/commit/681b265ea11e950ce313ef1f99452a6f899f3f4f) | 1.14x | 1.52x | Cache shaped layouts (bidirectional ordering and shaping). The key with `shaping_state()` is more complex here, as the result depends on the state of this face and of every fallback face it may shape with. |
| 4 | [`0587aa44b9`](https://github.com/matplotlib/matplotlib/commit/0587aa44b9a192c34167eb5ede0152c7bd4131fd) | 1.26x | 1.91x | Kerning was reloading every glyph and re-running the hinter. But we already calculated the advance width, so take that from the glyph cache instead. Same thing for measuring text, which now uses the outlines from the cache. This drops per-glyph hinting passes from 3x to 1x. |
| 5 | [`33c40f64c9`](https://github.com/matplotlib/matplotlib/commit/33c40f64c9e3207316f5a383bcc092975cc2e932) | 1.16x (svg), 1.21x (pdf) | - | Lazily load glyphs when saving figures, which skips loads on the vector (svg and pdf) backends which don't need it for `get_path()`. |
| 6 | [`51d14736da`](https://github.com/matplotlib/matplotlib/commit/51d14736dac52a38afd2fe81ce4d59ea85a68fdc) | 1.15x | 2.19x | Position and rasterize a run of glyphs in one call, then blit it in one call. Agg only right now. Avoids per-glyph Python/C++ boundary crossings. |
| 7 | [`e133bf037c`](https://github.com/matplotlib/matplotlib/commit/e133bf037c824b3a96dade1e69b7790cd14af784) | 1.11x | 2.44x | Cache the font height metrics used by `Text._get_layout`. |
| 8 |  | - | 2.44x | Code review updates |

**Before** (4.03 sec draw):
<img width="2557" height="610" alt="image" src="https://github.com/user-attachments/assets/475e4673-a235-4bf4-9fe3-22dba7eea86b" />


**After** (1.86 sec draw):
<img width="2557" height="812" alt="image" src="https://github.com/user-attachments/assets/110e7f9b-d9c2-4306-aa48-6e524901d553" />


**Benchmark script**:
```python
import statistics
import time
import matplotlib.pyplot as plt

fig, ax = plt.subplots(figsize=(8, 6), dpi=100)

# Simple plot with several types of text
ax.plot([1, 2, 3], [1, 4, 2], label="series one")
ax.set_title("Rendering a title with plenty of glyphs")
ax.set_xlabel("x axis label")
ax.set_ylabel("y axis label")
ax.legend()

for i, text in enumerate(["one", "two", "three", "four"]):
    ax.text(1, 1 + i * 0.5, "annotation" + text)
ax.text(2, 3, "rotated annotation", rotation=45)

fig.canvas.draw()  # warm the cache

times = []
for _ in range(50):
    start = time.process_time()
    fig.canvas.draw()
    times.append(time.process_time() - start)

print(f"draw: median={statistics.median(times) * 1e3:.2f} ms  "
      f"min={min(times) * 1e3:.2f} ms")
```

## AI Disclosure
Lots of help from claude on the first pass for this one. I spent several hours reviewing and polishing its draft, and am confident in each of the changes. What I am less confident on is potential corner cases of the text rendering pipeline that I'm unfamiliar with, so would appreciate @QuLogic to take a look through this when he has the time.

## PR checklist
- [n/a] "closes #0000" is in the body of the PR description to [link the related issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue)
- [x] new and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] *Plotting related* features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] *New Features* and *API Changes* are noted with a [directive and release note](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines