### PR TITLE
Remove unused curve_distance_epsilon

### DIFF
--- a/extern/agg24-svn/src/agg_curves.cpp
+++ b/extern/agg24-svn/src/agg_curves.cpp
@@ -21,7 +21,6 @@ namespace agg
 {
 
     //------------------------------------------------------------------------
-    const double curve_distance_epsilon                  = 1e-30;
     const double curve_collinearity_epsilon              = 1e-30;
     const double curve_angle_tolerance_epsilon           = 0.01;
     enum curve_recursion_limit_e { curve_recursion_limit = 32 };


### PR DESCRIPTION
## PR summary

This PR removes `curve_distance_epsilon` from "src_agg_curves.cpp". As far as I can tell, this was present in the original agg 2.4 source but was never used.

It has generated a warning for at least the last decade, if not longer:

```
[7/33] Compiling C++ object extern/agg24-svn/libagg.a.p/src_agg_curves.cpp.o
../../extern/agg24-svn/src/agg_curves.cpp:24:18:
warning: unused variable 'curve_distance_epsilon' [-Wunused-const-variable]
    const double curve_distance_epsilon                  = 1e-30;
```

## AI Disclosure

No AI used.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [X] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines