### PR TITLE
DOC: Add provisional API guidelines

### DIFF
--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -345,3 +345,60 @@ Additionally, if a whole function is discouraged, prefix the summary line with
 ``[*Discouraged*]`` so that it renders in the API overview like this
 
     [*Discouraged*] Return the XAxis instance.
+
+
+.. _provisional-api:
+
+Provisional API
+---------------
+
+Provisional status marks new API that we are reasonably confident in, but for
+which we do not yet want to provide the full stability guarantees of the
+deprecation process. It is used for larger or uncertain changes that need
+real-world usage before being finalized.
+
+Provisional API is expected to stabilize; it is not expected to be removed.
+This differs from *discouraged* API (which exists but is not recommended for
+new code) and from *deprecated* API (which is scheduled for removal).
+
+When to use provisional status
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- New API with an uncertain design space that needs user feedback before
+  finalizing.
+- Larger changes where the exact API surface may need adjustment.
+- Not for small, well-understood additions — those should go directly to
+  stable API with proper versioning directives.
+
+How to mark provisional API
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add an admonition to the docstring::
+
+    .. admonition:: Provisional status of X
+
+        The ``X`` module/API is considered provisional and may change at
+        any time without a deprecation period.
+
+Use the ``.. versionadded::`` directive to record when the provisional status
+was introduced.
+
+Duration
+^^^^^^^^
+
+There is no fixed duration for provisional status. API may remain provisional
+for multiple releases while it gathers adoption and feedback. For example,
+``subplot_mosaic`` was provisional from 3.3.0 to 3.7.0 before being declared
+stable.
+
+To remove provisional status, add a note to the release notes (e.g.,
+"``X`` no longer provisional") and remove the admonition from the docstring.
+The API then falls under the normal deprecation process for any future
+changes.
+
+Terminology
+^^^^^^^^^^^
+
+Use "provisional" (not "experimental"). "Experimental" is reserved for earlier,
+less certain work where the outcome is more open. "Provisional" indicates
+reasonable confidence in the approach but without stability guarantees.

--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -352,7 +352,7 @@ Additionally, if a whole function is discouraged, prefix the summary line with
 Provisional API
 ---------------
 
-Provisional status marks new API that we are reasonably confident in, but for
+Provisional status marks new APIs that we are reasonably confident in, but for
 which we do not yet want to provide the full stability guarantees of the
 deprecation process. It is used for larger or uncertain changes that need
 real-world usage before being finalized.


### PR DESCRIPTION
Closes #32044.

Adds a "Provisional API" section to the API guidelines documenting:

- **When**: new API with uncertain design space or larger changes needing real-world feedback
- **How**: the `.. admonition:: Provisional status of X` template already in use in `typing.py`, `colorizer.py`, `widgets.py`, and `__init__.py`
- **Duration**: no fixed limit — `subplot_mosaic` was provisional from 3.3.0 to 3.7.0
- **Terminology**: "provisional" (reasonably confident, no guarantees) vs "experimental" (less certain, outcome open), per @timhoffm's comment in #32044

The section follows the same structure as the existing "Discourage API" section — a short section explaining a non-deprecation status flag with its admonition template.