### PR TITLE
Fix Line3D.draw AttributeError for list coordinates with NaN

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -338,7 +338,8 @@ class Line3D(lines.Line2D):
         for name, xyz in zip('xyz', args):
             if not np.iterable(xyz):
                 raise RuntimeError(f'{name} must be a sequence')
-        self._verts3d = args
+        # Coerce to arrays so draw() can rely on .shape (e.g. list + NaN).
+        self._verts3d = tuple(np.asarray(xyz) for xyz in args)
         self.stale = True
 
     def get_data_3d(self):

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -338,7 +338,7 @@ class Line3D(lines.Line2D):
         for name, xyz in zip('xyz', args):
             if not np.iterable(xyz):
                 raise RuntimeError(f'{name} must be a sequence')
-        self._verts3d = tuple(np.asarray(xyz) for xyz in args)
+        self._verts3d = args
         self.stale = True
 
     def get_data_3d(self):
@@ -360,7 +360,7 @@ class Line3D(lines.Line2D):
         if np.any(scale_mask):
             mask = np.broadcast_to(
                 scale_mask,
-                (len(self._verts3d), *self._verts3d[0].shape)
+                (len(self._verts3d), *np.shape(self._verts3d[0]))
             )
             xs3d, ys3d, zs3d = np.ma.array(self._verts3d,
                                            dtype=float, mask=mask).filled(np.nan)

--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -338,7 +338,6 @@ class Line3D(lines.Line2D):
         for name, xyz in zip('xyz', args):
             if not np.iterable(xyz):
                 raise RuntimeError(f'{name} must be a sequence')
-        # Coerce to arrays so draw() can rely on .shape (e.g. list + NaN).
         self._verts3d = tuple(np.asarray(xyz) for xyz in args)
         self.stale = True
 

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -13,6 +13,16 @@ from mpl_toolkits.mplot3d.art3d import (
 )
 
 
+def test_line3d_set_data_3d_list_with_nan():
+    # Regression test for #32127: set_data_3d accepts array-like (e.g. lists),
+    # and draw must not require ndarray .shape when a coordinate is non-finite.
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="3d")
+    line, = ax.plot([0.0], [0.0], [0.0])
+    line.set_data_3d([float("nan")], [float("nan")], [float("nan")])
+    fig.canvas.draw()
+
+
 @pytest.mark.parametrize("zdir, expected", [
     ("x", (1, 0, 0)),
     ("y", (0, 1, 0)),

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -14,12 +14,14 @@ from mpl_toolkits.mplot3d.art3d import (
 
 
 def test_line3d_set_data_3d_list_with_nan():
-    # Regression test for #32127: set_data_3d accepts array-like (e.g. lists),
-    # and draw must not require ndarray .shape when a coordinate is non-finite.
+    # Regression test for #32127: set_data_3d stores array-like as given, and
+    # draw must not require ndarray .shape when a coordinate is non-finite.
     fig = plt.figure()
     ax = fig.add_subplot(projection="3d")
     line, = ax.plot([0.0], [0.0], [0.0])
-    line.set_data_3d([float("nan")], [float("nan")], [float("nan")])
+    xs, ys, zs = [float("nan")], [float("nan")], [float("nan")]
+    line.set_data_3d(xs, ys, zs)
+    assert line.get_data_3d() == (xs, ys, zs)
     fig.canvas.draw()
 
 


### PR DESCRIPTION
﻿## PR summary

Closes #32127.

`Line3D.set_data_3d` is documented to take array-like input and stores the values as given. `draw` then used `self._verts3d[0].shape` when applying the invalid-scale mask, so a plain Python list with a NaN raised `AttributeError`. Finite lists still drew, which is why this only shows up once a coordinate goes non-finite.

This PR changes that access to `np.shape(self._verts3d[0])` so lists and tuples work. `set_data_3d` is left alone, so `get_data_3d()` still returns whatever was passed in.

Added a regression test for the reported case: lists containing NaN, then `canvas.draw()`, and an assert that `get_data_3d()` still returns the original lists.

## AI Disclosure

Used Cursor to find the mplot3d code paths, draft the small patch/test, and help open the PR. Updated the approach to `np.shape` in `draw` based on review feedback on the issue. The summary above is written in my own words.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
