### PR TITLE
Fix Poly3DCollection ragged padding overflow warnings

### DIFF
--- a/lib/mpl_toolkits/mplot3d/art3d.py
+++ b/lib/mpl_toolkits/mplot3d/art3d.py
@@ -1360,7 +1360,8 @@ class Poly3DCollection(PolyCollection):
             num_faces = len(segments3d)
             num_verts = np.fromiter(map(len, segments3d), dtype=np.intp)
             max_verts = num_verts.max(initial=0)
-            segments = np.empty((num_faces, max_verts, 3))
+            # Pad with NaN so unused entries cannot overflow during projection (#32272).
+            segments = np.full((num_faces, max_verts, 3), np.nan)
             for i, face in enumerate(segments3d):
                 segments[i, :len(face)] = face
             self._faces = segments

--- a/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
+++ b/lib/mpl_toolkits/mplot3d/tests/test_art3d.py
@@ -117,3 +117,19 @@ def test_generate_normals():
     ax = fig.add_subplot(projection='3d')
     ax.add_collection3d(shape)
     plt.draw()
+
+
+def test_poly3dcollection_ragged_padding_no_overflow():
+    # Ragged faces pad to a rectangular array. Padding must not overflow when
+    # projected before _invalid_vertices is applied. See #32272.
+    square = np.zeros((4, 3))
+    triangle = np.zeros((3, 3))
+    collection = Poly3DCollection([square, triangle])
+    assert np.all(np.isnan(collection._faces[collection._invalid_vertices]))
+
+    fig = plt.figure()
+    ax = fig.add_subplot(projection="3d")
+    ax.add_collection(collection, autolim=False)
+    ax.set(xlim=(0, 1), ylim=(0, 1), zlim=(0, 1))
+    with np.errstate(over="raise"):
+        fig.canvas.draw()


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
When `Poly3DCollection` gets polygons with different vertex counts, `_get_vector` packs them into a rectangular array with `np.empty()`. Unused padding is marked in `_invalid_vertices`, but `do_3d_projection` still projects the whole array first. Uninitialized padding can hold huge float values and trigger nondeterministic `RuntimeWarning: overflow encountered in dot`.

This change initializes that padded storage with `np.nan` instead. NaN values do not overflow in the projection math, and `do_3d_projection` already ignores invalid floating point results. A regression test builds a square plus triangle collection, checks that padding is NaN, and draws under `np.errstate(over="raise")`.

Closes #32272

Note: #32279 proposed the same fix earlier and was closed because of the automated-contribution account policy, not because the change itself was wrong.

## AI Disclosure
I used Cursor to help locate the `np.empty` padding path, draft the regression test, and prepare the PR text. I reviewed the code path in `Poly3DCollection._get_vector` / `do_3d_projection`, confirmed why #32279 was closed, and verified the overflow reproduction plus the NaN-padding behavior locally before opening this PR.

## PR quality check
<!-- Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
