### PR TITLE
DOC: add boilerplate guidelines to api changes

### DIFF
--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -50,7 +50,7 @@ Add or change pyplot method signature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 When changing the signature of a method wrapped by :doc:`pyplot <doc/api/pyplot_summary>`
 , run :file:`lib/matplotlib/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
-and you had intended to change the signatures, run :file:`tools\boilerplate.py` to
+and you had intended to change the signatures, run :file:`tools/boilerplate.py` to
 generate new pyplot wrappers and commit the changes.
 
 

--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -48,7 +48,7 @@ When adding a new rcParam, the following files must be updated:
 
 Add or change pyplot method signature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When changing the signature of a method wrapped by :doc:`pyplot <doc/api/pyplot_summary>`
+When changing the signature of a method wrapped by :doc:`pyplot </api/pyplot_summary>`
 , run :file:`lib/matplotlib/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
 and you had intended to change the signatures, run :file:`tools/boilerplate.py` to
 generate new pyplot wrappers and commit the changes.

--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -48,7 +48,7 @@ When adding a new rcParam, the following files must be updated:
 
 Add or change pyplot method signature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When changing the signature of a method wrapped by :doc:`pyplot <.doc/api/pyplot_summary>`
+When changing the signature of a method wrapped by :doc:`pyplot <doc/api/pyplot_summary>`
 , run :file:`lib/matplotlib/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
 and you had intended to change the signatures, run :file:`tools\boilerplate.py` to
 generate new pyplot wrappers and commit the changes.

--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -48,8 +48,8 @@ When adding a new rcParam, the following files must be updated:
 
 Add or change pyplot method signature
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-When changing the signature of a method wrapped by :doc:`pyplot </api/pyplot_summary>`
-, run :file:`lib/matplotlib/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
+When changing the signature of a method wrapped by :doc:`pyplot </api/pyplot_summary>`,
+run :file:`lib/matplotlib/tests/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
 and you had intended to change the signatures, run :file:`tools/boilerplate.py` to
 generate new pyplot wrappers and commit the changes.
 

--- a/doc/devel/api_changes.rst
+++ b/doc/devel/api_changes.rst
@@ -46,8 +46,16 @@ When adding a new rcParam, the following files must be updated:
    so that it is recognized as a valid rcParam key.
 
 
+Add or change pyplot method signature
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+When changing the signature of a method wrapped by :doc:`pyplot <.doc/api/pyplot_summary>`
+, run :file:`lib/matplotlib/test_pyplot.py::test_pyplot_up_to_date`. If the test fails
+and you had intended to change the signatures, run :file:`tools\boilerplate.py` to
+generate new pyplot wrappers and commit the changes.
+
+
 Add or change colormaps, color sequences, and styles
-----------------------------------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 Visual changes are considered an API break. Therefore, we generally do not modify
 existing colormaps, color sequences, or styles.
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

Followup to #30562 b/c during today's gsoc meeting would have been useful to have a doc link w/ all the info. Also moves the "add color" stuff down a heading level 'cause it's part of the broader "what to do when adding" discussion. 

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [ ] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
