### PR TITLE
Qt IconEngine: Use a device pixel ratio of 1 when high-DPI pixmaps are disabled

### DIFF
--- a/lib/matplotlib/backends/backend_qt.py
+++ b/lib/matplotlib/backends/backend_qt.py
@@ -723,7 +723,12 @@ class _IconEngine(QtGui.QIconEngine):
 
     def _devicePixelRatio(self):
         """Return the current device pixel ratio for the toolbar, defaulting to 1."""
-        return (self.toolbar.devicePixelRatioF() or 1) if self.toolbar else 1
+        use_high_dpi_pixmaps = True
+        if hasattr(QtCore.Qt.ApplicationAttribute, "AA_UseHighDpiPixmaps"):
+            app = QtWidgets.QApplication.instance()
+            use_high_dpi_pixmaps = app.testAttribute(QtCore.Qt.AA_UseHighDpiPixmaps)
+        toolbar_dpr = (self.toolbar.devicePixelRatioF() or 1) if self.toolbar else 1
+        return toolbar_dpr if use_high_dpi_pixmaps else 1
 
     def _create_pixmap_from_svg(self, svg_path, size):
         """Create a pixmap from SVG with proper scaling and dark mode support."""


### PR DESCRIPTION
## PR summary

On Qt5, if the `QApplication` instance has an `AA_UseHighDpiPixmaps` attribute set to false, our `_IconEngine` will return icons that are too large.

Check this attribute and return `1` for `_IconEngine._devicePixelRatio()` if high DPI pixmaps are disabled.

This attribute is always true on Qt6.

Closes #32217


## AI Disclosure

I used AI to help me write a test reduction for #32217. I used AI to help me clean up the resulting implementation.


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [X] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) *Tested manually, I don't know how to automate this.*
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines