### PR TITLE
Fix PillowWriter GIF frame skew: frame_size must match the rendered RGBA buffer

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -178,7 +178,11 @@ class AbstractMovieWriter(abc.ABC):
     def frame_size(self):
         """A tuple ``(width, height)`` in pixels of a movie frame."""
         w, h = self.fig.get_size_inches()
-        return int(w * self.dpi), int(h * self.dpi)
+        # Match the rounding FigureCanvasBase.get_width_height(physical=True)
+        # applies when rendering: round up when within 1e-8 px of the integer,
+        # otherwise the frame size can be one pixel short of the RGBA buffer
+        # PillowWriter grabs via savefig(format="rgba"), skewing the frames.
+        return int(w * self.dpi + 1e-8), int(h * self.dpi + 1e-8)
 
     def _supports_transparency(self):
         """

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -558,3 +558,23 @@ def test_animation_with_transparency():
     # Check that the alpha channel is not 255, so frame has transparency
     assert frame.getextrema()[3][0] < 255
     plt.close(fig)
+
+
+def test_animation_frame_size_matches_rgba_buffer():
+    """
+    The movie frame size must match the RGBA buffer that PillowWriter grabs via
+    savefig(format="rgba"); a one-pixel mismatch makes Image.frombuffer misread
+    the rows and skew the frames (3.11.1 regression, GH #32186).
+    """
+    from io import BytesIO
+
+    # 8.2 in * 100 dpi = 819.9999999999999 px: plain int() truncates to 819,
+    # but the rendered RGBA buffer is rounded up to 820 (get_width_height).
+    fig, ax = plt.subplots(figsize=(8.2, 7), dpi=100)
+    writer = PillowWriter(fps=1)
+    writer.setup(fig, 'unused.gif', dpi=100)
+    buf = BytesIO()
+    fig.savefig(buf, format='rgba', dpi=100)
+    buffer_width = buf.getbuffer().nbytes // 4 // writer.frame_size[1]
+    assert writer.frame_size[0] == buffer_width
+    plt.close(fig)


### PR DESCRIPTION
## Problem

Since 3.11.1, GIF frames written by `animation.PillowWriter` are skewed to the left (e.g. figsize `(8.2, 7)` at 100 dpi). #32186

`AbstractMovieWriter.frame_size` computes the frame dimensions with plain `int(w * dpi)` (truncation), but the RGBA buffer `PillowWriter.grab_frame` grabs via `savefig(format="rgba")` is sized by `FigureCanvasBase.get_width_height`, which—since #32038—rounds **up** when the value is within 1e-8 px of the integer:

```python
return tuple(int(size / (1 if physical else self.device_pixel_ratio) + 1e-8)
```

For `8.2 in * 100 dpi = 819.9999999999999`, `frame_size` truncates to **819** while the buffer is **820**. `PIL.Image.frombuffer("RGBA", (819, 700), buf, …)` then reads the 820-wide rows as 819-wide and the image is skewed.

```python
fig, ax = plt.subplots(figsize=(8.2, 7), dpi=100)
ax.plot([0, 1], [0, 1])
ani = animation.FuncAnimation(fig, lambda f: ax.plot([0, 1], [0, f]), frames=1, blit=False)
ani.save("test.gif", writer=animation.PillowWriter(fps=1), dpi=100)
```

## Fix

Apply the same `+ 1e-8` rounding `get_width_height(physical=True)` uses, so `frame_size` always matches the buffer that gets grabbed. This is the “missed point to pass the corrected size through” noted in the bisect comment on the issue.

```diff
         w, h = self.fig.get_size_inches()
-        return int(w * self.dpi), int(h * self.dpi)
+        return int(w * self.dpi + 1e-8), int(h * self.dpi + 1e-8)
```

`frame_size` lives on `AbstractMovieWriter`, so every writer (ffmpeg/imagemagick via `-s %dx%d`, etc.) now also reports the corrected size consistently with the frames it writes.

## Verification

Verified fail-before / pass-after on matplotlib 3.11.1:

```
before: frame_size=(819, 700)  rgba buffer=820×700  → skewed
after:  frame_size=(820, 700)  matches buffer        → correct
```

The rounding only changes the result when `w * dpi` is within 1e-8 below an integer (the bug case); for typical sizes (`6@100`, `8@72`, `10.5@100`, `5@100`, `4.8@100`) the value is identical, so there is no behavior change for non-affected figures.

Added a regression test asserting `frame_size` equals the width of the RGBA buffer produced by `savefig(format="rgba")`.

Closes #32186