### PR TITLE
Use "{}" for format strings

### DIFF
--- a/src/mplutils.h
+++ b/src/mplutils.h
@@ -68,7 +68,7 @@ inline void check_trailing_shape(T array, char const* name, long d1)
 {
     if (array.ndim() != 2) {
         throw py::value_error(
-            "Expected 2-dimensional array, got %d"_s.format(array.ndim()));
+            "Expected 2-dimensional array, got {}"_s.format(array.ndim()));
     }
     if (array.size() == 0) {
         // Sometimes things come through as atleast_2d, etc., but they're empty, so
@@ -77,7 +77,7 @@ inline void check_trailing_shape(T array, char const* name, long d1)
     }
     if (array.shape(1) != d1) {
         throw py::value_error(
-            "%s must have shape (N, %d), got (%d, %d)"_s.format(
+            "{} must have shape (N, {}), got ({}, {})"_s.format(
                 name, d1, array.shape(0), array.shape(1)));
     }
 }
@@ -87,7 +87,7 @@ inline void check_trailing_shape(T array, char const* name, long d1, long d2)
 {
     if (array.ndim() != 3) {
         throw py::value_error(
-            "Expected 3-dimensional array, got %d"_s.format(array.ndim()));
+            "Expected 3-dimensional array, got {}"_s.format(array.ndim()));
     }
     if (array.size() == 0) {
         // Sometimes things come through as atleast_3d, etc., but they're empty, so
@@ -96,7 +96,7 @@ inline void check_trailing_shape(T array, char const* name, long d1, long d2)
     }
     if (array.shape(1) != d1 || array.shape(2) != d2) {
         throw py::value_error(
-            "%s must have shape (N, %d, %d), got (%d, %d, %d)"_s.format(
+            "{} must have shape (N, {}, {}), got ({}, {}, {})"_s.format(
                 name, d1, d2, array.shape(0), array.shape(1), array.shape(2)));
     }
 }


### PR DESCRIPTION
## PR summary

pybind11 `format()` uses Python-style placeholders (`{}`) rather than C-style (`%d`). This PR fixes the placeholders in mplutils.h

## AI Disclosure

None

## PR quality check

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
