### PR TITLE
DOC: Use raw strings instead of doubling \\ for hatches where possible

### DIFF
--- a/galleries/examples/images_contours_and_fields/contourf_hatching.py
+++ b/galleries/examples/images_contours_and_fields/contourf_hatching.py
@@ -32,7 +32,7 @@ fig2, ax2 = plt.subplots()
 n_levels = 6
 ax2.contour(x, y, z, n_levels, colors='black', linestyles='-')
 cs = ax2.contourf(x, y, z, n_levels, colors='none',
-                  hatches=['.', '/', '\\', None, '\\\\', '*'],
+                  hatches=['.', '/', '\\', None, r'\\', '*'],
                   extend='lower')
 
 # create a legend for the contour set

--- a/galleries/examples/shapes_and_collections/hatch_demo.py
+++ b/galleries/examples/shapes_and_collections/hatch_demo.py
@@ -40,7 +40,7 @@ axs['patches'].fill_between(x, np.sin(x) * 4 + 30, y2=0,
 axs['patches'].add_patch(Ellipse((4, 50), 10, 10, fill=True,
                                  hatch='*', facecolor='y'))
 axs['patches'].add_patch(Polygon([(10, 20), (30, 50), (50, 10)],
-                                 hatch='\\/...', facecolor='g'))
+                                 hatch=r'\/...', facecolor='g'))
 axs['patches'].set_xlim(0, 40)
 axs['patches'].set_ylim(10, 60)
 axs['patches'].set_aspect(1)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

Implementing https://github.com/matplotlib/matplotlib/pull/32078#issuecomment-5044976338.

Note: `r"\"` is invalid in python, so for single backslash we still must keep `"\\"`.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
no AI

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
