### PR TITLE
ci: Drop some extraneous setup-python invocations

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -15,9 +15,6 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        with:
-          python-version: "3.x"
       - uses: j178/prek-action@5337cb91e0fa35a7ff31b9ca345126d8bbbcdf16  # v2.0.6
         with:
           extra-args: --hook-stage manual --all-files

--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -44,11 +44,6 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97  # v7.0.0
-        name: Install Python
-        with:
-          python-version: '3.13'
-
       - name: Build wheels for wasm
         uses: pypa/cibuildwheel@4726cd35bb13f7bde50cf2761f2499ac7b3aa32c  # v4.1.1
         env:


### PR DESCRIPTION
## PR summary

The prek action bundles in everything it needs, and all the linters should be installed in venvs with uv or similar, so there's no need to setup Python as well.

Since 2.19.1, cibuildwheel no longer needed setup-python for building Pyodide wheels, so we can drop that as well. It also appears to be causing some kind of conflict during the build [1].

[1] https://github.com/pypa/cibuildwheel/issues/2566

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines