### PR TITLE
Clarify interval semantics in BoundaryNorm documentation

### DIFF
--- a/lib/matplotlib/colors.py
+++ b/lib/matplotlib/colors.py
@@ -3224,6 +3224,8 @@ class BoundaryNorm(Normalize):
         boundaries : array-like
             Monotonically increasing sequence of at least 2 bin edges:  data
             falling in the n-th bin will be mapped to the n-th color.
+            Bins are left-closed and right-open; i.e., the n-th bin is
+            ``boundaries[n] <= value < boundaries[n + 1]``.
 
         ncolors : int
             Number of colors in the colormap to be used.
@@ -3231,12 +3233,12 @@ class BoundaryNorm(Normalize):
         clip : bool, optional
             If clip is ``True``, out of range values are mapped to 0 if they
             are below ``boundaries[0]`` or mapped to ``ncolors - 1`` if they
-            are above ``boundaries[-1]``.
+            are greater than or equal to ``boundaries[-1]``.
 
             If clip is ``False``, out of range values are mapped to -1 if
             they are below ``boundaries[0]`` or mapped to *ncolors* if they are
-            above ``boundaries[-1]``. These are then converted to valid indices
-            by `Colormap.__call__`.
+            greater than or equal to ``boundaries[-1]``. These are then
+            converted to valid indices by `Colormap.__call__`.
 
         extend : {'neither', 'both', 'min', 'max'}, default: 'neither'
             Extend the number of bins to include one or both of the


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
Small documentation change to clarify that the intervals defined by `BoundaryNorm` are left-closed and right-open.
This was slightly misleading in the [current documentation](https://matplotlib.org/stable/api/_as_gen/matplotlib.colors.BoundaryNorm.html), which states, for example:

> out of range values are mapped to -1 if they are below boundaries[0] or mapped to ncolors if they are **above boundaries[-1]**.

The existing code explicitly checks `xx >= self.vmax`, and `test_BoundaryNorm` tests this expecting that the upper value is considered outside of the final-boundary.

## AI Disclosure
I used AI for rubber ducking, but changes are my own 🐥

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
