### PR TITLE
FIX: interpolate the path and name MPLCONFIGDIR in the temp cache dir warning

### DIFF
--- a/lib/matplotlib/__init__.py
+++ b/lib/matplotlib/__init__.py
@@ -575,7 +575,10 @@ def _get_config_or_cache_dir(xdg_base_getter):
             if os.access(str(configdir), os.W_OK) and configdir.is_dir():
                 return str(configdir)
             _log.warning("%s is not a writable directory", configdir)
-        issue_msg = "the default path ({configdir})"
+        if os.environ.get('MPLCONFIGDIR'):
+            issue_msg = f"MPLCONFIGDIR ({configdir})"
+        else:
+            issue_msg = f"the default path ({configdir})"
     else:
         issue_msg = "resolving the home directory"
     # If the config or cache directory cannot be created or is not a writable

--- a/lib/matplotlib/tests/test_matplotlib.py
+++ b/lib/matplotlib/tests/test_matplotlib.py
@@ -32,6 +32,7 @@ def test_tmpconfigdir_warning(tmp_path):
             [sys.executable, "-c", "import matplotlib"],
             env={**os.environ, "MPLCONFIGDIR": str(tmp_path)},
             stderr=subprocess.PIPE, text=True, check=True)
+        assert f"MPLCONFIGDIR ({tmp_path.resolve()})" in proc.stderr
         assert "set the MPLCONFIGDIR" in proc.stderr
     finally:
         os.chmod(tmp_path, mode)


### PR DESCRIPTION
## PR summary

When Matplotlib falls back to a temporary cache directory, the warning has two problems (discussed in #32246):

1. Since #30454 it prints a literal `{configdir}`: the message text was refactored into the `issue_msg` variable and lost its `f` prefix on the way. The regression ships in releases since 3.11.0.
2. When `MPLCONFIGDIR` is set explicitly, the message still blames "the default path", pointing the reader away from the variable they set.

This PR restores the interpolation and names `MPLCONFIGDIR` in the message when it is the source of the path. `test_tmpconfigdir_warning` now also asserts that the resolved path appears in the warning — the strengthened test fails against current main and passes with the fix.

The behavioral half of #32246 (honoring a read-only cache dir) is left for a separate PR per the discussion there.

## AI Disclosure

AI-assisted: I used Claude (Anthropic) to help analyze the code paths and draft the patch, tests and text. I reviewed and understand every change, and verified the behavior myself: the strengthened test fails against current main (it prints the literal `{configdir}`) and passes with the fix.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
