### PR TITLE
Fix `Collection.draw()` single-path optimization when edgecolor/facecolor is 'none'

### DIFF
--- a/lib/matplotlib/collections.py
+++ b/lib/matplotlib/collections.py
@@ -393,7 +393,7 @@ class Collection(mcolorizer.ColorizingArtist):
         edgecolors = self.get_edgecolor()
         do_single_path_optimization = False
         if (len(paths) == 1 and len(trans) <= 1 and
-                len(facecolors) == 1 and len(edgecolors) == 1 and
+                len(facecolors) <= 1 and len(edgecolors) <= 1 and
                 len(self._linewidths) == 1 and
                 all(ls[1] is None for ls in self._linestyles) and
                 len(self._antialiaseds) == 1 and len(self._urls) == 1 and
@@ -414,14 +414,16 @@ class Collection(mcolorizer.ColorizingArtist):
             gc.set_capstyle(self._capstyle)
 
         if do_single_path_optimization:
-            gc.set_foreground(tuple(edgecolors[0]), isRGBA=True)
+            edgecolor = edgecolors[0] if len(edgecolors) == 1 else (0, 0, 0, 0)
+            facecolor = facecolors[0] if len(facecolors) == 1 else (0, 0, 0, 0)
+            gc.set_foreground(tuple(edgecolor), isRGBA=True)
             gc.set_linewidth(self._linewidths[0])
             gc.set_dashes(*self._linestyles[0])
             gc.set_antialiased(self._antialiaseds[0])
             gc.set_url(self._urls[0])
             renderer.draw_markers(
                 gc, paths[0], combined_transform.frozen(),
-                mpath.Path(offsets), offset_trf, tuple(facecolors[0]))
+                mpath.Path(offsets), offset_trf, tuple(facecolor))
         else:
             # The current new API of draw_path_collection() is provisional
             # and will be changed in a future PR.

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -3217,6 +3217,16 @@ class TestScatter:
                         facecolors=["#ffffff", "#000000", "#f0f0f0"],
                             facecolor="#ffffff")
 
+    @check_figures_equal()
+    def test_scatter_color_none(self, fig_test, fig_ref):
+        ax_test = fig_test.subplots()
+        ax_test.scatter([1], [1], facecolor='red', edgecolor='none')
+        ax_test.scatter([2], [2], facecolor='none', edgecolor='blue')
+
+        ax_ref = fig_ref.subplots()
+        ax_ref.scatter([1], [1], facecolor='red', edgecolor=(0, 0, 0, 0))
+        ax_ref.scatter([2], [2], facecolor=(0, 0, 0, 0), edgecolor='blue')
+
 
 def _params(c=None, xsize=2, *, edgecolors=None, **kwargs):
     return (c, edgecolors, kwargs, xsize)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

Fixes #17790.  The immediate bug is that setting `facecolor` or `edgecolor` to `"none"` sets the color to an empty list, but the `Collection.draw()` logic to detect for single-path optimization does not consider an empty list to be a single color.  That is, single-path optimization would never happen if `facecolor` or `edgecolor` is set to `"none"`.  This PR fixes that situation.

That said, this PR requires discussion because single-path optimization is newly triggered in 30+ figure tests, which means their baseline images need to be updated.  This is because `draw_markers()` produces different output than `draw_path_collection()`.  It's worth investigating whether single-path optimization is in fact appropriate in all cases before accepting this PR.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
