### PR TITLE
Fix tiny wx plot window on wxPython 4.3

### DIFF
--- a/lib/matplotlib/backends/backend_wx.py
+++ b/lib/matplotlib/backends/backend_wx.py
@@ -935,10 +935,16 @@ class FigureFrameWx(wx.Frame):
         # otherwise the toolbar further resizes the canvas.
         w, h = map(math.ceil, fig.bbox.size)
         self.canvas.SetInitialSize(self.FromDIP(wx.Size(w, h)))
-        self.canvas.SetMinSize(self.FromDIP(wx.Size(2, 2)))
         self.canvas.SetFocus()
 
+        # Size the frame to the canvas's initial size *before* relaxing the
+        # canvas min size.  ``SetInitialSize`` sets both the size and the min
+        # size to (w, h); with wxPython 4.3 (wxWidgets 3.3) ``Fit`` uses the
+        # current min size, so shrinking it to (2, 2) first collapses the
+        # window to a tiny size (GH #32143).  Relax the min size afterwards so
+        # the user can still resize the window smaller.
         self.Fit()
+        self.canvas.SetMinSize(self.FromDIP(wx.Size(2, 2)))
 
         self.Bind(wx.EVT_CLOSE, self._on_close)
 


### PR DESCRIPTION
## PR summary

Fixes #32143 — with wxPython 4.3 / 4.3.1 the WxAgg plot window opens tiny (~132×131) and must be manually resized; wxPython 4.2.5 is unaffected.

### Cause

In `FigureFrameWx.__init__` (`lib/matplotlib/backends/backend_wx.py`):

```python
self.canvas.SetInitialSize(self.FromDIP(wx.Size(w, h)))  # sets size AND min size to (w, h)
self.canvas.SetMinSize(self.FromDIP(wx.Size(2, 2)))      # resets min size to (2, 2)
self.canvas.SetFocus()

self.Fit()                                               # sizes the frame from the canvas
```

`SetInitialSize(w, h)` sets both the size and the min size to `(w, h)`, but the next line resets the canvas min size to `(2, 2)`, and only then is `Fit()` called. wxPython 4.3 tracks wxWidgets 3.3, where `Fit()` sizes the frame from the canvas's current min size — so the `(2, 2)` reset collapses the window. wxPython 4.2.5 (wxWidgets 3.2) honoured the initial size instead.

### Fix

Call `Fit()` while the canvas min size is still the initial `(w, h)`, then relax it to `(2, 2)` afterwards so the window can still be resized smaller.

### Testing

This is GUI-backend window sizing, which isn't covered by the automated suite. The issue reporter tested this exact reorder and confirmed it:

> Thanks a lot for investigating. I can confirm that this works!

— https://github.com/matplotlib/matplotlib/issues/32143#issuecomment-5146451385 (and their confirmation).
