### PR TITLE
Remove tk button swap logic on macOS

### DIFF
--- a/lib/matplotlib/backends/_backend_tk.py
+++ b/lib/matplotlib/backends/_backend_tk.py
@@ -356,8 +356,6 @@ class FigureCanvasTk(FigureCanvasBase):
         self._tkcanvas.focus_set()
 
         num = getattr(event, 'num', None)
-        if sys.platform == 'darwin':  # 2 and 3 are reversed.
-            num = {2: 3, 3: 2}.get(num, num)
         MouseEvent("button_press_event", self,
                    *self._event_mpl_coords(event), num, dblclick=dblclick,
                    modifiers=self._mpl_modifiers(event),
@@ -368,8 +366,6 @@ class FigureCanvasTk(FigureCanvasBase):
 
     def button_release_event(self, event):
         num = getattr(event, 'num', None)
-        if sys.platform == 'darwin':  # 2 and 3 are reversed.
-            num = {2: 3, 3: 2}.get(num, num)
         MouseEvent("button_release_event", self,
                    *self._event_mpl_coords(event), num,
                    modifiers=self._mpl_modifiers(event),
@@ -402,14 +398,6 @@ class FigureCanvasTk(FigureCanvasBase):
         # NOTE: This fails to report multiclicks on macOS; only one button is
         # reported (multiclicks work correctly on Linux & Windows).
         modifiers = [
-            # macOS appears to swap right and middle (look for "Swap buttons
-            # 2/3" in tk/macosx/tkMacOSXMouseEvent.c).
-            (MouseButton.LEFT, 1 << 8),
-            (MouseButton.RIGHT, 1 << 9),
-            (MouseButton.MIDDLE, 1 << 10),
-            (MouseButton.BACK, 1 << 11),
-            (MouseButton.FORWARD, 1 << 12),
-        ] if sys.platform == "darwin" else [
             (MouseButton.LEFT, 1 << 8),
             (MouseButton.MIDDLE, 1 << 9),
             (MouseButton.RIGHT, 1 << 10),


### PR DESCRIPTION
## PR summary

During testing, I noticed that the middle and right mouse buttons are reversed under macOS when running under tk.

The original 2/3 button swap logic is [22 years old](https://github.com/matplotlib/matplotlib/commit/7499f7c7eeedbe6692b3f2716bc9c5fb2c500352).

tk fixed this [6 years ago](https://github.com/tcltk/tk/commit/7e3135f1d1b0207895e455bc6cd8bbb05fe22e05).

## Test File

```python
import matplotlib.pyplot as plt

def on_press(event):
    print(f"Press: button={event.button}")

def on_release(event):
    print(f"Release: button={event.button}")

def on_move(event):
    if event.key == 'shift':
        print(f"Buttons: {sorted(event.buttons)}")

fig, ax = plt.subplots()
fig.canvas.mpl_connect("button_press_event", on_press)
fig.canvas.mpl_connect("button_release_event", on_release)
fig.canvas.mpl_connect("motion_notify_event", on_move)

plt.show()
```


## AI Disclosure

No AI.


## PR quality check

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [X] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
