### PR TITLE
ENH: Add screen-proportional mutation_aspect to FancyBboxPatch

### DIFF
--- a/lib/matplotlib/patches.py
+++ b/lib/matplotlib/patches.py
@@ -4053,11 +4053,17 @@ class FancyBboxPatch(Patch):
             Scaling factor applied to the attributes of the box style
             (e.g. pad or rounding_size).
 
-        mutation_aspect : float, default: 1
+        mutation_aspect : float or str, default: 1
             The height of the rectangle will be squeezed by this value before
             the mutation and the mutated box will be stretched by the inverse
             of it. For example, this allows different horizontal and vertical
             padding.
+
+            The special value ``"screen-proportional"`` resolves the aspect
+            dynamically from the axes at draw time, so that the box is scaled
+            proportionally to the display scaling of the data.  This keeps
+            features such as the rounding of ``"Round"`` boxstyles circular
+            on screen, independent of the axes aspect ratio.
 
         Other Parameters
         ----------------
@@ -4140,8 +4146,15 @@ class FancyBboxPatch(Patch):
 
         Parameters
         ----------
-        aspect : float
+        aspect : float or "screen-proportional"
+            A float value, or the string ``"screen-proportional"`` to resolve
+            the aspect dynamically from the axes at draw time (see
+            `.FancyBboxPatch` for details).
         """
+        if (not isinstance(aspect, (int, float))
+                and aspect != "screen-proportional"):
+            raise ValueError(
+                "mutation_aspect must be a number or 'screen-proportional'")
         self._mutation_aspect = aspect
         self.stale = True
 
@@ -4150,10 +4163,26 @@ class FancyBboxPatch(Patch):
         return (self._mutation_aspect if self._mutation_aspect is not None
                 else 1)  # backcompat.
 
+    def _get_screen_proportional_aspect(self):
+        """Return the mutation aspect that is isotropic in display space."""
+        axes = self.axes
+        if axes is None:
+            return 1
+        # Display-space size of the Axes and of one data unit in each
+        # direction, so that the box is scaled like the data on screen.
+        bbox = axes.get_window_extent()
+        txmin, txmax = axes.xaxis.get_transform().transform(axes.get_xbound())
+        tymin, tymax = axes.yaxis.get_transform().transform(axes.get_ybound())
+        xsize = max(abs(txmax - txmin), 1e-30)
+        ysize = max(abs(tymax - tymin), 1e-30)
+        return bbox.width * ysize / (bbox.height * xsize)
+
     def get_path(self):
         """Return the mutated path of the rectangle."""
         boxstyle = self.get_boxstyle()
         m_aspect = self.get_mutation_aspect()
+        if m_aspect == "screen-proportional":
+            m_aspect = self._get_screen_proportional_aspect()
         # Call boxstyle with y, height squeezed by aspect_ratio.
         path = boxstyle(self._x, self._y / m_aspect,
                         self._width, self._height / m_aspect,

--- a/lib/matplotlib/tests/test_patches.py
+++ b/lib/matplotlib/tests/test_patches.py
@@ -813,6 +813,46 @@ def test_boxstyle_errors(fmt, match):
         BoxStyle(fmt)
 
 
+def test_fancybbox_patch_screen_proportional_mutation_aspect():
+    fig, ax = plt.subplots(figsize=(10, 5))
+    w, h = 0.18, 1.0
+    patch = mpatches.FancyBboxPatch(
+        (0.3, 0), w, h,
+        boxstyle=BoxStyle("Round", pad=0, rounding_size=w / 2),
+        mutation_aspect="screen-proportional")
+    ax.add_patch(patch)
+    ax.autoscale_view()
+    fig.canvas.draw()
+
+    # The corner of the Round box must be a circular arc in display space,
+    # i.e. the rounding is isotropic on screen.
+    verts = patch.get_transform().transform(patch.get_path().vertices)
+    # Bottom-right corner: verts[1] = (x1 - dr, y0), verts[2] = (x1, y0),
+    # verts[3] = (x1, y0 + dr).
+    np.testing.assert_allclose(verts[2, 0] - verts[1, 0],
+                               verts[3, 1] - verts[2, 1])
+
+    # A plain numeric mutation_aspect does not compensate the axes aspect.
+    patch.set_mutation_aspect(1)
+    verts = patch.get_transform().transform(patch.get_path().vertices)
+    assert not np.isclose(verts[2, 0] - verts[1, 0],
+                          verts[3, 1] - verts[2, 1])
+
+    with pytest.raises(ValueError, match="mutation_aspect"):
+        patch.set_mutation_aspect("bogus")
+
+
+def test_fancybbox_patch_screen_proportional_without_axes():
+    # Without an Axes the screen aspect cannot be resolved; it falls back to 1.
+    patch = mpatches.FancyBboxPatch(
+        (0, 0), 0.2, 0.1,
+        boxstyle=BoxStyle("Round", pad=0, rounding_size=0.1),
+        mutation_aspect="screen-proportional")
+    verts = patch.get_path().vertices
+    np.testing.assert_allclose(verts[2, 0] - verts[1, 0],
+                               verts[3, 1] - verts[2, 1])
+
+
 @image_comparison(['annulus.png'], style='mpl20')
 def test_annulus():
 


### PR DESCRIPTION
## PR summary

### What problem existed

`FancyBboxPatch` requires a numeric `mutation_aspect` to compensate for a non-unit axes aspect ratio. In a plot with `aspect="auto"` (e.g. a typical bar chart), the rounding of `BoxStyle("Round", ...)` is drawn as an ellipse on screen, not a circle. The only way to get isotropic rounding was the private workaround `mutation_aspect=1/ax._get_aspect_ratio()`, which is also computed too early (before layout) and therefore stale by draw time.

### How it was reproduced

```py
import matplotlib.pyplot as plt
from matplotlib.patches import FancyBboxPatch, BoxStyle

def add_bar(ax, x, y, w, h, mutation_aspect=1):
    patch = FancyBboxPatch(
        (x, y), w, h,
        boxstyle=BoxStyle("Round", pad=0, rounding_size=w / 2),
        linewidth=0, facecolor="C0",
        mutation_aspect=mutation_aspect,
    )
    ax.add_patch(patch)

fig, ax = plt.subplots(figsize=(10, 5))
x, y, w, h = 0.3, 0, 0.18, 1
add_bar(ax, x, y, w, h)
ax.autoscale_view()
fig.canvas.draw()
```

### What caused it

`FancyBboxPatch.get_path()` applies `mutation_aspect` in data coordinates only. When the axes display scaling differs between x and y (`aspect != 1`), a data-space circle is drawn as an on-screen ellipse. There was no public way to opt in to resolving the aspect ratio from the axes.

### What changed

`FancyBboxPatch.mutation_aspect` now additionally accepts the string `"screen-proportional"`. At draw time the patch resolves it from the owning axes using public API (`get_window_extent`, axis transforms), so the box is scaled like the data on screen and the rounding renders circular regardless of the axes aspect ratio. `set_mutation_aspect` validates the new value.

### Why this approach

The issue proposed an opt-in mode; discussion suggested a name that is more specific than a generic `"auto"`. The resolution is deferred to draw time so the layout (and thus the display scaling) is final, fixing the stale-value problem of the private-API workaround. All existing numeric behavior is unchanged.

### How it was tested

- `python -m pytest lib/matplotlib/tests/test_patches.py -k "mutation_aspect" -v` → 1 passed
- `python -m pytest lib/matplotlib/tests/test_patches.py` → 73 passed, 11 skipped (pre-existing skips)
- Added tests: display-space circular corner check with a non-unit-aspect axes, fallback to 1 without an Axes, and `ValueError` on invalid values.

### Risks / limitations

- Without an attached Axes, `"screen-proportional"` falls back to an aspect of 1 (documented in the new tests).
- The resolved aspect is a snapshot at draw time; it updates when the figure is redrawn after a resize.

### Related issue

Closes #31175
