### PR TITLE
FIX: keep SVG axes siblings when ending draw with rasterized artists

### DIFF
--- a/lib/matplotlib/backends/backend_mixed.py
+++ b/lib/matplotlib/backends/backend_mixed.py
@@ -68,6 +68,15 @@ class MixedModeRenderer:
         # to the underlying C implementation).
         return getattr(self._renderer, attr)
 
+    def close_group(self, s):
+        # docstring inherited
+        # If rasterizing can be stopped, stop it before closing the group so
+        # the vector backend receives the matching close_group (#32174).
+        if self._raster_depth == 0 and self._rasterizing:
+            self.stop_rasterizing()
+            self._rasterizing = False
+        self._renderer.close_group(s)
+
     def close_blend_group(self):
         # docstring inherited
         # If rasterizing can be stopped, stop it before closing the group

--- a/lib/matplotlib/tests/test_backend_svg.py
+++ b/lib/matplotlib/tests/test_backend_svg.py
@@ -206,6 +206,38 @@ def test_count_bitmaps():
     assert count_tag(fig5, "path") == 1  # axis patch
 
 
+def test_rasterized_zorder_axes_hierarchy():
+    # With rasterized artists ending an Axes draw, MixedModeRenderer must flush
+    # before close_group so SVG axes groups stay siblings (#32174).
+    fig, axs = plt.subplots(ncols=2)
+    for ax in axs:
+        ax.scatter([1, 2], [1, 2], rasterized=True, zorder=10)
+
+    with BytesIO() as fd:
+        fig.savefig(fd, format='svg')
+        buf = fd.getvalue().decode()
+
+    # Strip the default namespace so ElementTree tag matching stays simple.
+    buf = buf.replace(' xmlns="http://www.w3.org/2000/svg"', '', 1)
+    root = xml.etree.ElementTree.fromstring(buf)
+
+    axes_parents = {}
+
+    def walk(elem, axes_ancestor=None):
+        gid = elem.get('id') if elem.tag == 'g' else None
+        next_ancestor = axes_ancestor
+        if gid is not None and gid.startswith('axes_'):
+            axes_parents[gid] = axes_ancestor
+            next_ancestor = gid
+        for child in elem:
+            walk(child, next_ancestor)
+
+    walk(root)
+    assert set(axes_parents) >= {'axes_1', 'axes_2'}
+    assert axes_parents['axes_1'] is None
+    assert axes_parents['axes_2'] is None
+
+
 # Use Computer Modern Sans Serif, not Helvetica (which has no \textwon).
 @mpl.style.context('default')
 @needs_usetex


### PR DESCRIPTION
## PR summary

Closes #32174.

When the last artist drawn in an Axes uses `rasterized=True`, mixed-mode rendering can still be active when `Axes.draw` calls `close_group('axes')`. `MixedModeRenderer` was proxying that call to the Agg raster renderer, where `close_group` is a no-op. The SVG axes group therefore stayed open, so the next axes was nested inside it.

This mirrors the existing `close_blend_group` handling: if rasterization can be stopped (`_raster_depth == 0`), flush to the vector backend before closing the group. Nested `close_group` calls from rasterized artists still run at `_raster_depth > 0`, so consecutive rasterized artists can still merge into one image.

## AI Disclosure

Cursor was used to help locate the mixed-mode grouping bug, implement the flush-before-`close_group` fix, and add the regression test. I reviewed the change and verified the issue reproduction and the fix locally.

## PR quality check

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
