### PR TITLE
fix: initialize ragged Poly3DCollection padding with NaN

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -1360,7 +1360,7 @@ class Poly3DCollection(PolyCollection):
             num_faces = len(segments3d)
             num_verts = np.fromiter(map(len, segments3d), dtype=np.intp)
             max_verts = num_verts.max(initial=0)
-            segments = np.empty((num_faces, max_verts, 3))
+            segments = np.full((num_faces, max_verts, 3), np.nan)
             for i, face in enumerate(segments3d):
                 segments[i, :len(face)] = face
             self._faces = segments


### PR DESCRIPTION
## Problem

When `Poly3DCollection` receives polygons with different numbers of vertices, it creates a padded rectangular array using `np.empty()`. Unused entries are marked as invalid via `_invalid_vertices`, but `do_3d_projection()` projects the complete backing array before applying that mask. Uninitialized padding values can contain values near `float64` max, causing `RuntimeWarning: overflow encountered in dot`.

## Fix

Replace `np.empty()` with `np.full(..., np.nan)` when creating padded storage for ragged polygons. NaN values propagate safely through matrix operations and are later masked out by `_invalid_vertices`.

Fixes #32272