### PR TITLE
Apply unit conversion to hist2d's x/y/range, fixing datetime input

### DIFF
--- a/doc/api/next_api_changes/behavior/hist2d_unit_conversion.rst
+++ b/doc/api/next_api_changes/behavior/hist2d_unit_conversion.rst
@@ -1,0 +1,11 @@
+``Axes.hist2d`` now converts *x*/*y*/*range* through the axis unit converters
+------------------------------------------------------------------------------
+
+`~matplotlib.axes.Axes.hist2d` previously passed *x* and *y* directly to
+`numpy.histogram2d` without applying the axes' unit converters, unlike
+`~.Axes.plot`, `~.Axes.scatter`, and `~.Axes.hist`. This meant that, e.g.,
+plotting ``datetime64`` data with `~.Axes.hist2d` produced bin edges in raw
+(often nanosecond-scale) units instead of Matplotlib's internal date
+representation, so the histogram did not line up with other artists plotted
+on the same Axes. ``x``, ``y``, and ``range`` (if passed) are now converted
+consistently with the other plotting methods.

--- a/lib/matplotlib/axes/_axes.py
+++ b/lib/matplotlib/axes/_axes.py
@@ -7992,7 +7992,19 @@ such objects
            Previously, `~.Axes.hist2d` would force the axes limits to match the
            extents of the histogram; now, autoscaling also takes other plot
            elements into account.
+
+        .. versionchanged:: 3.12
+           *x* and *y* (and *range*, if given) are now passed through the axes'
+           unit converters before binning, so e.g. datetime inputs are handled
+           the same way as in `~.Axes.plot` and `~.Axes.scatter`. Previously
+           they were passed unconverted to `numpy.histogram2d`.
         """
+
+        x, y = self._process_unit_info([("x", x), ("y", y)], kwargs)
+        if range is not None:
+            (xmin, xmax), (ymin, ymax) = range
+            range = (self.convert_xunits((xmin, xmax)),
+                     self.convert_yunits((ymin, ymax)))
 
         h, xedges, yedges = np.histogram2d(x, y, bins=bins, range=range,
                                            density=density, weights=weights)

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2919,6 +2919,37 @@ def test_hist2d_autolimits():
     assert ax.get_autoscale_on()  # Autolimits have not been disabled.
 
 
+def test_hist2d_datetime():
+    # Regression test for gh-17319: hist2d must apply the same unit
+    # conversion to x/y as plot()/scatter() so datetime input lands on the
+    # same (small, date2num-like) numeric scale, instead of raw
+    # nanosecond-scale datetime64 integers.
+    x = np.arange(np.datetime64('2020-01-01'), np.datetime64('2020-01-11'))
+    y = np.arange(10.)
+
+    ax_hist2d = plt.figure().add_subplot()
+    ax_hist2d.hist2d(x, y, bins=5)
+
+    ax_plot = plt.figure().add_subplot()
+    ax_plot.plot(x, y)
+
+    assert ax_hist2d.get_xlim() == ax_plot.get_xlim()
+    # sanity check: this is a small (date2num-like) scale, not raw datetime64
+    assert all(abs(lim) < 1e6 for lim in ax_hist2d.get_xlim())
+
+
+def test_hist2d_datetime_range():
+    # The `range` parameter should also be converted, so datetime bounds
+    # work the same way as passing already-converted (float) bounds.
+    x = np.arange(np.datetime64('2020-01-01'), np.datetime64('2020-01-11'))
+    y = np.arange(10.)
+    xlim = np.array([np.datetime64('2020-01-01'), np.datetime64('2020-01-11')])
+
+    h, xedges, yedges, pc = plt.figure().add_subplot().hist2d(
+        x, y, bins=5, range=[xlim, [0, 10]])
+    assert all(abs(e) < 1e6 for e in (xedges[0], xedges[-1]))
+
+
 class TestScatter:
     @image_comparison(['scatter'], style='mpl20', remove_text=True)
     def test_scatter_plot(self):

--- a/lib/matplotlib/tests/test_axes.py
+++ b/lib/matplotlib/tests/test_axes.py
@@ -2920,34 +2920,43 @@ def test_hist2d_autolimits():
 
 
 def test_hist2d_datetime():
-    # Regression test for gh-17319: hist2d must apply the same unit
-    # conversion to x/y as plot()/scatter() so datetime input lands on the
-    # same (small, date2num-like) numeric scale, instead of raw
-    # nanosecond-scale datetime64 integers.
+    # Regression test for gh-17319: hist2d's returned bin edges for
+    # datetime input should be on the same numeric scale as
+    # matplotlib.dates.date2num (i.e. equivalent to converting the dates
+    # yourself and calling np.histogram2d directly), not raw
+    # (nanosecond-scale) datetime64 integers.
     x = np.arange(np.datetime64('2020-01-01'), np.datetime64('2020-01-11'))
     y = np.arange(10.)
 
-    ax_hist2d = plt.figure().add_subplot()
-    ax_hist2d.hist2d(x, y, bins=5)
+    ax = plt.figure().add_subplot()
+    h, xedges, yedges, pc = ax.hist2d(x, y, bins=5)
 
-    ax_plot = plt.figure().add_subplot()
-    ax_plot.plot(x, y)
-
-    assert ax_hist2d.get_xlim() == ax_plot.get_xlim()
-    # sanity check: this is a small (date2num-like) scale, not raw datetime64
-    assert all(abs(lim) < 1e6 for lim in ax_hist2d.get_xlim())
+    expected_h, expected_xedges, expected_yedges = np.histogram2d(
+        mdates.date2num(x), y, bins=5)
+    np.testing.assert_array_equal(xedges, expected_xedges)
+    np.testing.assert_array_equal(yedges, expected_yedges)
+    np.testing.assert_array_equal(h, expected_h)
 
 
 def test_hist2d_datetime_range():
-    # The `range` parameter should also be converted, so datetime bounds
-    # work the same way as passing already-converted (float) bounds.
+    # The `range` parameter should be converted through the unit converters
+    # just like x/y, so passing datetime bounds is equivalent to manually
+    # converting them (e.g. via `date2num`) and passing the result.
     x = np.arange(np.datetime64('2020-01-01'), np.datetime64('2020-01-11'))
     y = np.arange(10.)
-    xlim = np.array([np.datetime64('2020-01-01'), np.datetime64('2020-01-11')])
+    xlim_datetime = [np.datetime64('2020-01-01'), np.datetime64('2020-01-11')]
+    xlim_converted = mdates.date2num(xlim_datetime)
 
-    h, xedges, yedges, pc = plt.figure().add_subplot().hist2d(
-        x, y, bins=5, range=[xlim, [0, 10]])
-    assert all(abs(e) < 1e6 for e in (xedges[0], xedges[-1]))
+    h_datetime, xedges_datetime, yedges_datetime, _ = (
+        plt.figure().add_subplot().hist2d(
+            x, y, bins=5, range=[xlim_datetime, [0, 10]]))
+    h_converted, xedges_converted, yedges_converted, _ = (
+        plt.figure().add_subplot().hist2d(
+            mdates.date2num(x), y, bins=5, range=[xlim_converted, [0, 10]]))
+
+    np.testing.assert_array_equal(xedges_datetime, xedges_converted)
+    np.testing.assert_array_equal(yedges_datetime, yedges_converted)
+    np.testing.assert_array_equal(h_datetime, h_converted)
 
 
 class TestScatter:


### PR DESCRIPTION
## PR summary

`Axes.hist2d` passes `x` and `y` straight to `np.histogram2d` without running them through the Axes' unit converters first, unlike `plot`, `scatter`, and `hist`. So datetime input to `hist2d` was silently treated as raw values instead of Matplotlib's internal date representation — on current NumPy this now raises a hard `TypeError` (`numpy` no longer silently mixes `datetime64` and `float`), so the bug is very visible, but the same gap also applies to any other unit-aware input (not just dates), and to the `range` argument, which wasn't converted either.

Fix: call `self._process_unit_info(...)` for `x`/`y` at the top of `hist2d`, matching the pattern already used elsewhere in `_axes.py`, and run `range`'s bounds through `convert_xunits`/`convert_yunits` before handing them to `np.histogram2d`.

Closes nothing filed upstream yet — found this while exercising `hist2d` with datetime data and hitting the `TypeError`.

## AI Disclosure

I used an AI coding assistant (Claude Code) to help locate this bug, implement the fix, and write the regression tests and this description. Specifically:
- The assistant found the bug by tracing why `hist2d` failed on datetime input while `hist`/`scatter` on the same data worked, and identified the missing `_process_unit_info` call by comparing against those methods.
- The assistant wrote the fix, the two new tests (`test_hist2d_datetime`, `test_hist2d_datetime_range`), and the API-changes note.
- I reviewed the diff, ran the full `hist2d`-related test suite locally to confirm the fix and no regressions, and I'm responsible for and stand behind this change.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is tested
- [ ] Plotting related features are demonstrated in an example — N/A, this is a bug fix to existing behavior, not a new plotting feature
- [x] New features and API changes have release notes
- [x] Documentation complies with general and docstring guidelines