### PR TITLE
MNT: Future version of dateutil warns on non-existent time zone

### DIFF
--- a/lib/matplotlib/tests/test_dates.py
+++ b/lib/matplotlib/tests/test_dates.py
@@ -1300,6 +1300,7 @@ def test_change_interval_multiples():
     assert ax.get_xticklabels()[1].get_text() == 'Feb 01 2020'
 
 
+@pytest.mark.filterwarnings("ignore:I/O error")
 def test_DateLocator():
     locator = mdates.DateLocator()
     # Test nonsingular


### PR DESCRIPTION
Which in turn fails our tests.

I am seeing this warning with

```
✔ 16:43:47 [belanna] @ pip list | grep -i dateutil
python-dateutil                2.9.0.post1.dev32+g48bd1af97
```
