### PR TITLE
Fix Line3D.draw requiring .shape on array-like coordinates

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -358,9 +358,12 @@ class Line3D(lines.Line2D):
         if self._axlim_clip:
             scale_mask |= _viewlim_mask(*self._verts3d, self.axes)
         if np.any(scale_mask):
+            # np.shape rather than .shape: set_data_3d documents its
+            # parameters as array-like and stores whatever it is given, so
+            # _verts3d can hold lists.
             mask = np.broadcast_to(
                 scale_mask,
-                (len(self._verts3d), *self._verts3d[0].shape)
+                (len(self._verts3d), *np.shape(self._verts3d[0]))
             )
             xs3d, ys3d, zs3d = np.ma.array(self._verts3d,
                                            dtype=float, mask=mask).filled(np.nan)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -360,7 +360,7 @@ class Line3D(lines.Line2D):
         if np.any(scale_mask):
             # np.shape rather than .shape: set_data_3d documents its
             # parameters as array-like and stores whatever it is given, so
-            # _verts3d can hold lists.
+            # _verts3d can hold lists or tuples.
             mask = np.broadcast_to(
                 scale_mask,
                 (len(self._verts3d), *np.shape(self._verts3d[0]))

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -13,6 +13,20 @@ from mpl_toolkits.mplot3d.art3d import (
 )
 
 
+def test_line3d_draws_array_like_coordinates():
+    # set_data_3d documents its parameters as array-like and stores whatever it
+    # is given, so _verts3d can hold lists. Drawing must not require an ndarray.
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="3d")
+    line, = ax.plot([0.], [0.], [0.])
+
+    line.set_data_3d([np.nan], [np.nan], [np.nan])
+
+    # Only a coordinate that is invalid for the scale reaches the masking
+    # branch, which is why this needs the non-finite value above.
+    fig.canvas.draw()
+
+
 @pytest.mark.parametrize("zdir, expected", [
     ("x", (1, 0, 0)),
     ("y", (0, 1, 0)),

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -13,17 +13,38 @@ from mpl_toolkits.mplot3d.art3d import (
 )
 
 
-def test_line3d_draws_array_like_coordinates():
+@pytest.mark.parametrize("container", [list, tuple])
+@pytest.mark.parametrize("case", ["nan", "inf", "log_domain", "axlim_clip", "one_of_many"])
+def test_line3d_draws_array_like_coordinates(container, case):
     # set_data_3d documents its parameters as array-like and stores whatever it
-    # is given, so _verts3d can hold lists. Drawing must not require an ndarray.
+    # is given, so _verts3d can hold lists or tuples. Drawing must not require
+    # an ndarray.
+    #
+    # The masking branch that reads a shape is entered when a coordinate is
+    # non-finite, outside the active scale's domain, or outside the view limits
+    # with axlim_clip enabled, so each of those is a way in.
     fig = plt.figure()
     ax = fig.add_subplot(projection="3d")
-    line, = ax.plot([0.], [0.], [0.])
+    line, = ax.plot([1.], [1.], [1.],
+                    axlim_clip=(case == "axlim_clip"))
 
-    line.set_data_3d([np.nan], [np.nan], [np.nan])
+    if case == "nan":
+        xs, ys, zs = [np.nan], [1.], [1.]
+    elif case == "inf":
+        xs, ys, zs = [np.inf], [1.], [1.]
+    elif case == "log_domain":
+        # Finite, and invalid only because of the scale.
+        ax.set_xscale("log")
+        xs, ys, zs = [0.], [1.], [1.]
+    elif case == "axlim_clip":
+        # Finite and valid for the scale; masked for being out of view.
+        xs, ys, zs = [1e6], [1e6], [1e6]
+    else:
+        # A line where only one vertex is masked.
+        xs, ys, zs = [1., np.nan], [1., 2.], [1., 2.]
 
-    # Only a coordinate that is invalid for the scale reaches the masking
-    # branch, which is why this needs the non-finite value above.
+    line.set_data_3d(container(xs), container(ys), container(zs))
+
     fig.canvas.draw()
 
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -14,7 +14,8 @@ from mpl_toolkits.mplot3d.art3d import (
 
 
 @pytest.mark.parametrize("container", [list, tuple])
-@pytest.mark.parametrize("case", ["nan", "inf", "log_domain", "axlim_clip", "one_of_many"])
+@pytest.mark.parametrize(
+    "case", ["nan", "inf", "log_domain", "axlim_clip", "one_of_many"])
 def test_line3d_draws_array_like_coordinates(container, case):
     # set_data_3d documents its parameters as array-like and stores whatever it
     # is given, so _verts3d can hold lists or tuples. Drawing must not require


### PR DESCRIPTION
## PR summary

Closes #32127.

`Line3D.set_data_3d` documents its parameters as `array-like`, checks only that each argument is iterable, and stores them as given:

```python
for name, xyz in zip('xyz', args):
    if not np.iterable(xyz):
        raise RuntimeError(f'{name} must be a sequence')
self._verts3d = args
```

`draw` then read `self._verts3d[0].shape`, so a list raised `AttributeError: 'list' object has no attribute 'shape'`.

```python
fig = plt.figure()
ax = fig.add_subplot(projection="3d")
(line,) = ax.plot([0.0], [0.0], [0.0])
line.set_data_3d([float("nan")], [float("nan")], [float("nan")])
fig.canvas.draw()
```

The access lives inside the invalid-scale masking branch, so a finite list draws and only an invalid coordinate reaches it. That is why it went unnoticed.

The requirement arrived in two steps. d18c52bc9 introduced `_verts3d[0].shape` behind `if self._axlim_clip:`, so it applied only to lines that had opted into clipping. 629d39670 then added `_scale_invalid_mask`, which runs unconditionally, and changed the guard to `if np.any(scale_mask):`. Nothing about `set_data_3d` changed; the block consuming what it stores did. 3.10.9 has neither and draws all of these.

NaN is not the only trigger. On 3.11.1 with lists in `_verts3d`, `AttributeError` also comes from `inf`, from a value `<= 0` on a log scale, and from an out-of-view point with `axlim_clip=True`. Tuples fail the same way. The log-scale row is the awkward one: `_scale_invalid_mask` was added so that data outside a scale's valid domain is ignored rather than breaking the plot, and here it raises instead.

`np.shape` accepts both, and unlike converting in the setter it leaves what `get_data_3d()` returns unchanged, so a caller that reads back what it passed still gets it.

## PR checklist

- [x] Has pytest style unit tests, and `pytest` passes
- [x] New features are documented, with examples if plot related — n/a, this is a bug fix with no API change
- [x] Documentation is sphinx and numpydoc compliant — n/a
- [x] Added an entry to `doc/users/next_whats_new/` if major new feature — n/a
- [x] Documented in `doc/api/next_api_changes/` if API changed — no API change; this makes the documented contract hold

## Verification

Against a released 3.11.1 with only `art3d.py` replaced, so the comparison is like for like:

| | new test | full `test_art3d.py` |
|---|---|---|
| 3.11.1 as released | 1 failed | — |
| with this change | 1 passed | 11 passed |

## Note on a sibling occurrence

`Path3DCollection.do_3d_projection` has the same pattern one screen down:

```python
mask = np.broadcast_to(mask, (len(self._offsets3d), *self._offsets3d[0].shape))
```

I left it alone. `_offsets3d` is private and its public writer routes through `juggle_axes(xs, ys, np.atleast_1d(zs), zdir)` with `xs, ys` coming from `get_offsets()`, so it holds arrays; `ax.scatter` with a NaN draws fine. Assigning `_offsets3d` a tuple of lists directly does reproduce the same error, so it is the same defect, just not one reachable through public API. Happy to include it here if you would rather the two were consistent.

I checked the other users of `_scale_invalid_mask` and `_viewlim_mask` the same way, driving each through its public entry point with list input and a triggering coordinate: `Line3DCollection`, `Poly3DCollection`, `ax.scatter`, `ax.text`, `plot_surface` and `ax.plot` all draw, because each converts to arrays on the way in. The two `Line3D` setters are the exception, and they are the documented way to update an existing 3D line in place. Details in #32127.

## How this was found

Downstream code updating a rocket marker each frame, written against the advice in #22308 to use `set_data([a], [b])` and `set_3d_properties([c])`. That produces exactly this state, and it drew on 3.10 and raised on 3.11 the moment a coordinate went non-finite, which happens before the object being plotted has a position.




---

## Update: the test was covering one way in, of three

`set_data_3d` with a list of NaN on a linear scale was the only case. The masking branch is entered when a coordinate is non-finite, when it is outside the active scale's domain, or when it is outside the view limits with `axlim_clip` enabled. The last two need no non-finite value at all: `0.0` on a log axis reaches it, and so does a finite in-domain point that is simply off screen. My first commit message said only a non-finite coordinate could get there, which was wrong.

Parametrized over `list` and `tuple`, and over five ways in: NaN, inf, a finite value outside a log domain, a finite value masked by `axlim_clip`, and a multi-vertex line where only one vertex is masked.

| against released 3.11.1, `art3d.py` only | result |
|---|---|
| before this change | 10 failed |
| after | 10 passed |
| rest of `test_art3d.py` | 20 passed |

## Backport

3.11.1 is affected, so this wants a `v3.11.x` backport once it lands. Flagging rather than labelling, since I cannot set milestones.

## Two findings from the same audit, filed separately

Neither belongs in this PR, and neither blocks it.

**#32129** is the one I would look at next. `ScaleBase.val_in_range` calls `limit_range_for_scale` with an array, and when a third-party scale is written for scalars, which is the shape `LogScale.limit_range_for_scale` itself uses, the `except (TypeError, ValueError)` fallback returns "nothing is in range". `_scale_invalid_mask` negates that, so every point on the axis is masked and every 3D artist silently disappears with ordinary finite data. Measured: line 0/4 and scatter 0/4 finite points after projection, no warning, no exception. Silent deletion seems worse than the crash this PR fixes.

`Line3D.set_data_3d` also accepts two or four coordinate sequences, because `zip('xyz', args)` truncates silently. The failure then surfaces at draw time as `TypeError: _scale_invalid_mask() missing 1 required positional argument`, which names an internal function at the user. Pre-existing and unrelated to the masking change; I have not filed it separately, and can if it is wanted.
