### PR TITLE
ci: Force-enable long path support on AppVeyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -40,6 +40,11 @@ cache:
   - '%USERPROFILE%\.cache\matplotlib'
 
 init:
+  # Force enable long path support, because micromamba isn't doing it correctly.
+  # https://github.com/mamba-org/mamba/issues/4392
+  - ps:
+      New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem"
+      -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
   - ps:
       Invoke-Webrequest
       -URI https://micro.mamba.pm/api/micromamba/win-64/latest


### PR DESCRIPTION
## PR summary

This should be done automatically by micromamba, but there seems to be a bug with enabling it. https://github.com/mamba-org/mamba/issues/4392

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
