### PR TITLE
TST: Set subprocess timeouts consistently on CI

### DIFF
--- a/lib/matplotlib/testing/__init__.py
+++ b/lib/matplotlib/testing/__init__.py
@@ -143,6 +143,8 @@ def subprocess_run_helper(func, *args, timeout, extra_env=None):
     extra_env : dict[str, str]
         Any additional environment variables to be set for the subprocess.
     """
+    if is_ci_environment():
+        timeout *= 6
     target = func.__name__
     module = func.__module__
     file = func.__code__.co_filename

--- a/lib/matplotlib/tests/test_backends_interactive.py
+++ b/lib/matplotlib/tests/test_backends_interactive.py
@@ -119,8 +119,9 @@ def _get_testable_interactive_backends():
             for env, marks in _get_available_interactive_backends()]
 
 
-# Reasonable safe values for slower CI/Remote and local architectures.
-_test_timeout = 120 if is_ci_environment() else 20
+# Reasonable safe values for slower CI/Remote and local architectures; timeouts may be
+# automatically increased later by subprocess_run_helper.
+_test_timeout = 20
 _retry_count = 3 if is_ci_environment() else 0
 
 

--- a/lib/matplotlib/tests/test_getattr.py
+++ b/lib/matplotlib/tests/test_getattr.py
@@ -6,7 +6,8 @@ import warnings
 import pytest
 
 import matplotlib
-from matplotlib.testing import is_ci_environment, subprocess_run_helper
+from matplotlib.testing import subprocess_run_helper
+
 
 # Get the names of all matplotlib submodules,
 # except for the unit tests and private modules.
@@ -59,8 +60,7 @@ def _test_module_getattr():
 
 @pytest.mark.parametrize('module_name', backend_module_names)
 def test_backend_getattr(module_name):
-    proc = subprocess_run_helper(_test_module_getattr, module_name,
-                                 timeout=120 if is_ci_environment() else 20)
+    proc = subprocess_run_helper(_test_module_getattr, module_name, timeout=20)
     if 'SKIP: ' in proc.stdout:
         pytest.skip(proc.stdout.removeprefix('SKIP: '))
     print(proc.stdout)

--- a/lib/matplotlib/tests/test_pickle.py
+++ b/lib/matplotlib/tests/test_pickle.py
@@ -9,7 +9,7 @@ import pytest
 
 import matplotlib as mpl
 from matplotlib import cm
-from matplotlib.testing import subprocess_run_helper, is_ci_environment
+from matplotlib.testing import subprocess_run_helper
 from matplotlib.testing.decorators import check_figures_equal
 from matplotlib.dates import rrulewrapper  # type: ignore[attr-defined]
 from matplotlib.lines import VertexSelector
@@ -319,6 +319,6 @@ def _test_axeswidget_interactive():
 def test_axeswidget_interactive():
     subprocess_run_helper(
         _test_axeswidget_interactive,
-        timeout=120 if is_ci_environment() else 20,
+        timeout=20,
         extra_env={'MPLBACKEND': 'tkagg'}
     )


### PR DESCRIPTION
## PR summary

Some places do, and some places don't, increase the timeout when running on CI. Instead of having that accidental inconsistency, increase the timeout for everything in the helper function.

For example, I've just now seen `test_dpi_change_triggers_resize` fail, and it has a fixed timeout of 60 instead of raising it to 120 like other tests.

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines