### PR TITLE
Improve error message for boxplot_stats function, by printing dimensions.

### DIFF
--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -1265,7 +1265,8 @@ def boxplot_stats(X, whis=1.5, bootstrap=None, labels=None, autorange=False):
     if labels is None:
         labels = itertools.repeat(None)
     elif len(labels) != ncols:
-        raise ValueError("Dimensions of labels and X must be compatible")
+        raise ValueError(f"The number of labels ({len(labels)}) must match the"
+            f" number of columns ({ncols}).")
 
     input_whis = whis
     for ii, (x, label) in enumerate(zip(X, labels)):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
This edits the error message raised by [`boxplot_stats`](https://matplotlib.org/stable/api/cbook_api.html#matplotlib.cbook.boxplot_stats) for incompatible dimensions to print those dimensions. This is useful for debugging. Related issue: https://github.com/matplotlib/matplotlib/issues/32304.


## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
No AI used.


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
