### PR TITLE
ci: Add environment variable to detect Azure Pipelines

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -260,7 +260,8 @@ def is_ci_environment():
         'JENKINS',   # Jenkins
         'GITLAB_CI',  # GitLab CI
         'GITHUB_ACTIONS',  # GitHub Actions
-        'TEAMCITY_VERSION'  # TeamCity
+        'TEAMCITY_VERSION',  # TeamCity
+        'TF_BUILD',  # Azure Pipelines
         # Add other CI environment variables as needed
     ]
 


### PR DESCRIPTION
## PR summary

There is no mention of the generic `CI` or `CONTINUOUS_INTEGRATION` on Azure's docs [1], so use the one that is there: `TF_BUILD`.

[1] https://learn.microsoft.com/en-us/azure/devops/pipelines/build/variables

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines