### PR TITLE
DOC: fix stale 'examples/api directory' reference in UI gallery header

### DIFF
--- a/galleries/examples/user_interfaces/GALLERY_HEADER.rst
+++ b/galleries/examples/user_interfaces/GALLERY_HEADER.rst
@@ -9,5 +9,5 @@ Matplotlib supports PyQt/PySide, PyGObject, Tkinter, and wxPython.
 
 When embedding Matplotlib in a GUI, you must use the Matplotlib API
 directly rather than the pylab/pyplot procedural interface, so take a
-look at the examples/api directory for some example code working with
-the API.
+look at the examples in this directory for some example code working
+with the API.


### PR DESCRIPTION
Closes #31935. The GALLERY_HEADER.rst for user_interfaces still points readers to the nonexistent 'examples/api directory'. This updates the text to point to the examples in the current user_interfaces directory instead.

Doc-only change; no behavior/logic affected.