### PR TITLE
Fix the rounding of animation frame size to match the eventual canvas size

### DIFF
--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -177,8 +177,10 @@ class AbstractMovieWriter(abc.ABC):
     @property
     def frame_size(self):
         """A tuple ``(width, height)`` in pixels of a movie frame."""
+        # We cannot query the canvas for width/height because the dpi may be different
+        # The tolerance of 1e-8 covers a floating-point tick for even 100,000 pixels
         w, h = self.fig.get_size_inches()
-        return int(w * self.dpi), int(h * self.dpi)
+        return int(w * self.dpi + 1e-8), int(h * self.dpi + 1e-8)
 
     def _supports_transparency(self):
         """
@@ -293,15 +295,17 @@ class MovieWriter(AbstractMovieWriter):
         self.extra_args = extra_args
 
     def _adjust_frame_size(self):
+        wo, ho = self.frame_size  # in pixels, so need to convert to inches
+        wo /= self.dpi
+        ho /= self.dpi
         if self.codec == 'h264':
-            wo, ho = self.fig.get_size_inches()
             w, h = adjusted_figsize(wo, ho, self.dpi, 2)
             if (wo, ho) != (w, h):
                 self.fig.set_size_inches(w, h, forward=True)
                 _log.info('figure size in inches has been adjusted '
                           'from %s x %s to %s x %s', wo, ho, w, h)
         else:
-            w, h = self.fig.get_size_inches()
+            w, h = wo, ho
         _log.debug('frame size in pixels is %s x %s', *self.frame_size)
         return w, h
 

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -103,6 +103,19 @@ def test_null_movie_writer(anim):
     assert writer._count == anim._save_count
 
 
+def test_frame_size():
+    # Test that the frame size is the canvas size and not the figure size
+    fig = plt.figure(figsize=(1, 2.03), dpi=100)
+    assert fig.bbox.height < 203  # due to floating-point precision
+    assert fig.canvas.get_width_height() == (100, 203)
+
+    anim = animation.FuncAnimation(fig, lambda frame: tuple(), frames=1)
+    writer = NullMovieWriter()
+    anim.save("unused.null", dpi=100, writer=writer)
+
+    assert writer.frame_size == fig.canvas.get_width_height()
+
+
 @pytest.mark.parametrize('anim', [dict(klass=dict)], indirect=['anim'])
 def test_animation_delete(anim):
     if platform.python_implementation() == 'PyPy':


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

As reported in #32186, the change in #32038 to have appropriately rounded canvas sizes made the necessary updates to the backends, but missed that `matplotlib.animation` also needed to be updated.  This PR updates `matplotlib.animation` to calculate the frame size with the same rounding as will be used for the canvas size during saving.

Closes #32186 

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
No AI was used

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
