### PR TITLE
FIX: Avoid unbounded allocations for float markevery

### DIFF
--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -202,8 +202,7 @@ def _mark_every_path(markevery, tpath, affine, ax):
             marker_step = step * scale
             if marker_step <= 0:
                 raise ValueError(
-                    f"markevery={markevery!r} is a tuple with len 2, but its "
-                    f"second element is not positive")
+                    f"`markevery` step must be positive, but got {step!r}")
             # A theoretical marker can select a vertex only if the marker
             # immediately before or after that vertex selects it.  Limit
             # the candidates to those markers instead of materializing

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -202,7 +202,7 @@ def _mark_every_path(markevery, tpath, affine, ax):
             marker_step = step * scale
             if marker_step <= 0:
                 raise ValueError(
-                    f"`markevery` step must be positive, but got {step!r}")
+                    f"'markevery' step must be positive, but got {step!r}")
             # A theoretical marker can select a vertex only if the marker
             # immediately before or after that vertex selects it.  Limit
             # the candidates to those markers instead of materializing

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -200,43 +200,32 @@ def _mark_every_path(markevery, tpath, affine, ax):
             scale = np.hypot(x1 - x0, y1 - y0)
             marker_start = start * scale
             marker_step = step * scale
-            if marker_step > 0:
-                # A theoretical marker can select a vertex only if the marker
-                # immediately before or after that vertex selects it.  Limit
-                # the candidates to those markers instead of materializing
-                # every marker position, which may be arbitrarily large when
-                # zoomed in far enough.
-                marker_delta = (
-                    delta
-                    - np.remainder(delta - marker_start, marker_step)
-                )
-                marker_delta = np.concatenate(
-                    ([marker_start], marker_delta, marker_delta + marker_step))
-                marker_delta = np.unique(marker_delta[
-                    (marker_delta >= marker_start)
-                    & (marker_delta < delta[-1])
-                ])
+            if marker_step <= 0:
+                raise ValueError(
+                    f"markevery={markevery!r} is a tuple with len 2, but its "
+                    f"second element is not positive")
+            # A theoretical marker can select a vertex only if the marker
+            # immediately before or after that vertex selects it.  Limit
+            # the candidates to those markers instead of materializing
+            # every marker position, which may be arbitrarily large when
+            # zoomed in far enough.
+            marker_delta = delta - np.remainder(delta - marker_start, marker_step)
+            marker_delta = np.union1d(marker_delta, marker_delta + marker_step)
+            marker_delta = marker_delta[
+                (marker_delta >= marker_start) & (marker_delta < delta[-1])]
 
-                # Find each candidate's closest actual data point without
-                # constructing a len(marker_delta) x len(delta) array.
-                right = np.searchsorted(delta, marker_delta, side="left")
-                left = np.maximum(right - 1, 0)
-                right = np.minimum(right, len(delta) - 1)
-                inds = np.where(
-                    np.abs(delta[right] - marker_delta)
-                    < np.abs(marker_delta - delta[left]),
-                    right, left)
-                # Match argmin's handling of repeated cumulative distances by
-                # choosing the first vertex at that distance.
-                inds = np.searchsorted(delta, delta[inds], side="left")
-            else:
-                # Preserve the existing behavior for unsupported non-positive
-                # spacing, including the exception raised for zero spacing.
-                marker_delta = np.arange(
-                    marker_start, delta[-1], marker_step)
-                inds = np.abs(
-                    delta[np.newaxis, :] - marker_delta[:, np.newaxis])
-                inds = inds.argmin(axis=1)
+            # Find each candidate's closest actual data point without
+            # constructing a len(marker_delta) x len(delta) array.
+            right = np.searchsorted(delta, marker_delta, side="left")
+            left = np.maximum(right - 1, 0)
+            right = np.minimum(right, len(delta) - 1)
+            inds = np.where(
+                np.abs(delta[right] - marker_delta)
+                < np.abs(marker_delta - delta[left]),
+                right, left)
+            # If there are multiple vertices at a given distance, use the
+            # first one.
+            inds = np.searchsorted(delta, delta[inds], side="left")
             inds = np.unique(inds)
             # return, we are done here
             return Path(fverts[inds], _slice_or_none(codes, inds))

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -198,11 +198,45 @@ def _mark_every_path(markevery, tpath, affine, ax):
             # bounding box diagonal being a distance of unity:
             (x0, y0), (x1, y1) = ax.transAxes.transform([[0, 0], [1, 1]])
             scale = np.hypot(x1 - x0, y1 - y0)
-            marker_delta = np.arange(start * scale, delta[-1], step * scale)
-            # find closest actual data point that is closest to
-            # the theoretical distance along the path:
-            inds = np.abs(delta[np.newaxis, :] - marker_delta[:, np.newaxis])
-            inds = inds.argmin(axis=1)
+            marker_start = start * scale
+            marker_step = step * scale
+            if marker_step > 0:
+                # A theoretical marker can select a vertex only if the marker
+                # immediately before or after that vertex selects it.  Limit
+                # the candidates to those markers instead of materializing
+                # every marker position, which may be arbitrarily large when
+                # zoomed in far enough.
+                marker_delta = (
+                    delta
+                    - np.remainder(delta - marker_start, marker_step)
+                )
+                marker_delta = np.concatenate(
+                    ([marker_start], marker_delta, marker_delta + marker_step))
+                marker_delta = np.unique(marker_delta[
+                    (marker_delta >= marker_start)
+                    & (marker_delta < delta[-1])
+                ])
+
+                # Find each candidate's closest actual data point without
+                # constructing a len(marker_delta) x len(delta) array.
+                right = np.searchsorted(delta, marker_delta, side="left")
+                left = np.maximum(right - 1, 0)
+                right = np.minimum(right, len(delta) - 1)
+                inds = np.where(
+                    np.abs(delta[right] - marker_delta)
+                    < np.abs(marker_delta - delta[left]),
+                    right, left)
+                # Match argmin's handling of repeated cumulative distances by
+                # choosing the first vertex at that distance.
+                inds = np.searchsorted(delta, delta[inds], side="left")
+            else:
+                # Preserve the existing behavior for unsupported non-positive
+                # spacing, including the exception raised for zero spacing.
+                marker_delta = np.arange(
+                    marker_start, delta[-1], marker_step)
+                inds = np.abs(
+                    delta[np.newaxis, :] - marker_delta[:, np.newaxis])
+                inds = inds.argmin(axis=1)
             inds = np.unique(inds)
             # return, we are done here
             return Path(fverts[inds], _slice_or_none(codes, inds))

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -287,7 +287,7 @@ def test_markevery_float_nonpositive_spacing(markevery):
     fig, ax = plt.subplots()
     ax.plot([0, 1], marker="o", markevery=markevery)
 
-    with pytest.raises(ValueError, match="`markevery` step must be positive"):
+    with pytest.raises(ValueError, match="'markevery' step must be positive"):
         fig.canvas.draw()
 
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -287,7 +287,7 @@ def test_markevery_float_nonpositive_spacing(markevery):
     fig, ax = plt.subplots()
     ax.plot([0, 1], marker="o", markevery=markevery)
 
-    with pytest.raises(ValueError, match="second element is not positive"):
+    with pytest.raises(ValueError, match="`markevery` step must be positive"):
         fig.canvas.draw()
 
 

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -274,43 +274,39 @@ def test_markevery_figure_line_unsupported_relsize():
 def test_markevery_extreme_zoom():
     x = np.linspace(0, 10, 200)
     fig, ax = plt.subplots()
-    line, = ax.plot(x, np.sin(x), marker="o", markevery=0.05)
+    ax.plot(x, np.sin(x), marker="o", markevery=0.05)
     ax.set_xlim(5.000000, 5.000001)
 
-    path = mlines._mark_every_path(
-        line.get_markevery(), line.get_path(), line.get_transform(), ax)
+    # Calculating marker positions must not allocate an unbounded distance
+    # matrix when the axes are zoomed in extremely far.
+    fig.canvas.draw()
 
-    # At this zoom level the theoretical markers are close enough that every
-    # data point is selected.  In particular, finding them must not allocate
-    # the full 160371706 x 200 distance matrix from gh-32133.
-    assert_array_equal(path.vertices, line.get_path().vertices)
+
+@pytest.mark.parametrize("markevery", [0.0, -0.1])
+def test_markevery_float_nonpositive_spacing(markevery):
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], marker="o", markevery=markevery)
+
+    with pytest.raises(ValueError, match="second element is not positive"):
+        fig.canvas.draw()
 
 
 @pytest.mark.parametrize(
-    "markevery",
-    [0.1, 0.3, 1.5, (-0.2, 0.1), (0.0, 0.1), (0.45, 0.1), (2.0, 0.1)])
-def test_markevery_float_matches_brute_force(markevery):
-    x = np.linspace(-1, 1)
+    ("markevery", "expected"),
+    [(1.5, [0, 3, 4, 5, 6, 7, 8]),
+     ((-0.2, 1.5), [0, 3, 4, 5, 6, 7]),
+     ((11.0, 1.5), [])])
+def test_markevery_float_vertex_selection(markevery, expected):
     fig, ax = plt.subplots()
-    line, = ax.plot(x, 5 * x**2)
-
-    path = line.get_path()
-    affine = line.get_transform()
-    expected_verts = affine.transform(path.vertices)
-    delta = np.empty((len(expected_verts), 2))
-    delta[0] = 0
-    delta[1:] = expected_verts[1:] - expected_verts[:-1]
-    delta = np.hypot(*delta.T).cumsum()
     (x0, y0), (x1, y1) = ax.transAxes.transform([[0, 0], [1, 1]])
     scale = np.hypot(x1 - x0, y1 - y0)
-    start, step = (0, markevery) if np.isscalar(markevery) else markevery
-    marker_delta = np.arange(start * scale, delta[-1], step * scale)
-    inds = np.abs(delta - marker_delta[:, None]).argmin(axis=1)
-    expected = path.vertices[np.unique(inds)]
+    path = Path(np.column_stack([
+        [0, 0.2, 0.8, 1.6, 2.7, 4.1, 5.8, 7.8, 10], np.zeros(9)]))
 
-    actual = mlines._mark_every_path(markevery, path, affine, ax)
+    actual = mlines._mark_every_path(
+        markevery, path, mtransforms.Affine2D().scale(scale), ax)
 
-    assert_array_equal(actual.vertices, expected)
+    assert_array_equal(actual.vertices, path.vertices[expected])
 
 
 @pytest.mark.parametrize(

--- a/lib/matplotlib/tests/test_lines.py
+++ b/lib/matplotlib/tests/test_lines.py
@@ -271,6 +271,64 @@ def test_markevery_figure_line_unsupported_relsize():
         fig.canvas.draw()
 
 
+def test_markevery_extreme_zoom():
+    x = np.linspace(0, 10, 200)
+    fig, ax = plt.subplots()
+    line, = ax.plot(x, np.sin(x), marker="o", markevery=0.05)
+    ax.set_xlim(5.000000, 5.000001)
+
+    path = mlines._mark_every_path(
+        line.get_markevery(), line.get_path(), line.get_transform(), ax)
+
+    # At this zoom level the theoretical markers are close enough that every
+    # data point is selected.  In particular, finding them must not allocate
+    # the full 160371706 x 200 distance matrix from gh-32133.
+    assert_array_equal(path.vertices, line.get_path().vertices)
+
+
+@pytest.mark.parametrize(
+    "markevery",
+    [0.1, 0.3, 1.5, (-0.2, 0.1), (0.0, 0.1), (0.45, 0.1), (2.0, 0.1)])
+def test_markevery_float_matches_brute_force(markevery):
+    x = np.linspace(-1, 1)
+    fig, ax = plt.subplots()
+    line, = ax.plot(x, 5 * x**2)
+
+    path = line.get_path()
+    affine = line.get_transform()
+    expected_verts = affine.transform(path.vertices)
+    delta = np.empty((len(expected_verts), 2))
+    delta[0] = 0
+    delta[1:] = expected_verts[1:] - expected_verts[:-1]
+    delta = np.hypot(*delta.T).cumsum()
+    (x0, y0), (x1, y1) = ax.transAxes.transform([[0, 0], [1, 1]])
+    scale = np.hypot(x1 - x0, y1 - y0)
+    start, step = (0, markevery) if np.isscalar(markevery) else markevery
+    marker_delta = np.arange(start * scale, delta[-1], step * scale)
+    inds = np.abs(delta - marker_delta[:, None]).argmin(axis=1)
+    expected = path.vertices[np.unique(inds)]
+
+    actual = mlines._mark_every_path(markevery, path, affine, ax)
+
+    assert_array_equal(actual.vertices, expected)
+
+
+@pytest.mark.parametrize(
+    ("x", "expected"), [([0, 0.5, 1.5], [0, 1]), ([0, 0, 2], [0])])
+def test_markevery_float_ties_and_repeated_vertices(x, expected):
+    fig, ax = plt.subplots()
+    (x0, y0), (x1, y1) = ax.transAxes.transform([[0, 0], [1, 1]])
+    scale = np.hypot(x1 - x0, y1 - y0)
+    path = Path(np.column_stack([x, np.zeros(len(x))]))
+
+    actual = mlines._mark_every_path(
+        1.0, path, mtransforms.Affine2D().scale(scale), ax)
+
+    # Match np.argmin's preference for the first vertex on ties, including
+    # repeated cumulative distances.
+    assert_array_equal(actual.vertices, path.vertices[expected])
+
+
 def test_marker_as_markerstyle():
     fig, ax = plt.subplots()
     line, = ax.plot([2, 4, 3], marker=MarkerStyle("D"))


### PR DESCRIPTION
## PR summary

The large allocation appears to come from constructing the full
`len(marker_delta) × len(delta)` distance matrix. This avoids materialising both
the full `marker_delta` sequence and the 2D distance matrix, preserves the existing
float `markevery` placement semantics, and adds extreme-zoom plus parity coverage.

Closes #32133

Validation:

- The reported extreme-zoom reproduction completes without the previous 239 GiB allocation.
- Focused line/markevery tests: 12 passed.
- Ruff: passed for the two changed files.
- `git diff --check`: passed.

## AI Disclosure

This PR includes AI-assisted code understanding to speed up the process; the implementation and tests were updated and reviewed manually with AI assistance.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
