### PR TITLE
Fixed a bug with drawing an empty Collection

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -359,7 +359,7 @@ class Collection(mcolorizer.ColorizingArtist):
 
     @artist.allow_rasterization
     def draw(self, renderer):
-        if not self.get_visible():
+        if not self.get_visible() or len(self.get_offsets()) == 0:
             return
         renderer.open_group(self.__class__.__name__, self.get_gid())
 

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -366,6 +366,7 @@ class Collection(mcolorizer.ColorizingArtist):
         # Bail if the collection does not have any offsets (e.g., an empty scatter plot)
         if len(self.get_offsets()) == 0:
             renderer.close_group(self.__class__.__name__)
+            self.stale = False
             return
 
         self.update_scalarmappable()

--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -359,9 +359,14 @@ class Collection(mcolorizer.ColorizingArtist):
 
     @artist.allow_rasterization
     def draw(self, renderer):
-        if not self.get_visible() or len(self.get_offsets()) == 0:
+        if not self.get_visible():
             return
         renderer.open_group(self.__class__.__name__, self.get_gid())
+
+        # Bail if the collection does not have any offsets (e.g., an empty scatter plot)
+        if len(self.get_offsets()) == 0:
+            renderer.close_group(self.__class__.__name__)
+            return
 
         self.update_scalarmappable()
 

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3217,6 +3217,24 @@ class TestScatter:
                         facecolors=["#ffffff", "#000000", "#f0f0f0"],
                             facecolor="#ffffff")
 
+    @pytest.mark.parametrize('edgecolor, facecolor, linestyle',
+                             [('red', 'blue', 'solid'),
+                              ('red', 'blue', 'dashed'),
+                              ('red', 'none', 'solid'),
+                              ('none', 'blue', 'solid')])
+    @check_figures_equal()
+    def test_empty_scatter(self, fig_test, fig_ref, edgecolor, facecolor, linestyle):
+        # Verify that a spurious marker is not plotted in the bottom-left corner
+        # https://github.com/matplotlib/matplotlib/issues/32219
+        ax_test = fig_test.subplots()
+        ax_test.scatter([], [], ec=edgecolor, fc=facecolor, ls=linestyle, clip_on=False)
+        ax_test.set_xlim(0, 1)
+        ax_test.set_ylim(0, 1)
+
+        ax_ref = fig_ref.subplots()
+        ax_ref.set_xlim(0, 1)
+        ax_ref.set_ylim(0, 1)
+
 
 def _params(c=None, xsize=2, *, edgecolors=None, **kwargs):
     return (c, edgecolors, kwargs, xsize)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

The PR fixes a bug (fixes #32219) with drawing an empty scatter plot creating a `PathCollection` with an empty `offsets` list.  Renderers can interpret this (incorrectly) as wanting a single marker with no offset rather than no markers.  This PR simply bails out of the `draw()` call when `offsets` is empty.

~Fixes a bug revealed in #32219, where specifying `facecolor="none"` (or `edgecolor="none"`) went down a different code path than specifying a color.  It turns out that specifying `"none"` would not be understood as a single color – because zero colors is not equal to one color – which would prevent the optimized drawing of a collection when there is just a single path (allowing the use of `draw_markers()` instead of `draw_path_collection()`).~ I'm going to create an issue for this because it opened up a can of worms.  Edit: Ah, #17790 already exists, so I have created #32232 for discussion.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
No AI was used

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
