### PR TITLE
animation.py: Stop event sources instead of nulling them on animation stop

### DIFF
--- a/doc/api/next_api_changes/behavior/animation_stop_event_stop_not_null.rst
+++ b/doc/api/next_api_changes/behavior/animation_stop_event_stop_not_null.rst
@@ -1,0 +1,26 @@
+``TimedAnimation``/``Animation`` now perform .stop() on mpl_disconnect
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Previously these classes set ``self.event_source = None`` when
+``self._fig.canvas.mpl_disconnect`` was called. Now they run
+``self.event_source.stop()``.
+
+This hange is for issue `30622 <https://github.com/matplotlib/matplotlib/issues/30622>`__.
+
+The following code snippet would before have returned None but would now return a
+``matplotlib.backend_bases.TimerBase``.  Code that used None to check for successful
+stoppage should be updated.
+
+.. code-block:: python
+
+    import matplotlib
+    matplotlib.use('agg')
+    import matplotlib.pyplot as plt
+    from matplotlib.animation import FuncAnimation
+
+    fig, ax = plt.subplots()
+    anim = FuncAnimation(fig, lambda f: [], frames=3, repeat=False)
+    anim._start()
+    while anim._step():
+        pass
+    print(anim.event_source)

--- a/lib/matplotlib/animation.py
+++ b/lib/matplotlib/animation.py
@@ -946,7 +946,7 @@ class Animation:
             self._fig.canvas.mpl_disconnect(self._resize_id)
         self._fig.canvas.mpl_disconnect(self._close_id)
         self.event_source.remove_callback(self._step)
-        self.event_source = None
+        self.event_source.stop()
 
     def save(self, filename, writer=None, fps=None, dpi=None, codec=None,
              bitrate=None, extra_args=None, metadata=None, extra_anim=None,
@@ -1483,7 +1483,7 @@ class TimedAnimation(Animation):
                     # Remove the resize callback if we were blitting
                     self._fig.canvas.mpl_disconnect(self._resize_id)
                 self._fig.canvas.mpl_disconnect(self._close_id)
-                self.event_source = None
+                self.event_source.stop()
                 return False
 
         self.event_source.interval = self._interval

--- a/lib/matplotlib/animation.pyi
+++ b/lib/matplotlib/animation.pyi
@@ -160,7 +160,7 @@ class EventSourceProtocol(Protocol):
 
 class Animation:
     frame_seq: Iterable[Artist]
-    event_source: EventSourceProtocol | None  # TODO: We should remove None
+    event_source: EventSourceProtocol
     def __init__(
         self, fig: Figure, event_source: EventSourceProtocol, blit: bool = ...
     ) -> None: ...

--- a/lib/matplotlib/tests/test_animation.py
+++ b/lib/matplotlib/tests/test_animation.py
@@ -13,7 +13,7 @@ import pytest
 import matplotlib as mpl
 from matplotlib import pyplot as plt
 from matplotlib import animation
-from matplotlib.animation import PillowWriter
+from matplotlib.animation import PillowWriter, FuncAnimation
 from matplotlib.testing.decorators import check_figures_equal
 
 
@@ -571,3 +571,33 @@ def test_animation_with_transparency():
     # Check that the alpha channel is not 255, so frame has transparency
     assert frame.getextrema()[3][0] < 255
     plt.close(fig)
+
+
+def test_event_source_stops_leaves_event():
+    """
+    Added for issue #30622
+
+    Tests that animations now stop the event source instead
+    of destroying it on animation completion.
+    """
+    fig, ax = plt.subplots()
+    anim = FuncAnimation(fig, lambda f: [], frames=3, repeat=False)
+    anim._start()
+    while anim._step():
+        pass  # goes through all 3 steps
+    assert anim.event_source is not None
+    plt.close(fig)
+
+
+def test_event_source_stops_early_leaves_event():
+    """
+    Added for issue #30622
+
+    Tests that animations now stop the event source instead
+    of destroying it on animation early stop.
+    """
+    fig, ax = plt.subplots()
+    anim = FuncAnimation(fig, lambda f: [], frames=3)
+    anim._start()
+    plt.close(fig)
+    assert anim.event_source is not None


### PR DESCRIPTION
## PR summary
Closes: #30622
Followed [issue link](https://github.com/matplotlib/matplotlib/issues/30622) to #30590. Then followed suggestions made there.

code to exercise this change
```python
import matplotlib
matplotlib.use('agg')
import matplotlib.pyplot as plt
from matplotlib.animation import FuncAnimation

fig, ax = plt.subplots()
anim = FuncAnimation(fig, lambda f: [], frames=3, repeat=False)
anim._start()
while anim._step():
    pass
anim.event_source 
```

Output before change
```print(anim.event_source)
None
```

Output after change
```
print(anim.event_source)
<matplotlib.backend_bases.TimerBase at 0x...>
```


## AI Disclosure
Used ai to help me find an easy issue to try and dip my toe in the water.  Then had it write the exercising code.


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
