### PR TITLE
Speed up RGBA-stage image resampling

### DIFF
--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -572,7 +572,7 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                     A = A * alpha_in[..., None]
                     A[..., 3] = alpha_in
                 res = _resample(self, A, out_shape, t)
-                # Unpremultiply.  Zeroes in the divisor are replaced by ones,
+                # Demultiply.  Zeroes in the divisor are replaced by ones,
                 # which leaves the corresponding (premultiplied) RGB values
                 # untouched.  Dividing the whole contiguous array is several
                 # times faster than np.divide(..., where=...) into the strided

--- a/lib/matplotlib/image.py
+++ b/lib/matplotlib/image.py
@@ -461,8 +461,6 @@ class _ImageBase(mcolorizer.ColorizingArtist):
             if not (A.ndim == 2 or A.ndim == 3 and A.shape[-1] in (3, 4)):
                 raise ValueError(f"Invalid shape {A.shape} for image data")
 
-            float_rgba_in = A.ndim == 3 and A.shape[-1] == 4 and A.dtype.kind == 'f'
-
             # if antialiased, this needs to change as window sizes
             # change:
             interpolation_stage = self._interpolation_stage
@@ -566,13 +564,22 @@ class _ImageBase(mcolorizer.ColorizingArtist):
                 # Resample in premultiplied alpha space.  (TODO: Consider
                 # implementing premultiplied-space resampling in
                 # span_image_resample_rgba_affine::generate?)
-                if float_rgba_in and np.ndim(alpha) == 0 and np.any(A[..., 3] < 1):
-                    # Do not modify original RGBA input
-                    A = A.copy()
-                A[..., :3] *= A[..., 3:]
+                # Multiplying the whole array and then restoring the alpha channel
+                # is faster than an in-place multiply of the strided A[..., :3]
+                # view.  If alpha is uniformly 1, premultiplication can be skipped.
+                alpha_in = A[..., 3]
+                if (alpha_in != 1).any():
+                    A = A * alpha_in[..., None]
+                    A[..., 3] = alpha_in
                 res = _resample(self, A, out_shape, t)
-                np.divide(res[..., :3], res[..., 3:], out=res[..., :3],
-                            where=res[..., 3:] != 0)
+                # Unpremultiply.  Zeroes in the divisor are replaced by ones,
+                # which leaves the corresponding (premultiplied) RGB values
+                # untouched.  Dividing the whole contiguous array is several
+                # times faster than np.divide(..., where=...) into the strided
+                # res[..., :3] view.
+                alpha_out = res[..., 3].copy()
+                res /= np.where(alpha_out != 0, alpha_out, 1)[..., None]
+                res[..., 3] = alpha_out
                 if post_apply_alpha:
                     res[..., 3] *= alpha
 

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1860,6 +1860,35 @@ def test_resample_dtypes(dtype, ndim):
     axes_image.make_image(None)[0]
 
 
+def test_rgba_stage_unpremultiplies_resampled_alpha():
+    # Issue 32240: resampling in the 'rgba' stage happens in premultiplied
+    # alpha space, so the RGB channels must be restored afterwards.  The
+    # original colors must come back independently of the alpha channel, and a
+    # zero resampled alpha must not be divided by.
+    rgb = np.array([0.2, 0.4, 0.6])
+
+    def render(alpha):
+        data = np.empty((4, 4, 4))
+        data[..., :3] = rgb
+        data[..., 3] = alpha
+        fig, ax = plt.subplots()
+        axes_image = ax.imshow(data, interpolation='nearest',
+                               interpolation_stage='rgba')
+        with np.errstate(divide='raise', invalid='raise'):
+            image = axes_image.make_image(None)[0]
+        # Trim the partially covered pixels at the edges of the image.
+        return image[2:-2, 2:-2]
+
+    opaque = render(1)
+    for alpha in (0.25, 0.5, 0.75):
+        partial = render(alpha)
+        assert_array_equal(partial[..., :3], opaque[..., :3])
+        assert_allclose(partial[..., 3], alpha * 255, atol=1)
+
+    # A fully transparent image resamples to a zero alpha everywhere.
+    assert_array_equal(render(0)[..., 3], 0)
+
+
 @pytest.mark.parametrize('intp_stage', ('data', 'rgba'))
 @check_figures_equal(extensions=['png', 'pdf', 'svg'])
 def test_interpolation_stage_rgba_respects_alpha_param(fig_test, fig_ref, intp_stage):

--- a/lib/matplotlib/tests/test_image.py
+++ b/lib/matplotlib/tests/test_image.py
@@ -1860,33 +1860,24 @@ def test_resample_dtypes(dtype, ndim):
     axes_image.make_image(None)[0]
 
 
-def test_rgba_stage_unpremultiplies_resampled_alpha():
-    # Issue 32240: resampling in the 'rgba' stage happens in premultiplied
-    # alpha space, so the RGB channels must be restored afterwards.  The
-    # original colors must come back independently of the alpha channel, and a
-    # zero resampled alpha must not be divided by.
-    rgb = np.array([0.2, 0.4, 0.6])
-
-    def render(alpha):
-        data = np.empty((4, 4, 4))
-        data[..., :3] = rgb
-        data[..., 3] = alpha
-        fig, ax = plt.subplots()
-        axes_image = ax.imshow(data, interpolation='nearest',
-                               interpolation_stage='rgba')
-        with np.errstate(divide='raise', invalid='raise'):
-            image = axes_image.make_image(None)[0]
-        # Trim the partially covered pixels at the edges of the image.
-        return image[2:-2, 2:-2]
-
-    opaque = render(1)
-    for alpha in (0.25, 0.5, 0.75):
-        partial = render(alpha)
-        assert_array_equal(partial[..., :3], opaque[..., :3])
-        assert_allclose(partial[..., 3], alpha * 255, atol=1)
-
-    # A fully transparent image resamples to a zero alpha everywhere.
-    assert_array_equal(render(0)[..., 3], 0)
+@pytest.mark.parametrize('alpha', [0, 0.25, 0.5, 0.75, 1])
+def test_rgba_stage_demultiplies_resampled_alpha(alpha):
+    # Issue 32240: resampling in the 'rgba' stage happens in premultiplied alpha
+    # space, so the RGB channels are demultiplied afterwards.  The original
+    # colors must come back independently of the alpha channel, and a zero
+    # resampled alpha must not be divided by.
+    rgb = [0.2, 0.4, 0.6]
+    data = np.empty((4, 4, 4))
+    data[..., :3] = rgb
+    data[..., 3] = alpha
+    fig, ax = plt.subplots()
+    axes_image = ax.imshow(data, interpolation='nearest', interpolation_stage='rgba')
+    image = axes_image.make_image(None)[0]
+    # A fully transparent image premultiplies to zero and is never divided back.
+    expected_rgb = np.multiply(rgb, 255) if alpha else [0, 0, 0]
+    # The rendered image is a single flat colour, so compare against it directly.
+    assert_array_equal(np.unique(image.reshape(-1, 4), axis=0),
+                       [[*expected_rgb, int(alpha * 255)]])
 
 
 @pytest.mark.parametrize('intp_stage', ('data', 'rgba'))


### PR DESCRIPTION
## PR summary

Closes #32240.

Redrawing an `imshow` image got about 2x slower between 3.10.9 and 3.11. @ayshih traced this to #29776, which moved resampling into premultiplied alpha space. The premultiply and demultiply are both full-array NumPy passes, but in their current form, they can't use NumPy's fast paths.

Demultiply is the more expensive one:

```python
np.divide(res[..., :3], res[..., 3:], out=res[..., :3], where=res[..., 3:] != 0)
```

This takes ~16 ms per draw in the code I used to reproduce the issue in #32240. Two reasons it's slow: `out=res[..., :3]` is a stride-4 view (so contiguous inner loops can't be used), and passing an array to `where=` is itself expensive. Running it on a 462x1560x4 float64 array takes 16.3 ms as written, 8.3 ms without `where=`, and only 2.8 ms operating on the whole contiguous array. An all-True mask array still costs 2.3-2.8x depending on whether the destination is strided, so the cost just comes from taking the masked path itself.

For both the demultiply and premultiply steps, this PR implements contiguous whole-array operations that save the alpha channel and then restore it.

- **Demultiply**: save the alpha values, divide the whole array by a version of alpha where zeros have been replaced by ones, then put the original alpha values back. This is equivalent to the `where=` form, and while dividing alpha by itself involves more operations, the fact that it runs contiguously means it's much faster.
- **Premultiply**: same idea. Making the multiply contiguous takes it from 13.4 ms to 4.6 ms per draw in my reproduction code. On top of that, when the alpha channel is all 1 (as with colormapped or opaque RGBA inputs), it can be skipped entirely for the cost of a 0.6 ms check, taking the line from 13.4 ms to 0.6 ms.

One positive side effect is that the line `A = A.copy()` is no longer needed. It existed to stop `A[..., :3] *= A[..., 3:]` from writing into the caller's array, but now `A` is not modified in place. When alpha is all 1 it's left untouched, and otherwise the multiplication just builds a new array.

### Timings

Median of 15 repeats, same code from #32240 (macOS arm64, NumPy 2.5.2)

| case | 3.10.9 | 3.11.1 | main | this PR |
|---|---|---|---|---|
| scalar, `interpolation='none'` | 26.9 ms | 53.1 ms | 51.2 ms | 23.9 ms |
| scalar, `interpolation='nearest'` | 27.1 ms | 61.7 ms | 56.7 ms | 28.9 ms |
| RGBA, `interpolation='none'` | 13.7 ms | 34.0 ms | 32.9 ms | 17.2 ms |
| RGBA, `interpolation='nearest'` | 13.9 ms | 35.2 ms | 33.7 ms | 17.9 ms |

### Verification

A new test, `test_rgba_stage_demultiplies_resampled_alpha`, checks that RGB values survive the premultiply/demultiply round trip for several alpha values and that a fully transparent image never divides by zero.

To double-check that rendered output is unchanged, I rendered a large set of configurations and compared the RGBA canvas buffers against `main` and against the 3.11.1 wheel. No differences were observed.

<details>
<summary>Script used for the comparison</summary>
                      
Run under each build, then compare:

```python
import sys, numpy as np, matplotlib
matplotlib.use("Agg")
import matplotlib.pyplot as plt

rng = np.random.default_rng(1234)
alpha_arr = rng.random((7, 11))
arrays = {
    "scalar_f":    rng.random((7, 11)),
    "scalar_u8":   (rng.random((7, 11)) * 255).astype(np.uint8),
    "scalar_mask": np.ma.masked_array(rng.random((7, 11)), rng.random((7, 11)) < .3),
    "rgb_f":       rng.random((7, 11, 3)),
    "rgba_f":      rng.random((7, 11, 4)),
    "rgba_opaque": np.dstack([rng.random((7, 11, 3)), np.ones((7, 11))]),
    "rgb_u8":      (rng.random((7, 11, 3)) * 255).astype(np.uint8),
    "rgba_u8":     (rng.random((7, 11, 4)) * 255).astype(np.uint8),
    "wide":        rng.random((60, 900)),
}

out = {}
for name, arr in arrays.items():
    for interp in ["none", "nearest", "bilinear", "bicubic", "lanczos", "antialiased"]:
        for alpha in [None, 0.4, "array"]:
            for stage in ["auto", "data", "rgba"]:
                for origin in ["upper", "lower"]:
                    if alpha == "array" and arr.shape[:2] != alpha_arr.shape:
                        continue
                    fig = plt.figure(figsize=(2.37, 1.63), dpi=100)
                    ax = fig.add_axes((0.13, 0.11, 0.7, 0.72))
                    ax.imshow(arr, interpolation=interp, origin=origin, aspect="auto",
                              alpha=alpha_arr if alpha == "array" else alpha,
                              interpolation_stage=stage)
                    fig.canvas.draw()
                    out[f"{name}|{interp}|{alpha}|{stage}|{origin}"] = \
                        np.asarray(fig.canvas.buffer_rgba()).copy()
                    plt.close(fig)

np.savez_compressed(sys.argv[1], **out)
print(f"{len(out)} configurations -> {sys.argv[1]}")
```

```python
a, b = np.load("before.npz"), np.load("after.npz")
print(sum(np.array_equal(a[k], b[k]) for k in a.files), "of", len(a.files), "identical")
```

</details>

## AI Disclosure

I used Claude Code in several places and thoroughly reviewed its output. It profiled 3.10.9 against 3.11.1 to locate the two affected lines, benchmarked the approach implemented here, wrote the patch and the test, and ran the verification. I wrote or revised all prose, reviewed all code, and re-ran the verification script. 

## PR quality check

- [x] Use an expressive title
- [x] New and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New features and API changes have release notes
- [N/A] Documentation complies with general and docstring guidelines
