### PR TITLE
DOC: fix coords demo notebook note rendering

### DIFF
--- a/galleries/examples/event_handling/coords_demo.py
+++ b/galleries/examples/event_handling/coords_demo.py
@@ -11,7 +11,8 @@ and click events.
     will not appear in the static documentation. Please run this code on your
     machine to see the interactivity.
 
-    You can copy and paste individual parts, or download the entire example
+You can copy and paste individual parts, or download the entire example
+    using the link at the bottom of the page.
     using the link at the bottom of the page.
 """
 


### PR DESCRIPTION
This removes the extra indentation from the second paragraph of the `coords_demo` note so the downloaded Jupyter notebook renders the note as a paragraph instead of treating it as a code block.

Fixes #31869