### PR TITLE
Document and fix `AngleAnnotation` constructor default case of using the current Axes

### DIFF
--- a/galleries/examples/text_labels_and_annotations/angle_annotation.py
+++ b/galleries/examples/text_labels_and_annotations/angle_annotation.py
@@ -91,7 +91,7 @@ class AngleAnnotation(Arc):
             * "axes min", "axes max": minimum or maximum of relative Axes
               width, height
 
-        ax : `matplotlib.axes.Axes`
+        ax : `matplotlib.axes.Axes`, default: current Axes
             The Axes to add the angle annotation to.
 
         text : str
@@ -128,7 +128,7 @@ class AngleAnnotation(Arc):
                        xytext=(0, 0), textcoords="offset points",
                        annotation_clip=True)
         self.kw.update(text_kw or {})
-        self.text = ax.annotate(text, xy=self._center, **self.kw)
+        self.text = self.ax.annotate(text, xy=self._center, **self.kw)
 
     def get_size(self):
         factor = 1.


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
The provided `AngleAnnotation` class is already designed such that the current Axes will be used by default if no Axes are passed explicitly. Document this behavior. Call `annotate` on the correctly initialized class attribute `self.ax` instead of the constructor argument `ax`, which is `None` in the default case.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
No AI was used.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
