### PR TITLE
TST: Convert all non-RGB(A) images to RGBA

### DIFF
--- a/lib/matplotlib/testing/compare.py
+++ b/lib/matplotlib/testing/compare.py
@@ -401,11 +401,16 @@ def calculate_rms(expected_image, actual_image):
 
 def _load_image(path):
     img = Image.open(path)
-    # In an RGBA image, if the smallest value in the alpha channel is 255, all
-    # values in it must be 255, meaning that the image is opaque. If so,
-    # discard the alpha channel so that it may compare equal to an RGB image.
-    if img.mode != "RGBA" or img.getextrema()[3][0] == 255:
-        img = img.convert("RGB")
+    if img.mode != "RGB":
+        # If we have anything other than RGB(A) (e.g., a paletted image), convert it
+        # to RGBA.
+        if img.mode != "RGBA":
+            img = img.convert("RGBA")
+        # In an RGBA image, if the smallest value in the alpha channel is 255, all
+        # values in it must be 255, meaning that the image is opaque. If so, discard the
+        # alpha channel so that it may compare equal to an RGB image.
+        if img.getextrema()[3][0] == 255:
+            img = img.convert("RGB")
     return np.asarray(img)
 
 


### PR DESCRIPTION
## PR summary

Sometimes, `oxipng` may optimize an image by making it use a palette, and converting that directly to RGB causes a warning from Pillow. In fact, it may be wrong, since there may be transparency in the palette.

Instead of checking all image formats, convert everything non-RGB(A) to RGBA first.

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines