### PR TITLE
Allow setting frequency units for psd plots

### DIFF
--- a/doc/release/next_whats_new/new_psd_feature.rst
+++ b/doc/release/next_whats_new/new_psd_feature.rst
@@ -13,7 +13,7 @@ assumed to be Hz.)
     dt = 1/24
 
     # Create example signal: sinusoid with red noise
-    np.random.seed(19680801) # Fixing random state for reproducibility
+    np.random.seed(19680801)  # Fixing random state for reproducibility.
     t = np.arange(0, 20, dt)
     nse = np.random.randn(len(t))
     r = np.exp(-t / 0.05)

--- a/doc/release/next_whats_new/new_psd_feature.rst
+++ b/doc/release/next_whats_new/new_psd_feature.rst
@@ -1,0 +1,32 @@
+Sampling frequency units can be specified for `.Axes.psd`
+---------------------------------------------------------
+
+When creating a power spectral density (psd) plot, the units of the
+sampling frequency can be specified. (Units were previously always
+assumed to be Hz.)
+
+.. plot::
+    :include-source: true
+    :alt: Time series and its power spectral density (psd), where the psd is correctly labeled with frequency units
+
+    import matplotlib.pyplot as plt
+    import numpy as np
+
+    # Sampling period in units of days
+    dt = 1/24
+
+    # Create example signal: sinusoid with red noise
+    np.random.seed(19680801) # Fixing random state for reproducibility
+    t = np.arange(0, 20, dt)
+    nse = np.random.randn(len(t))
+    r = np.exp(-t / 0.05)
+    cnse = np.convolve(nse, r) * dt
+    cnse = cnse[:len(t)]
+    s = 0.1 * np.sin(2 * np.pi * t) + cnse
+
+    # Show signal and power spectral density
+    fig, (ax0, ax1) = plt.subplots(2, 1, layout='constrained')
+    ax0.plot(t,s)
+    ax0.set(xlabel='Time (d)', ylabel='Signal')
+    ax1.psd(s, NFFT=256, Fs=1 / dt, Funits='cpd')
+    plt.show()

--- a/doc/release/next_whats_new/new_psd_feature.rst
+++ b/doc/release/next_whats_new/new_psd_feature.rst
@@ -9,9 +9,6 @@ assumed to be Hz.)
     :include-source: true
     :alt: Time series and its power spectral density (psd), where the psd is correctly labeled with frequency units
 
-    import matplotlib.pyplot as plt
-    import numpy as np
-
     # Sampling period in units of days
     dt = 1/24
 

--- a/galleries/examples/statistics/psd_demo.py
+++ b/galleries/examples/statistics/psd_demo.py
@@ -33,6 +33,9 @@ ax0.plot(t, s)
 ax0.set_xlabel('Time (s)')
 ax0.set_ylabel('Signal')
 ax1.psd(s, NFFT=512, Fs=1 / dt)
+# If dt had other units (e.g. days instead of seconds),
+# then the units of Fs (e.g. cycles per day or cps) can be specified
+# by the keyword Funits (e.g. Funits='cpd') in psd.
 
 plt.show()
 

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -8113,7 +8113,8 @@ such objects
     @_docstring.interpd
     def psd(self, x, NFFT=None, Fs=None, Fc=None, detrend=None,
             window=None, noverlap=None, pad_to=None,
-            sides=None, scale_by_freq=None, return_line=None, **kwargs):
+            sides=None, scale_by_freq=None, return_line=None, Funits=None,
+            **kwargs):
         r"""
         Plot the power spectral density.
 
@@ -8146,6 +8147,12 @@ such objects
 
         return_line : bool, default: False
             Whether to include the line object plotted in the returned values.
+
+        Funits : str, default: 'Hz'
+            Units for the sampling frequency *Fs*. It is used to label the
+            xaxis and yaxis.
+
+            .. versionadded:: 3.12
 
         Returns
         -------
@@ -8194,6 +8201,8 @@ such objects
         """
         if Fc is None:
             Fc = 0
+        if Funits is None:
+            Funits = 'Hz'
 
         pxx, freqs = mlab.psd(x=x, NFFT=NFFT, Fs=Fs, detrend=detrend,
                               window=window, noverlap=noverlap, pad_to=pad_to,
@@ -8201,12 +8210,12 @@ such objects
         freqs += Fc
 
         if scale_by_freq in (None, True):
-            psd_units = 'dB/Hz'
+            psd_units = 'dB/%s' % Funits
         else:
             psd_units = 'dB'
 
         line = self.plot(freqs, 10 * np.log10(pxx), **kwargs)
-        self.set_xlabel('Frequency')
+        self.set_xlabel('Frequency (%s)' % Funits)
         self.set_ylabel('Power Spectral Density (%s)' % psd_units)
         self.grid(True)
 

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -654,6 +654,7 @@ class Axes(_AxesBase):
         scale_by_freq: bool | None = ...,
         return_line: bool | None = ...,
         data: DataParamType = ...,
+        Funits: str | None = ...,
         **kwargs
     ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, Line2D]: ...
     def csd(

--- a/lib/matplotlib/axes/_axes.pyi
+++ b/lib/matplotlib/axes/_axes.pyi
@@ -653,8 +653,8 @@ class Axes(_AxesBase):
         sides: Literal["default", "onesided", "twosided"] | None = ...,
         scale_by_freq: bool | None = ...,
         return_line: bool | None = ...,
-        data: DataParamType = ...,
         Funits: str | None = ...,
+        data: DataParamType = ...,
         **kwargs
     ) -> tuple[np.ndarray, np.ndarray] | tuple[np.ndarray, np.ndarray, Line2D]: ...
     def csd(

--- a/lib/matplotlib/mlab.py
+++ b/lib/matplotlib/mlab.py
@@ -362,9 +362,9 @@ def _spectral_helper(x, y=None, NFFT=None, Fs=None, detrend_func=None,
 
         result[slc] *= scaling_factor
 
-        # MATLAB divides by the sampling frequency so that density function
-        # has units of dB/Hz and can be integrated by the plotted frequency
-        # values. Perform the same scaling here.
+        # Divide by the sampling frequency so that density function
+        # has units of V**2/Hz, if x is measured in units of V and the sampling
+        # frequency is measured in Hz.
         if scale_by_freq:
             result /= Fs
             # Scale the spectrum by the norm of the window to compensate for
@@ -470,10 +470,10 @@ detrend : {'none', 'mean', 'linear'} or callable, default: 'none'
     `.detrend_mean`. 'linear' calls `.detrend_linear`.
 
 scale_by_freq : bool, default: True
-    Whether the resulting density values should be scaled by the scaling
-    frequency, which gives density in units of 1/Hz.  This allows for
-    integration over the returned frequency values.  The default is True for
-    MATLAB compatibility.""")
+    Whether the resulting density values should be divided by the sampling
+    frequency, which gives density in units of 1/Hz, if the sampling rate
+    is measured in Hz.  This allows for integration over the returned
+    frequency values.  The default is True for MATLAB compatibility.""")
 
 
 @_docstring.interpd

--- a/lib/matplotlib/pyplot.py
+++ b/lib/matplotlib/pyplot.py
@@ -4070,6 +4070,7 @@ def psd(
     sides: Literal["default", "onesided", "twosided"] | None = None,
     scale_by_freq: bool | None = None,
     return_line: bool | None = None,
+    Funits: str | None = None,
     *,
     data: DataParamType = None,
     **kwargs,
@@ -4086,6 +4087,7 @@ def psd(
         sides=sides,
         scale_by_freq=scale_by_freq,
         return_line=return_line,
+        Funits=Funits,
         **({"data": data} if data is not None else {}),
         **kwargs,
     )


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
This PR allows users to specify the units for the sampling frequency in power spectral density (psd) plots. psd previously assumed units to be Hz and displayed Hz on the y-axis label. Users can now specify other units with the `Funits` keyword. If the keyword is omitted, Hz is assumed by default, so the change is backward compatible. This change has no effect on the psd calculation, only the resulting plot.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
No AI was used

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
