### PR TITLE
ci: Bump AppVeyor image to Visual Studio 2026

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -17,7 +17,7 @@ skip_commits:
 
 clone_depth: 50
 
-image: Visual Studio 2022
+image: Visual Studio 2026
 
 environment:
 

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,11 @@ cache:
   - '%USERPROFILE%\.cache\matplotlib'
 
 init:
+  # Force enable long path support, because micromamba isn't doing it correctly.
+  # https://github.com/mamba-org/mamba/issues/4392
+  - ps:
+      New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem"
+      -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   - ps:
       Invoke-Webrequest
       -URI https://micro.mamba.pm/api/micromamba/win-64/latest

--- a/ci/schemas/appveyor.json
+++ b/ci/schemas/appveyor.json
@@ -1,5 +1,6 @@
 {
-  "$schema": "http://json-schema.org/draft-04/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/appveyor.json",
   "allOf": [
     {
       "$ref": "#/definitions/job"
@@ -135,6 +136,7 @@
         "Ubuntu1804",
         "Ubuntu2004",
         "Ubuntu2204",
+        "Ubuntu2404",
         "Previous Ubuntu",
         "Previous Ubuntu1604",
         "Previous Ubuntu1804",
@@ -144,6 +146,7 @@
         "Visual Studio 2017",
         "Visual Studio 2019",
         "Visual Studio 2022",
+        "Visual Studio 2026",
         "Visual Studio 2017 Preview",
         "Visual Studio 2019 Preview",
         "Previous Visual Studio 2013",
@@ -172,6 +175,7 @@
     "jobScalars": {
       "title": "job scalars",
       "type": "object",
+      "additionalProperties": false,
       "properties": {
         "image": {
           "$ref": "#/definitions/image"
@@ -204,29 +208,7 @@
             }
           ]
         }
-      },
-      "allOf": [
-        {
-          "not": {
-            "required": ["skip_tags"]
-          }
-        },
-        {
-          "not": {
-            "required": ["skip_commits"]
-          }
-        },
-        {
-          "not": {
-            "required": ["skip_branch_with_pr"]
-          }
-        },
-        {
-          "not": {
-            "required": ["skip_non_tags"]
-          }
-        }
-      ]
+      }
     },
     "job": {
       "title": "job",
@@ -776,6 +758,5 @@
       }
     }
   },
-  "id": "https://json.schemastore.org/appveyor.json",
   "title": "JSON schema for AppVeyor CI configuration files"
 }


### PR DESCRIPTION
## PR summary

Sometimes weird things can happen when path lengths are close to the limit on Windows (which has `MAX_PATH`=260). Evidentally, something changed in micromamba to go over the limit in 2.9.0. Based on [1], long path support should be enabled, but requires a newer version of Windows. Since this job is mostly about conda-forge, and we don't use much from the system, it should be fine to bump the builder.

Note, that I had to update the schema as well [2].

[1] https://github.com/mamba-org/mamba/pull/4342
[2] https://github.com/SchemaStore/schemastore/pull/6233

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines