### PR TITLE
Preserve explicitly set figure DPI when pickling

### DIFF
--- a/lib/matplotlib/figure.py
+++ b/lib/matplotlib/figure.py
@@ -2412,7 +2412,7 @@ class SubFigure(FigureBase):
         ----------
         val : float
         """
-        self._parent.dpi = val
+        self._parent.set_dpi(val)
         self.stale = True
 
     def _get_renderer(self):
@@ -3293,7 +3293,8 @@ None}, default: None
         ----------
         val : float
         """
-        self.dpi = val
+        self._original_dpi = val
+        self._set_dpi(val * self.canvas.device_pixel_ratio)
         self.stale = True
 
     def set_figwidth(self, val, forward=True):

--- a/lib/matplotlib/tests/test_figure.py
+++ b/lib/matplotlib/tests/test_figure.py
@@ -655,6 +655,20 @@ def test_savefig_pixel_ratio(backend):
     assert ratio1 == ratio2
 
 
+@pytest.mark.parametrize("target", ["figure", "subfigure"])
+def test_set_dpi_savefig(target):
+    fig = Figure(figsize=(2, 1), dpi=40)
+    fig.canvas._set_device_pixel_ratio(2)
+    (fig if target == "figure" else fig.subfigures()).set_dpi(60)
+
+    with io.BytesIO() as buf:
+        fig.savefig(buf, format="png", dpi="figure")
+        assert Image.open(buf).size == (120, 60)
+
+    assert fig.dpi == 120
+    assert fig.canvas.device_pixel_ratio == 2
+
+
 def test_savefig_preserve_layout_engine():
     fig = plt.figure(layout='compressed')
     fig.savefig(io.BytesIO(), bbox_inches='tight')
@@ -1724,6 +1738,27 @@ def test_unpickle_with_device_pixel_ratio():
     assert all(
         [orig / 7 == restore for orig, restore in zip(fig.bbox.max, fig2.bbox.max)]
     )
+
+
+@pytest.mark.parametrize("target", ["figure", "subfigure"])
+@pytest.mark.parametrize("set_dpi_first", [False, True])
+@pytest.mark.parametrize("device_pixel_ratio", [1, 7])
+def test_unpickle_with_set_dpi(target, set_dpi_first, device_pixel_ratio):
+    fig = Figure(dpi=42)
+    target = fig if target == "figure" else fig.subfigures()
+
+    if set_dpi_first:
+        target.set_dpi(84)
+        fig.canvas._set_device_pixel_ratio(device_pixel_ratio)
+    else:
+        fig.canvas._set_device_pixel_ratio(device_pixel_ratio)
+        target.set_dpi(84)
+
+    assert fig.dpi == 84 * device_pixel_ratio
+    restored = pickle.loads(pickle.dumps(fig))
+    assert restored.dpi == 84
+    np.testing.assert_allclose(
+        fig.bbox.max / device_pixel_ratio, restored.bbox.max)
 
 
 def test_gridspec_no_mutate_input():


### PR DESCRIPTION
## PR summary
Closes #32053 
This commit makes set_dpi() update _original_dpi first, then calculates the effective DPI as:
`requested DPI × device-pixel ratio`
That preserves the user’s DPI choice through pickle round-trips, still behaves correctly on HiDPI displays, and makes savefig(dpi="figure") use the explicitly set DPI.
It also routes SubFigure.set_dpi() through the parent figure’s public setter, so SubFigures follow the same behavior.

Tested normal and HiDPI cases. 

## AI Disclosure
AI was used for making the change and testing it locally. 

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [NA] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [NA] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [NA] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
