### PR TITLE
FIX: make EngFormatter respect axes.formatter.use_locale rcParam

### DIFF
--- a/doc/release/next_whats_new/engformatter_locale.rst
+++ b/doc/release/next_whats_new/engformatter_locale.rst
@@ -1,0 +1,17 @@
+``EngFormatter`` now respects ``axes.formatter.use_locale``
+-----------------------------------------------------------
+
+`~matplotlib.ticker.EngFormatter` now formats the decimal separator according to
+the current locale, like `~matplotlib.ticker.ScalarFormatter` already did. This
+is controlled by the :rc:`axes.formatter.use_locale` rcParam, or by the new
+*useLocale* keyword argument:
+
+.. code-block:: python
+
+    import locale
+    from matplotlib.ticker import EngFormatter
+
+    locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")
+
+    ax.yaxis.set_major_formatter(EngFormatter(places=2, useLocale=True))
+    # tick labels now read "555,10 m" instead of "555.10 m"

--- a/lib/matplotlib/tests/test_ticker.py
+++ b/lib/matplotlib/tests/test_ticker.py
@@ -1810,6 +1810,45 @@ def test_locale_comma():
         pytest.skip(skip_msg)
 
 
+def _impl_engformatter_locale():
+    try:
+        locale.setlocale(locale.LC_ALL, 'de_DE.UTF-8')
+    except locale.Error:
+        print('SKIP: Locale de_DE.UTF-8 is not supported on this machine')
+        return
+    # EngFormatter is a ScalarFormatter subclass, so it must honour the
+    # axes.formatter.use_locale rcParam like its parent does.
+    with mpl.rc_context(rc={'axes.formatter.use_locale': True}):
+        fmt = mticker.EngFormatter(places=2)
+        assert fmt.get_useLocale()
+        assert fmt.format_data(0.5551) == '555,10 m'
+        # An explicit keyword argument overrides the rcParam.
+        fmt = mticker.EngFormatter(places=2, useLocale=False)
+        assert not fmt.get_useLocale()
+        assert fmt.format_data(1234.5) == '1.23 k'
+    fmt = mticker.EngFormatter(places=2, useLocale=True)
+    assert fmt.get_useLocale()
+    assert fmt.format_data(1234.5) == '1,23 k'
+    # The inherited setter also reaches the engineering formatting path.
+    fmt = mticker.EngFormatter(places=2, useLocale=False)
+    fmt.set_useLocale(True)
+    assert fmt.format_data(1234.5) == '1,23 k'
+    # Separators are escaped for mathtext, as ScalarFormatter does.
+    fmt = mticker.EngFormatter(places=2, useLocale=True, useMathText=True)
+    assert fmt.format_data(0.5551) == '$555{,}10$ m'
+
+
+def test_engformatter_locale():
+    proc = mpl.testing.subprocess_run_helper(
+        _impl_engformatter_locale, timeout=60, extra_env={'MPLBACKEND': 'Agg'})
+    skip_msg = next((line[len('SKIP:'):].strip()
+                     for line in proc.stdout.splitlines()
+                     if line.startswith('SKIP:')),
+                    '')
+    if skip_msg:
+        pytest.skip(skip_msg)
+
+
 def test_majformatter_type():
     fig, ax = plt.subplots()
     with pytest.raises(TypeError):

--- a/lib/matplotlib/ticker.py
+++ b/lib/matplotlib/ticker.py
@@ -1433,7 +1433,7 @@ class EngFormatter(ScalarFormatter):
     }
 
     def __init__(self, unit="", places=None, sep=" ", *, usetex=None,
-                 useMathText=None, useOffset=False):
+                 useMathText=None, useOffset=False, useLocale=None):
         r"""
         Parameters
         ----------
@@ -1476,6 +1476,12 @@ class EngFormatter(ScalarFormatter):
             3 digits. See also `.set_useOffset`.
 
             .. versionadded:: 3.10
+
+        useLocale : bool, default: :rc:`axes.formatter.use_locale`.
+            Whether to use locale settings for decimal sign and positive sign.
+            See `.set_useLocale`.
+
+            .. versionadded:: 3.12
         """
         self.unit = unit
         self.places = places
@@ -1483,7 +1489,7 @@ class EngFormatter(ScalarFormatter):
         super().__init__(
             useOffset=useOffset,
             useMathText=useMathText,
-            useLocale=False,
+            useLocale=useLocale,
             usetex=usetex,
         )
 
@@ -1598,10 +1604,18 @@ class EngFormatter(ScalarFormatter):
             suffix = f"{self.sep}{unit_prefix}{self.unit}"
         else:
             suffix = ""
-        if self._usetex or self._useMathText:
-            return f"${mant:{fmt}}${suffix}"
+        if self._useLocale:
+            mant_str = locale.format_string(f"%{fmt}", (mant,), True)
+            if self._useMathText:
+                # Escape the separators introduced by locale.format_string, so
+                # that mathtext does not apply punctuation spacing to them.
+                mant_str = mant_str.replace(",", "{,}")
         else:
-            return f"{mant:{fmt}}{suffix}"
+            mant_str = f"{mant:{fmt}}"
+        if self._usetex or self._useMathText:
+            return f"${mant_str}${suffix}"
+        else:
+            return f"{mant_str}{suffix}"
 
 
 class PercentFormatter(Formatter):

--- a/lib/matplotlib/ticker.pyi
+++ b/lib/matplotlib/ticker.pyi
@@ -150,6 +150,7 @@ class EngFormatter(ScalarFormatter):
         usetex: bool | None = ...,
         useMathText: bool | None = ...,
         useOffset: bool | float | None = ...,
+        useLocale: bool | None = ...,
     ) -> None: ...
     def format_eng(self, num: float) -> str: ...
 


### PR DESCRIPTION
## Description

`EngFormatter` ignores `axes.formatter.use_locale` when formatting the mantissa.

With `de_DE.UTF-8`:

```python
import locale

import matplotlib as mpl
from matplotlib.ticker import EngFormatter, ScalarFormatter

locale.setlocale(locale.LC_ALL, "de_DE.UTF-8")

with mpl.rc_context({"axes.formatter.use_locale": True}):
    scalar = ScalarFormatter()
    eng = EngFormatter(places=2)
```

```text
ScalarFormatter.get_useLocale(): True
EngFormatter.get_useLocale()   : False

ScalarFormatter.format_data(0.5551): '5,551e−1'
EngFormatter.format_data(0.5551)   : '555.10 m'
```

There are two causes: `EngFormatter.__init__` passes `useLocale=False` to `ScalarFormatter`, and `format_data` formats the mantissa directly instead of using locale-aware formatting. Because of the latter, even `set_useLocale(True)` does not affect the normal `format_data` path. Locale-aware formatting is currently only used for the offset path.

This change passes `useLocale` through to `ScalarFormatter`, adds it as an `EngFormatter` keyword argument, and applies locale formatting to the mantissa. For MathText, locale separators are escaped to avoid punctuation spacing.

Tests cover the rcParam, explicit `useLocale` values, the inherited setter, and MathText.

I consider this a bug fix: `EngFormatter` already inherits the locale API from `ScalarFormatter`, but does not honor it consistently. #13477 fixed the same kind of issue for `axes.unicode_minus`.

The new constructor keyword is the only public API addition here and can be split out if preferred.

Related: #25006 concerns the same rcParam, but a different issue involving locale initialization/reset behavior.


## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [x] New features and API changes have release notes
- [x] Documentation complies with general and docstring guidelines