### PR TITLE
Fix TkCairo bug when displaying images with partially transparent pixels

### DIFF
--- a/lib/matplotlib/backends/backend_tkcairo.py
+++ b/lib/matplotlib/backends/backend_tkcairo.py
@@ -1,7 +1,6 @@
-import sys
-
 import numpy as np
 
+from .. import cbook
 from . import _backend_tk
 from .backend_cairo import cairo, FigureCanvasCairo
 from ._backend_tk import _BackendTk, FigureCanvasTk
@@ -14,10 +13,9 @@ class FigureCanvasTkCairo(FigureCanvasCairo, FigureCanvasTk):
         self._renderer.set_context(cairo.Context(surface))
         self._renderer.dpi = self.figure.dpi
         self.figure.draw(self._renderer)
-        buf = np.reshape(surface.get_data(), (height, width, 4))
-        _backend_tk.blit(
-            self._tkphoto, buf,
-            (2, 1, 0, 3) if sys.byteorder == "little" else (1, 2, 3, 0))
+        premult_argb = np.reshape(surface.get_data(), (height, width, 4))
+        unmult_rgba = cbook._premultiplied_argb32_to_unmultiplied_rgba8888(premult_argb)
+        _backend_tk.blit(self._tkphoto, unmult_rgba, (0, 1, 2, 3))
 
 
 @_BackendTk.export

--- a/lib/matplotlib/cbook.py
+++ b/lib/matplotlib/cbook.py
@@ -2210,6 +2210,8 @@ def _premultiplied_argb32_to_unmultiplied_rgba8888(buf):
         [2, 1, 0, 3] if sys.byteorder == "little" else [1, 2, 3, 0], axis=2)
     rgb = rgba[..., :-1]
     alpha = rgba[..., -1]
+    if alpha.min() == 0xff:
+        return rgba
     # Un-premultiply alpha.  The formula is the same as in cairo-png.c.
     mask = alpha != 0
     for channel in np.rollaxis(rgb, -1):


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->

For the `TkCairo` GUI backend, the Cairo image buffer uses premultiplied alpha, and is currently passed directly to Tk for blitting, but Tk (PhotoImage) expects unmultiplied alpha.  Thus, partially transparent pixels – which usually requires making the Figure and Axes patches transparent – are not displayed correctly.  This bug is only in the GUI; saving the image produces the correct output.

This PR uses an existing `cbook` function to convert from premultiplied-space alpha to unmultiplied-alpha space, and also adds a fast bailout path to that function when the image is fully opaque.

### Example
```python
import matplotlib
matplotlib.use('TkCairo')

import matplotlib.pyplot as plt
from matplotlib.patches import Rectangle

fig, ax = plt.subplots()
fig.set_facecolor('none')
ax.set_facecolor('none')
ax.set_axis_off()

# Construct a patch that is 50% transparent
rect1 = Rectangle((0, 0), 1, 0.5, facecolor=(1, 0, 0, 0.5))
ax.add_patch(rect1)
ax.text(0.5, 0.25, 'Test', ha='center', va='center')

# Construct an opaque patch with the expected color when the above is composited with a white backdrop
rect2 = Rectangle((0, 0.5), 1, 0.5, facecolor=(1, 0.5, 0.5, 1))
ax.add_patch(rect2)
ax.text(0.5, 0.75, 'Reference', ha='center', va='center')

plt.show()
```

### Before this PR
<img width="642" height="569" alt="tkcairo before" src="https://github.com/user-attachments/assets/9fbff0eb-3091-44ce-8bda-97c8b936ba2f" />

### After this PR
<img width="642" height="569" alt="tkcairo after" src="https://github.com/user-attachments/assets/b2bf090f-71cc-4592-8263-650345bb8096" />

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->

No AI was used

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
