### PR TITLE
BLD: Force all internal extension symbols to be hidden

### DIFF
--- a/src/hidden-symbols.map
+++ b/src/hidden-symbols.map
@@ -1,0 +1,6 @@
+{
+	global:
+		PyInit_*;
+	local:
+		*;
+};

--- a/src/meson.build
+++ b/src/meson.build
@@ -131,9 +131,19 @@ else
   new_preprocessor = []
 endif
 
+# Even though Meson defaults to hidden visibility, our bundled libraries like FreeType
+# may themselves export their own symbols individually. So force all symbols other than
+# the Python module initialization function to be hidden with a linker version script.
+mapfile = 'hidden-symbols.map'
+vflag = cc.get_supported_link_arguments([
+  '-Wl,--version-script,@0@/@1@'.format(meson.current_source_dir(), mapfile)
+])
+
 foreach ext, kwargs : extension_data
   additions = {
     'cpp_args': [new_preprocessor] + kwargs.get('cpp_args', []),
+    'link_args': [vflag] + kwargs.get('link_args', []),
+    'link_depends': [mapfile] + kwargs.get('link_depends', []),
   }
   py3.extension_module(
     ext,


### PR DESCRIPTION
## PR summary

Even though Meson defaults to hidden visibility, our bundled libraries like FreeType may themselves export their own symbols individually. So force all symbols other than the Python module initialization function to be hidden with a linker version script.

By making symbols like `FT_Init_Freetype` local, it ensures that they cannot be resolved by other global versions, such as a system copy loaded beforehand. It also allows the linker to discard more sections for unused code, saving us approximately 6.6% in shared library space.

Fixes #32208

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines