### PR TITLE
DOC: Make linestyle a referenceable type description via :mpltype:

### DIFF
--- a/galleries/examples/lines_bars_and_markers/linestyles.py
+++ b/galleries/examples/lines_bars_and_markers/linestyles.py
@@ -1,15 +1,23 @@
 """
+.. _linestyle_def:
+
 ==========
 Linestyles
 ==========
 
-Simple linestyles can be defined using the strings "solid", "dotted", "dashed"
-or "dashdot". More refined control can be achieved by providing a dash tuple
-``(offset, (on_off_seq))``. For example, ``(0, (3, 10, 1, 15))`` means
-(3pt line, 10pt space, 1pt line, 15pt space) with no offset, while
-``(5, (10, 3))``, means (10pt line, 3pt space), but skip the first 5pt line.
-See also `.Line2D.set_linestyle`.  The specific on/off sequences of the
-"dotted", "dashed" and "dashdot" styles are configurable:
+Linestyles can be specified in two ways:
+
+* **Named linestyles**: "solid", "dotted", "dashed", "dashdot" and their
+  short forms "-", ":", "--", "-."
+* **Parametrized linestyles**: a dash tuple ``(offset, (on_off_seq))``. For example,
+  ``(0, (3, 10, 1, 15))`` means (3pt line, 10pt space, 1pt line, 15pt space) with no
+  offset, while ``(5, (10, 3))``, means (10pt line, 3pt space), but skip the first
+  5pt line.
+
+See also `.Line2D.set_linestyle`.
+
+The specific on/off sequences of the "dotted", "dashed" and "dashdot" styles are
+configurable:
 
 * :rc:`lines.dotted_pattern`
 * :rc:`lines.dashed_pattern`

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -1998,7 +1998,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        linestyle : `~matplotlib.lines.Line2D` property, optional
+        linestyle : :mpltype:`linestyle`, optional
             The linestyle for plotting the data points.
             Only used if *usevlines* is ``False``.
 
@@ -2078,7 +2078,7 @@ class Axes(_AxesBase):
 
         Other Parameters
         ----------------
-        linestyle : `~matplotlib.lines.Line2D` property, optional
+        linestyle : :mpltype:`linestyle`, optional
             The linestyle for plotting the data points.
             Only used if *usevlines* is ``False``.
 
@@ -4027,11 +4027,8 @@ or pandas.DataFrame
             The linewidth of the errorbar lines. If None, the linewidth of
             the current style is used.
 
-        elinestyle : str or tuple, default: 'solid'
+        elinestyle : :mpltype:`linestyle`, default: 'solid'
            The linestyle of the errorbar lines.
-           Valid values for linestyles include {'-', '--', '-.',
-            ':', '', (offset, on-off-seq)}. See `.Line2D.set_linestyle` for a
-            complete description.
 
         capsize : float, default: :rc:`errorbar.capsize`
             The length of the error bar caps in points.

--- a/lib/matplotlib/axes/_base.py
+++ b/lib/matplotlib/axes/_base.py
@@ -3608,8 +3608,8 @@ class _AxesBase(martist.Artist):
             Transparency of gridlines: 0 (transparent) to 1 (opaque).
         grid_linewidth : float
             Width of gridlines in points.
-        grid_linestyle : str
-            Any valid `.Line2D` line style spec.
+        grid_linestyle : :mpltype:`linestyle`
+            Linestyle of the gridlines.
 
         Examples
         --------

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -675,7 +675,7 @@ class Collection(mcolorizer.ColorizingArtist):
 
         Parameters
         ----------
-        ls : {'-', '--', '-.', ':', '', ...} or (offset, on-off-seq) or list thereof
+        ls : :mpltype:`linestyle` or list of :mpltype:`linestyle`
             If a list, the individual elements are assigned to the elements of the
             collection.
 
@@ -1933,14 +1933,8 @@ class EventCollection(LineCollection):
             The line width of the event lines, in points.
         color : :mpltype:`color` or list of :mpltype:`color`, default: :rc:`lines.color`
             The color of the event lines.
-        linestyle : str or tuple or list thereof, default: 'solid'
-            Valid strings are ['solid', 'dashed', 'dashdot', 'dotted',
-            '-', '--', '-.', ':']. Dash tuples should be of the form::
-
-                (offset, onoffseq),
-
-            where *onoffseq* is an even length tuple of on and off ink
-            in points.
+        linestyle : :mpltype:`linestyle`, default: 'solid'
+            The linestyle of the event lines.
         antialiased : bool or list thereof, default: :rc:`lines.antialiased`
             Whether to use antialiasing for drawing the lines.
         **kwargs

--- a/lib/matplotlib/inset.py
+++ b/lib/matplotlib/inset.py
@@ -129,37 +129,10 @@ class InsetIndicator(artist.Artist):
         Parameters
         ----------
         ls : :mpltype:`linestyle`
-            Possible values:
+            A named line style (e.g. "dashed", or short "--") or a dash tuple
+            ``(offset, (on_off_seq))``.
 
-            - A string:
-
-              =======================================================  ================
-              linestyle                                                description
-              =======================================================  ================
-              ``'-'`` or ``'solid'``                                   solid line
-              ``'--'`` or ``'dashed'``                                 dashed line
-              ``'-.'`` or ``'dashdot'``                                dash-dotted line
-              ``':'`` or ``'dotted'``                                  dotted line
-              ``''`` or ``'none'`` (discouraged: ``'None'``, ``' '``)  draw nothing
-              =======================================================  ================
-
-            - A tuple describing the start position and lengths of dashes and spaces:
-
-                  (offset, onoffseq)
-
-              where
-
-              - *offset* is a float specifying the offset (in points); i.e. how much
-                is the dash pattern shifted.
-              - *onoffseq* is a sequence of on and off ink in points. There can be
-                arbitrary many pairs of on and off values.
-
-              Example: The tuple ``(0, (10, 5, 1, 5))`` means that the pattern starts
-              at the beginning of the line. It draws a 10 point long dash,
-              then a 5 point long space, then a 1 point long dash, followed by a 5 point
-              long space, and then the pattern repeats.
-
-            For examples see :doc:`/gallery/lines_bars_and_markers/linestyles`.
+            For a full reference see :doc:`/gallery/lines_bars_and_markers/linestyles`.
         """
         self._shared_setter('linestyle', ls)
 

--- a/lib/matplotlib/inset.py
+++ b/lib/matplotlib/inset.py
@@ -128,7 +128,7 @@ class InsetIndicator(artist.Artist):
 
         Parameters
         ----------
-        ls : {'-', '--', '-.', ':', '', ...} or (offset, on-off-seq)
+        ls : :mpltype:`linestyle`
             Possible values:
 
             - A string:

--- a/lib/matplotlib/lines.py
+++ b/lib/matplotlib/lines.py
@@ -1165,7 +1165,7 @@ class Line2D(Artist):
 
         Parameters
         ----------
-        ls : {'-', '--', '-.', ':', '', ...} or (offset, on-off-seq)
+        ls : :mpltype:`linestyle`
             Possible values:
 
             - A string:

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -511,37 +511,10 @@ class Patch(artist.Artist):
         Parameters
         ----------
         ls : :mpltype:`linestyle`
-            Possible values:
+            A named line style (e.g. "dashed", or short "--") or a dash tuple
+            ``(offset, (on_off_seq))``.
 
-            - A string:
-
-              =======================================================  ================
-              linestyle                                                description
-              =======================================================  ================
-              ``'-'`` or ``'solid'``                                   solid line
-              ``'--'`` or ``'dashed'``                                 dashed line
-              ``'-.'`` or ``'dashdot'``                                dash-dotted line
-              ``':'`` or ``'dotted'``                                  dotted line
-              ``''`` or ``'none'`` (discouraged: ``'None'``, ``' '``)  draw nothing
-              =======================================================  ================
-
-            - A tuple describing the start position and lengths of dashes and spaces:
-
-                  (offset, onoffseq)
-
-              where
-
-              - *offset* is a float specifying the offset (in points); i.e. how much
-                is the dash pattern shifted.
-              - *onoffseq* is a sequence of on and off ink in points. There can be
-                arbitrary many pairs of on and off values.
-
-              Example: The tuple ``(0, (10, 5, 1, 5))`` means that the pattern starts
-              at the beginning of the line. It draws a 10 point long dash,
-              then a 5 point long space, then a 1 point long dash, followed by a 5 point
-              long space, and then the pattern repeats.
-
-            For examples see :doc:`/gallery/lines_bars_and_markers/linestyles`.
+            For a full reference see :doc:`/gallery/lines_bars_and_markers/linestyles`.
         """
         if ls is None:
             ls = "solid"

--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -510,7 +510,7 @@ class Patch(artist.Artist):
 
         Parameters
         ----------
-        ls : {'-', '--', '-.', ':', '', ...} or (offset, on-off-seq)
+        ls : :mpltype:`linestyle`
             Possible values:
 
             - A string:

--- a/lib/matplotlib/sphinxext/roles.py
+++ b/lib/matplotlib/sphinxext/roles.py
@@ -143,6 +143,7 @@ def _mpltype_role(name, rawtext, text, lineno, inliner, options=None, content=No
     type_to_link_target = {
         'color': 'colors_def',
         'hatch': 'hatch_def',
+        'linestyle': 'linestyle_def',
     }
     if mpltype not in type_to_link_target:
         raise ValueError(f"Unknown mpltype: {mpltype!r}")


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
none

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
none


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
