### PR TITLE
ft2font: Make glyph loading failures more robust

### DIFF
--- a/lib/matplotlib/tests/test_ft2font.py
+++ b/lib/matplotlib/tests/test_ft2font.py
@@ -933,6 +933,12 @@ def test_ft2font_loading():
     file = fm.findfont('DejaVu Sans')
     font = ft2font.FT2Font(file)
     font.set_size(12, 72)
+    with pytest.warns(UserWarning,
+                      match=r'Glyph 6504 \(\\N{TAI LE LETTER OO}\) missing from '
+                            r'font\(s\) DejaVu Sans\.'):
+        with pytest.raises(RuntimeError, match='failed to find glyph to load'):
+            # Character doesn't exist in DejaVu Sans, and no fallback defined.
+            font.load_char(0x1968)
     for glyph in [font.load_char(ord('M')),
                   font.load_glyph(font.get_char_index(ord('M')))]:
         assert glyph is not None
@@ -946,7 +952,7 @@ def test_ft2font_loading():
         assert glyph.vertBearingY == 64
         assert glyph.vertAdvance == 832
         assert glyph.bbox == (54, 0, 574, 576)
-    assert font.get_num_glyphs() == 2  # Both count as loaded.
+    assert font.get_num_glyphs() == 2  # Both valid glyphs count as loaded.
     # But neither has been placed anywhere.
     assert font.get_width_height() == (0, 0)
     assert font.get_descent() == 0

--- a/src/ft2font.cpp
+++ b/src/ft2font.cpp
@@ -535,9 +535,13 @@ void FT2Font::load_char(long charcode, FT_Int32 flags, FT2Font *&ft_object, bool
             ft_glyph_warn(charcode, glyph_seen_fonts);
             if (charcode_error) {
                 THROW_FT_ERROR("charcode loading", charcode_error);
-            }
-            else if (glyph_error) {
+            } else if (glyph_error) {
                 THROW_FT_ERROR("charcode loading", glyph_error);
+            } else {
+                throw std::runtime_error{
+                    "charcode loading (ft2font.cpp line " + std::to_string(__LINE__) +
+                    ") failed to find glyph to load"
+                };
             }
         } else if (ft_object_with_glyph->warn_if_used) {
             ft_glyph_warn(charcode, glyph_seen_fonts);

--- a/src/ft2font_wrapper.cpp
+++ b/src/ft2font_wrapper.cpp
@@ -248,6 +248,10 @@ const char *PyGlyph__doc__ = R"""(
 static PyGlyph *
 PyGlyph_from_FT2Font(const FT2Font *font)
 {
+    if (font == nullptr || font->get_num_glyphs() == 0) {
+        throw std::runtime_error("No glyphs have been loaded.");
+    }
+
     const FT_Face &face = font->get_face();
     const FT_Glyph &glyph = font->get_last_glyph();
 


### PR DESCRIPTION
## PR summary
The main fix is to `FT2Font::load_char`, which didn't correctly fail if no fallback was defined to catch missing glyphs.

Also, while `PyGlyph_from_FT2Font` is internal and should never be called before loading a glyph, add a check in there anyway, just to be safe.

Fixes #32224

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines