### PR TITLE
Switch from colorspacious to colour-science

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -110,6 +110,10 @@ warnings.filterwarnings('default', category=UserWarning,
 warnings.filterwarnings('default', category=UserWarning,
                         message=r'Matplotlib currently does not support .+ natively\.')
 
+# Avoid warnings on import of the `colour` package for its optional dependencies.
+warnings.filterwarnings('ignore',
+                        message=r'".*" related API features are not available: ')
+
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
@@ -153,7 +157,7 @@ def _check_dependencies():
         **{ext: ext.split(".")[0] for ext in extensions},
         # Explicitly list deps that are not extensions, or whose PyPI package
         # name does not match the (toplevel) module name.
-        "colorspacious": 'colorspacious',
+        "colour": 'colour-science',
         "mpl_sphinx_theme": 'mpl_sphinx_theme',
         "sphinxcontrib.inkscapeconverter": 'sphinxcontrib-svg2pdfconverter',
     }

--- a/environment.yml
+++ b/environment.yml
@@ -31,7 +31,7 @@ dependencies:
   - setuptools_scm<10
   - wxpython
   # building documentation
-  - colorspacious
+  - colour-science
   - graphviz
   - ipython
   - ipywidgets

--- a/galleries/examples/user_interfaces/mplcvd.py
+++ b/galleries/examples/user_interfaces/mplcvd.py
@@ -4,14 +4,14 @@ mplcvd -- an example of figure hook
 
 To use this hook, ensure that this module is in your ``PYTHONPATH``, and set
 ``rcParams["figure.hooks"] = ["mplcvd:setup"]``.  This hook depends on
-the ``colorspacious`` third-party module.
+the ``colour-science`` third-party module.
 """
 
 import functools
 from pathlib import Path
 
 from PIL import Image
-import colorspacious
+import colour
 
 import numpy as np
 
@@ -20,9 +20,9 @@ _BUTTON_HELP = "Simulate color vision deficiencies"
 _MENU_ENTRIES = {
     "None": None,
     "Greyscale": "greyscale",
-    "Deuteranopia": "deuteranomaly",
-    "Protanopia": "protanomaly",
-    "Tritanopia": "tritanomaly",
+    "Deuteranopia": "Deuteranomaly",
+    "Protanopia": "Protanomaly",
+    "Tritanopia": "Tritanomaly",
 }
 
 
@@ -43,7 +43,7 @@ def _get_color_filter(name):
         - ``"tritanopia"``: Simulate the rare form of blue-yellow
           colorblindness.
 
-        Color conversions use `colorspacious`_.
+        Color conversions use `colour-science <https://www.colour-science.org/>`_.
 
     Returns
     -------
@@ -64,18 +64,21 @@ def _get_color_filter(name):
         return None
 
     elif name == "greyscale":
-        rgb_to_jch = colorspacious.cspace_converter("sRGB1", "JCh")
-        jch_to_rgb = colorspacious.cspace_converter("JCh", "sRGB1")
-
         def convert(im):
-            greyscale_JCh = rgb_to_jch(im)
-            greyscale_JCh[..., 1] = 0
-            im = jch_to_rgb(greyscale_JCh)
+            xyz = colour.sRGB_to_XYZ(im)
+            lab = colour.XYZ_to_CAM02UCS(xyz)
+            lab[..., 1] = lab[..., 2] = 0
+            xyz = colour.CAM02UCS_to_XYZ(lab)
+            im = colour.XYZ_to_sRGB(xyz)
             return im
 
     else:
-        cvd_space = {"name": "sRGB1+CVD", "cvd_type": name, "severity": 100}
-        convert = colorspacious.cspace_converter(cvd_space, "sRGB1")
+        def convert(im):
+            linear = colour.models.eotf_sRGB(im)
+            m = colour.matrix_cvd_Machado2009(name, severity=1)
+            linear_cvd = colour.apply_matrix_colour_correction(linear, m)
+            cvd = colour.models.eotf_inverse_sRGB(linear_cvd)
+            return cvd
 
     def filter_func(im, dpi):
         alpha = None

--- a/galleries/users_explain/colors/colormaps.py
+++ b/galleries/users_explain/colors/colormaps.py
@@ -86,7 +86,7 @@ Colormaps are often split into several categories based on their function (see,
 
 # sphinx_gallery_thumbnail_number = 2
 
-from colorspacious import cspace_converter
+import colour
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -271,6 +271,23 @@ plt.show()
 # Note that some documentation on the colormaps is available
 # ([list-colormaps]_).
 
+
+def rgb_to_lightness(rgb):
+    """
+    Convert from RGB to CAM02-UCS.
+
+    Note that this algorithm is a hard-coded equivalent to the simplifying helper:
+
+        colour.convert(rgb, "sRGB", "CAM02UCS")[..., 0] * 100
+
+    but that requires `networkx` to reduce the conversion graph and we don't want that
+    dependency for building the docs.
+    """
+    xyz = colour.sRGB_to_XYZ(rgb)
+    lab = colour.XYZ_to_CAM02UCS(xyz)
+    return lab[..., 0]
+
+
 mpl.rcParams.update({'font.size': 12})
 
 # Number of colormap per subplot for particular cmap categories
@@ -304,10 +321,10 @@ for cmap_category, cmap_list in cmaps.items():
 
         for j, cmap in enumerate(cmap_list[i*dsub:(i+1)*dsub]):
 
-            # Get RGB values for colormap and convert the colormap in
-            # CAM02-UCS colorspace.  lab[0, :, 0] is the lightness.
-            rgb = mpl.colormaps[cmap](x)[np.newaxis, :, :3]
-            lab = cspace_converter("sRGB1", "CAM02-UCS")(rgb)
+            # Get RGB values for colormap and convert the colormap to lightness in the
+            # CAM02-UCS colorspace.
+            rgb = mpl.colormaps[cmap](x)[:, :3]
+            L = rgb_to_lightness(rgb)
 
             # Plot colormap L values.  Do separately for each category
             # so each plot can be pretty.  To make scatter markers change
@@ -317,10 +334,10 @@ for cmap_category, cmap_list in cmaps.items():
             if cmap_category == 'Sequential':
                 # These colormaps all start at high lightness, but we want them
                 # reversed to look nice in the plot, so reverse the order.
-                y_ = lab[0, ::-1, 0]
+                y_ = L[::-1]
                 c_ = x[::-1]
             else:
-                y_ = lab[0, :, 0]
+                y_ = L
                 c_ = x
 
             dc = _DC.get(cmap_category, 1.4)  # cmaps horizontal spacing
@@ -409,11 +426,10 @@ def plot_color_gradients(cmap_category, cmap_list):
     for ax, name in zip(axs, cmap_list):
 
         # Get RGB values for colormap.
-        rgb = mpl.colormaps[name](x)[np.newaxis, :, :3]
+        rgb = mpl.colormaps[name](x)[:, :3]
 
         # Get colormap in CAM02-UCS colorspace. We want the lightness.
-        lab = cspace_converter("sRGB1", "CAM02-UCS")(rgb)
-        L = lab[0, :, 0]
+        L = rgb_to_lightness(rgb)
         L = np.float32(np.vstack((L, L, L)))
 
         ax[0].imshow(gradient, aspect='auto', cmap=mpl.colormaps[name])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,7 +107,7 @@ dev = [
 #
 doc = [
     "sphinx>=5.1.0,!=6.1.2",
-    "colorspacious",
+    "colour-science",
     "ipython",
     "ipywidgets",
     "ipykernel",


### PR DESCRIPTION
## PR summary

There has been no upstream activity with colorspacious for seven years, and this is slowly becoming problematic as Python moves forward [1]. On the other hand, colour-science is actively developed and contains far more conversions at this point.

[1] https://github.com/matplotlib/matplotlib/pull/31384/changes/edd1dcf0548970ab1e5ad862fcec9dc46877244b

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [n/a] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines