### PR TITLE
DOC: make championing pr standalone subsection and update alert procedure

### DIFF
--- a/doc/devel/pr_guide.rst
+++ b/doc/devel/pr_guide.rst
@@ -251,17 +251,19 @@ Some explicit rules following from this:
   subdirectories of :file:`doc/api/next_api_changes`, and significant new
   features have an entry in :file:`doc/user/whats_new`.
 
-  - If a PR already has a positive review, a core developer (e.g. the first
-    reviewer, but not necessarily) may champion that PR for merging.  In order
-    to do so, they should ping all core devs both on GitHub and on the dev
-    mailing list, and label the PR with the "Merge with single review?" label.
-    Other core devs can then either review the PR and merge or reject it, or
-    simply request that it gets a second review before being merged.  If no one
-    asks for such a second review within a week, the PR can then be merged on
-    the basis of that single review.
+Championing Pull Requests
+^^^^^^^^^^^^^^^^^^^^^^^^^
+If a PR already has a positive review, a core developer (e.g. the first reviewer, but
+not necessarily) may champion that PR for merging.  In order to do so, they should label
+the PR with the "Merge with single review?" label and ping core devs on GitHub, the
+weekly development meeting, the development channel on discourse and the dev mailing
+list. Other core devs can then either review the PR and merge or reject it, or simply
+request that it gets a second review before being merged.  If no one asks for such a
+second review within a week, the PR can then be merged on the basis of that single
+review.
 
-    A core dev should only champion one PR at a time and we should try to keep
-    the flow of championed PRs reasonable.
+A core dev should only champion one PR at a time and we should try to keep the flow of
+championed PRs reasonable.
 
 .. _pr-automated-tests:
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

Follow up to #32113, pulls language about championing PRs into a subsection to make extra clear that it applies to doc and code PRs. Also updates the alert/contact, but I think we have too many and should maybe pull back to:
* label PR w/ "merge w/ single review"
* put on weekly dev call
* post on discourse dev chat

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
nopes

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
