### PR TITLE
ScaleBase.val_in_range: stop swallowing errors from limit_range_for_scale

### DIFF
--- a/doc/release/next_whats_new/scale_val_in_range_errors.rst
+++ b/doc/release/next_whats_new/scale_val_in_range_errors.rst
@@ -1,0 +1,9 @@
+Custom scales no longer silently discard data when their
+``limit_range_for_scale`` implementation fails
+-------------------------------------------------
+
+`~.ScaleBase.val_in_range` previously caught ``TypeError`` and ``ValueError``
+raised by a custom scale's `~.ScaleBase.limit_range_for_scale` and returned an
+all-``False`` mask, which caused the data to be silently blanked on the plot
+(e.g. in 3D).  Such errors are now propagated to the user instead, making
+misbehaving custom scales much easier to debug.

--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -125,12 +125,8 @@ class ScaleBase:
         """
         arr = np.asarray(val)
         with np.errstate(invalid='ignore'):
-            try:
-                vmin, vmax = self.limit_range_for_scale(arr, arr, minpos=1e-300)
-            except (TypeError, ValueError):
-                result = np.zeros(arr.shape, dtype=bool)
-            else:
-                result = np.isfinite(arr) & (vmin == arr) & (vmax == arr)
+            vmin, vmax = self.limit_range_for_scale(arr, arr, minpos=1e-300)
+            result = np.isfinite(arr) & (vmin == arr) & (vmax == arr)
         return bool(result) if arr.ndim == 0 else result
 
 

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -497,3 +497,28 @@ def test_val_in_range_array():
     out = mscale._scale_mapping['log'](axis=None).val_in_range(
         np.array([[1.0, -1.0], [0.5, np.nan]]))
     np.testing.assert_array_equal(out, [[True, False], [True, False]])
+
+
+def test_val_in_range_does_not_swallow_limit_range_errors():
+    # A custom scale whose ``limit_range_for_scale`` rejects array input must
+    # surface the error instead of silently marking every value out of range
+    # (which previously blanked all data on the plot).
+    # See https://github.com/matplotlib/matplotlib/issues/32129.
+    class ScalarOnlyScale(mscale.ScaleBase):
+        def get_transform(self):
+            raise NotImplementedError
+
+        def set_default_locators_and_formatters(self, axis):
+            raise NotImplementedError
+
+        def limit_range_for_scale(self, vmin, vmax, minpos):
+            if np.ndim(vmin) != 0:
+                raise TypeError("limit_range_for_scale only supports scalars")
+            return vmin, vmax
+
+    s = ScalarOnlyScale(axis=None)
+    # Scalar input still works through the generic implementation.
+    assert s.val_in_range(1.0) is True
+    # Array input now raises instead of returning an all-False mask.
+    with pytest.raises(TypeError, match="only supports scalars"):
+        s.val_in_range(np.array([1.0, 2.0, 3.0]))


### PR DESCRIPTION
## PR summary

Closes #32129

`ScaleBase.val_in_range` previously caught `TypeError`/`ValueError` raised by a custom scale's `limit_range_for_scale` and returned an all-`False` mask. For a scalar-only custom scale, this silently blanked every point on the plot (the reporter hit it in 3D) with no error surfaced.

Per the discussion in #32129, the try/except is removed so the error propagates to the user instead of being swallowed.

```python
# Before: silently blanks all data
s.val_in_range(np.array([1.0, 2.0, 3.0]))   # -> array([False, False, False])

# After: surfaces the real error
s.val_in_range(np.array([1.0, 2.0, 3.0]))   # -> TypeError: ...
```

The only in-tree scale using the generic implementation is `FuncScale`, whose `limit_range_for_scale` is the identity base implementation and can never hit the removed except path — no behavior change for built-in scales.

## PR checklist

- [x] Has Pytest style unit tests
- [x] Code is PEP 8 compliant
- [x] New features are documented (What's New entry added)
- [x] API changes documented (`next_whats_new` entry added)
- [x] Tested with the `Agg` backend
- [x] CI passes (see below)

Verified locally: `test_scale.py` (26 passed), `test_axis.py` + `test_contour.py` (96 passed), and `mpl_toolkits/mplot3d` (244 passed).
