### PR TITLE
ENH: Preserve PolygonSelector cursor position after clear

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -1758,14 +1758,21 @@ def test_polygon_selector_box_props_handle_props(ax):
 def test_polygon_selector_clear_method(ax):
     onselect = mock.Mock(spec=noop, return_value=None)
     tool = widgets.PolygonSelector(ax, onselect)
+    artist = tool._selection_artist
+
+    tool.clear()
+    assert not tool._selection_completed
+    x0, x1 = ax.get_xlim()
+    y0, y1 = ax.get_ylim()
+    center = [((x0 + x1) / 2, (y0 + y1) / 2)]
+    # Cursor resets to center of the axes when last position is unknown.
+    np.testing.assert_equal(artist.get_xydata(), center)
 
     for result in ([(50, 50), (150, 50), (50, 150), (50, 50)],
                    [(50, 50), (100, 50), (50, 150), (50, 50)]):
         for xy in result:
             for event in polygon_place_vertex(ax, xy):
                 event._process()
-
-        artist = tool._selection_artist
 
         assert tool._selection_completed
         assert tool.get_visible()
@@ -1775,7 +1782,8 @@ def test_polygon_selector_clear_method(ax):
 
         tool.clear()
         assert not tool._selection_completed
-        np.testing.assert_equal(artist.get_xydata(), [(0, 0)])
+        # Cursor resets to last known position.
+        np.testing.assert_equal(artist.get_xydata(), [result[-1]])
 
 
 @pytest.mark.parametrize("horizOn", [False, True])

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -4368,7 +4368,16 @@ class PolygonSelector(_SelectorWidget):
 
     def _clear_without_update(self):
         self._selection_completed = False
-        self._xys = [(0, 0)]
+        prev = self._prev_event
+        if (prev is not None
+                and prev.xdata is not None and prev.ydata is not None
+                and not np.isnan(prev.xdata) and not np.isnan(prev.ydata)):
+            # Reset the pending vertex to the last known cursor position.
+            self._xys = [(prev.xdata, prev.ydata)]
+        else:
+            x0, x1 = self.ax.get_xlim()
+            y0, y1 = self.ax.get_ylim()
+            self._xys = [((x0 + x1) / 2, (y0 + y1) / 2)]
         self._draw_polygon_without_update()
 
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

Closes #28220

When pressing the Escape key to clear a polygonal chain, the pending vertex representing the cursor is reset to (0, 0) and rendered.

This PR enhances that behavior by reseting the pending vertex to the last known cursor position, falling back to the center of the axes if unknown.

Using the last known cursor position provides a more pleasant visualization interactively, and the center of the axes is preferable to (0, 0) since it is guaranteed to be visible.

<details>
  <summary>Visual comparison</summary>

  #### Current

  

https://github.com/user-attachments/assets/287b4602-8c87-4e2c-8938-618fd0111501


  #### Proposed

  

https://github.com/user-attachments/assets/8bc1b9f2-b522-4e62-9325-89254dc19d03


</details>

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->

The implementation is my own but I asked chatgpt to review it, and it recommended guarding against NaN, which I added.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [X] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
