### PR TITLE
TYP: Improve type coverage of matplotlib.sankey

### DIFF
--- a/lib/matplotlib/sankey.pyi
+++ b/lib/matplotlib/sankey.pyi
@@ -1,7 +1,7 @@
 from matplotlib.axes import Axes
 
 from collections.abc import Callable, Iterable
-from typing import Any
+from types import SimpleNamespace
 from typing import Self
 
 import numpy as np
@@ -15,11 +15,10 @@ RIGHT: int
 UP: int
 DOWN: int
 
-# TODO typing units
 class Sankey:
-    diagrams: list[Any]
+    diagrams: list[SimpleNamespace]
     ax: Axes
-    unit: Any
+    unit: str | None
     format: str | Callable[[float], str]
     scale: float
     gap: float
@@ -34,7 +33,7 @@ class Sankey:
         self,
         ax: Axes | None = ...,
         scale: float = ...,
-        unit: Any = ...,
+        unit: str | None = ...,
         format: str | Callable[[float], str] = ...,
         gap: float = ...,
         radius: float = ...,
@@ -58,4 +57,4 @@ class Sankey:
         rotation: float = ...,
         **kwargs
     ) -> Self: ...
-    def finish(self) -> list[Any]: ...
+    def finish(self) -> list[SimpleNamespace]: ...


### PR DESCRIPTION
## PR summary

Part of the type coverage effort in #32157.

This narrows the remaining `Any` annotations in `lib/matplotlib/sankey.pyi` to the actual types used at runtime:

- `diagrams` / `finish()`: `Sankey.add` appends `SimpleNamespace(patch=..., flows=..., angles=..., tips=..., text=..., texts=...)` to `self.diagrams`, and `finish()` returns that list, so both are now `list[SimpleNamespace]`.
- `unit`: the docstring documents it as `str`, and `finish()`'s labeling logic only checks `self.unit is not None` before concatenating it to a string, so it is now `str | None`.

With `Any` gone from the file, the `# TODO typing units` comment above the class is resolved and removed, and the `Any` import is dropped.

Checked with mypy (clean) and `mypy.stubtest` reports no issues for `matplotlib.sankey`.

## AI Disclosure

I used an AI assistant to help research the issue landscape and draft the stub changes. I reviewed the runtime code in `sankey.py` myself, and the change was verified locally with mypy and stubtest.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] N/A — New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) (stub-only change, covered by the stubtest CI)
- [ ] N/A — Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] N/A — New features and API changes have [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] N/A — Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
