### PR TITLE
Fix ResizeEvent handling for TextBox

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -4,7 +4,7 @@ import operator
 from unittest import mock
 
 import matplotlib as mpl
-from matplotlib.backend_bases import DrawEvent, KeyEvent, MouseEvent
+from matplotlib.backend_bases import DrawEvent, KeyEvent, MouseEvent, ResizeEvent
 import matplotlib.colors as mcolors
 import matplotlib.widgets as widgets
 import matplotlib.pyplot as plt
@@ -1096,6 +1096,8 @@ def test_TextBox(ax, toolbar):
     KeyEvent("key_press_event", ax.figure.canvas, "5")._process()
 
     assert text_change_event.call_count == 3
+
+    ResizeEvent("resize_event", ax.figure.canvas)._process()  # smoke test
 
 
 def test_RadioButtons(ax):

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -1718,7 +1718,6 @@ class TextBox(AxesWidget):
         self.cursor_index = self.text_disp._char_index_at(event.x)
         self._rendercursor()
 
-    @_call_with_reparented_event
     def _resize(self, event):
         self.stop_typing()
 


### PR DESCRIPTION
## PR summary

A `ResizeEvent` is not a `LocationEvent` subclass, so it does not need to be reparented to the correct `Axes`.

Fixes #32222

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines