### PR TITLE
DOC: update documented font weight options

### DIFF
--- a/galleries/users_explain/text/text_props.py
+++ b/galleries/users_explain/text/text_props.py
@@ -41,7 +41,9 @@ transform                   `~matplotlib.transforms.Transform` subclass
 variant                     [ ``'normal'`` | ``'small-caps'`` ]
 verticalalignment or va     [ ``'center'`` | ``'top'`` | ``'bottom'`` | ``'baseline'`` ]
 visible                     bool
-weight or fontweight        [ ``'normal'`` | ``'bold'`` | ``'heavy'`` | ``'light'`` | ``'ultrabold'`` | ``'ultralight'``]
+weight or fontweight        [ numeric value in range 0-1000 | ``'ultralight'`` | ``'light'`` | ``'normal'`` |
+                              ``'regular'`` | ``'book'`` | ``'medium'`` | ``'roman'`` | ``'semibold'`` | ``'demibold'`` |
+                              ``'demi'`` | ``'bold'`` | ``'heavy'`` | ``'extra bold'`` | ``'black'``' ]
 x                           `float`
 y                           `float`
 zorder                      any number


### PR DESCRIPTION
The text properties guide listed obsolete font weight names such as `ultrabold`. This updates the list to match the accepted values documented by `Text.set_fontweight`.

Fixes #31506