### PR TITLE
Fix ScaleBase.val_in_range for scalar-only custom scales (#32129)

### DIFF
--- a/lib/matplotlib/scale.py
+++ b/lib/matplotlib/scale.py
@@ -127,10 +127,25 @@ class ScaleBase:
         with np.errstate(invalid='ignore'):
             try:
                 vmin, vmax = self.limit_range_for_scale(arr, arr, minpos=1e-300)
-            except (TypeError, ValueError):
-                result = np.zeros(arr.shape, dtype=bool)
-            else:
                 result = np.isfinite(arr) & (vmin == arr) & (vmax == arr)
+            except (TypeError, ValueError):
+                try:
+                    if arr.size == 0:
+                        result = np.zeros(arr.shape, dtype=bool)
+                    else:
+                        def _single_val_in_range(x):
+                            if not np.isfinite(x):
+                                return False
+                            try:
+                                vmin, vmax = self.limit_range_for_scale(x, x, minpos=1e-300)
+                                return bool((vmin == x) and (vmax == x))
+                            except (TypeError, ValueError):
+                                return False
+
+                        vec_val_in_range = np.vectorize(_single_val_in_range, otypes=[bool])
+                        result = vec_val_in_range(arr)
+                except Exception:
+                    result = np.zeros(arr.shape, dtype=bool)
         return bool(result) if arr.ndim == 0 else result
 
 

--- a/lib/matplotlib/tests/test_scale.py
+++ b/lib/matplotlib/tests/test_scale.py
@@ -497,3 +497,26 @@ def test_val_in_range_array():
     out = mscale._scale_mapping['log'](axis=None).val_in_range(
         np.array([[1.0, -1.0], [0.5, np.nan]]))
     np.testing.assert_array_equal(out, [[True, False], [True, False]])
+
+
+def test_val_in_range_scalar_only_scale():
+    # Custom scale whose limit_range_for_scale only accepts scalars
+    class ScalarOnlyScale(mscale.ScaleBase):
+        name = "scalaronly"
+
+        def get_transform(self):
+            return IdentityTransform()
+
+        def limit_range_for_scale(self, vmin, vmax, minpos):
+            return (minpos if vmin <= 0 else vmin, minpos if vmax <= 0 else vmax)
+
+    scale = ScalarOnlyScale(axis=None)
+    arr = np.array([-1.0, 0.0, 1.0, 2.0, np.nan, np.inf])
+    expected = [False, False, True, True, False, False]
+    np.testing.assert_array_equal(scale.val_in_range(arr), expected)
+
+    # Scalar input returns bool
+    assert scale.val_in_range(1.0) is True
+    assert scale.val_in_range(-1.0) is False
+    assert scale.val_in_range(np.nan) is False
+


### PR DESCRIPTION
Fixes #32129

### Problem
Custom \ScaleBase\ implementations that only accept scalar inputs in \limit_range_for_scale\ raised \ValueError\ or \TypeError\ when passed full numpy arrays by \al_in_range\. This caused all data points to be filtered out, silently blanking 3D scatter plots and other artist renderings.

### Solution
- Added a fallback in \ScaleBase.val_in_range\ to use \
p.vectorize\ when array evaluation fails with \TypeError\ or \ValueError\.
- Preserves valid domain data points for custom user scales.
- Added unit test in \lib/matplotlib/tests/test_scale.py\.