### PR TITLE
Fix nested braces in mathtext \text arguments

### DIFF
--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -1890,12 +1890,11 @@ class _BracedText(Token):
         super().__init__()
         self.mayReturnEmpty = True
         self.mayIndexError = False
-        self.errmsg = "Expected '{'"
 
     def parseImpl(self, instring: str, loc: int,
                   do_actions: bool = True) -> tuple[int, str]:
         if loc >= len(instring) or instring[loc] != "{":
-            raise ParseException(instring, loc, self.errmsg, self)
+            raise ParseException(instring, loc, "Expected '{'", self)
         chars = []
         depth = 0
         while loc < len(instring):

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -24,9 +24,9 @@ import numpy as np
 from numpy.typing import NDArray
 from pyparsing import (
     Empty, Forward, Literal, Group, NotAny, OneOrMore, Optional,
-    ParseBaseException, ParseExpression, ParseFatalException,
-    ParserElement, ParseResults, QuotedString, Regex, StringEnd, ZeroOrMore,
-    pyparsing_common, nested_expr, one_of)
+    ParseBaseException, ParseException, ParseExpression, ParseFatalException,
+    ParserElement, ParseResults, QuotedString, Regex, StringEnd, Token,
+    ZeroOrMore, pyparsing_common, nested_expr, one_of)
 
 import matplotlib as mpl
 from . import cbook
@@ -1873,6 +1873,51 @@ def Error(msg: str) -> ParserElement:
     return Empty().set_parse_action(raise_error)
 
 
+class _BracedText(Token):
+    r"""
+    Match a brace-delimited literal string, allowing nested braces.
+
+    This is similar to ``QuotedString("{", "\\", end_quote_char="}")``, except
+    that brace depth is tracked, so that the string does not end at the first
+    ``}``.  As in TeX, nested unescaped braces only group, and are not
+    rendered; a literal brace is written as ``\{`` or ``\}``.  A backslash
+    escapes the following character, which therefore does not affect depth.
+    """
+
+    _escapes = {"t": "\t", "n": "\n", "f": "\f", "r": "\r"}
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.mayReturnEmpty = True
+        self.mayIndexError = False
+        self.errmsg = "Expected '{'"
+
+    def parseImpl(self, instring: str, loc: int,
+                  do_actions: bool = True) -> tuple[int, str]:
+        if loc >= len(instring) or instring[loc] != "{":
+            raise ParseException(instring, loc, self.errmsg, self)
+        chars = []
+        depth = 0
+        while loc < len(instring):
+            char = instring[loc]
+            if char == "\\" and loc + 1 < len(instring):
+                escaped = instring[loc + 1]
+                chars.append(self._escapes.get(escaped, escaped))
+                loc += 2
+                continue
+            loc += 1
+            if char == "{":
+                depth += 1
+                continue
+            elif char == "}":
+                depth -= 1
+                if depth == 0:
+                    return loc, "".join(chars)
+                continue
+            chars.append(char)
+        raise ParseException(instring, loc, "Expected '}'", self)
+
+
 class ParserState:
     """
     Parser state.
@@ -2216,7 +2261,7 @@ class Parser:
             r"\underset",
             p.optional_group("annotation") + p.optional_group("body"))
 
-        p.text = cmd(r"\text", QuotedString('{', '\\', end_quote_char="}"))
+        p.text = cmd(r"\text", _BracedText())
 
         p.substack = cmd(r"\substack",
                            nested_expr(opener="{", closer="}",

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -337,6 +337,8 @@ def test_fontinfo():
         (r'$a_2_2$', r'Double subscript'),
         (r'$a^2_a^2$', r'Double superscript'),
         (r'$a = {b$', r"Expected '}'"),
+        (r'$\text$', r'Expected \text'),
+        (r'$\text{foo$', r'Expected \text'),
     ],
     ids=[
         'hspace without value',
@@ -366,6 +368,8 @@ def test_fontinfo():
         'double subscript',
         'super on sub without braces',
         'unclosed group',
+        'text without argument',
+        'text with unclosed argument',
     ]
 )
 def test_mathtext_exceptions(math, msg):

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -577,6 +577,22 @@ def test_mathtext_single_char_super_with_prime(expr):
 
 
 @check_figures_equal()
+def test_text_nested_braces(fig_test, fig_ref):
+    # Nested braces group as in TeX, and are not rendered (gh-32105).
+    fig_test.text(0.1, 0.2, r"$\text{{example}}$")
+    fig_test.text(0.1, 0.5, r"$\text{a{b}{{c}}d}$")
+    fig_ref.text(0.1, 0.2, r"$\text{example}$")
+    fig_ref.text(0.1, 0.5, r"$\text{abcd}$")
+
+
+@check_figures_equal()
+def test_text_escaped_braces(fig_test, fig_ref):
+    # Escaped braces are still rendered as literal braces (gh-32105).
+    fig_test.text(0.1, 0.2, r"$\text{{\{example\}}}$")
+    fig_ref.text(0.1, 0.2, r"$\text{\{example\}}$")
+
+
+@check_figures_equal()
 def test_boldsymbol(fig_test, fig_ref):
     fig_test.text(0.1, 0.2, r"$\boldsymbol{\mathrm{abc0123\alpha}}$")
     fig_ref.text(0.1, 0.2, r"$\mathrm{abc0123\alpha}$")


### PR DESCRIPTION
## PR summary
Closes #32105.

`\text` used pyparsing's `QuotedString`, which ends at the first `}`, so that made `\text{{example}}` failed with a cryptic ParseException. 

I replaced that with a small brace-balanced token that tracks nesting depth.

Nested unescaped braces are treated as TeX groups (not rendered), matching real LaTeX, so `\text{{example}}` renders the same as `\text{example}`. Literal braces continue to use `\{` and `\}`.

## AI Disclosure
I used Cursor (generative AI) to explore the mathtext parser, draft the regression tests, and help write this PR description (to make sure I am following standards). I reviewed the change, verified the behavior against TeX grouping semantics, and ran a local smoke test covering nested braces, escaped braces, the existing `\text` test string, and malformed input.

## PR quality check
- [x] Use an expressive title
- [x] New and changed code is tested
- [ ] Plotting related features are demonstrated in an example
- [ ] New features and API changes have release notes
- [ ] Documentation complies with guidelines

N/A for example/release notes/docs: this is a bug fix restoring expected LaTeX-like behavior of an existing command.