### PR TITLE
PERF: Avoid `difflib` lookup in `ColormapRegistry.register`

### DIFF
--- a/lib/matplotlib/cm.py
+++ b/lib/matplotlib/cm.py
@@ -91,6 +91,9 @@ class ColormapRegistry(Mapping):
         self._cmaps = cmaps
         self._builtin_cmaps = tuple(cmaps)
 
+    def __contains__(self, item):
+        return item in self._cmaps
+
     def __getitem__(self, item):
         cmap = _api.getitem_checked(self._cmaps, colormap=item, _error_cls=KeyError)
         return cmap.copy()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

First reported here: https://github.com/holoviz/holoviews/issues/6981

Since 3.11 with #30001, there is a heavy penalty in registering multiple custom colormaps. A small example is given here:

``` python
import time

from matplotlib import colormaps

cmap = colormaps["viridis"]
t0 = time.perf_counter()
for i in range(1000):
    colormaps.register(cmap, name=f"repro_{i}")
print(time.perf_counter() - t0, "s")
```
<img width="571" height="237" alt="image" src="https://github.com/user-attachments/assets/57931aa0-bef4-4098-9c87-bb0ffc6041c5" />


## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->

The original problem reported in HoloViews was AI helped.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [ ] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
