### PR TITLE
Update ticklabel alignment examples.

### DIFF
--- a/galleries/examples/axisartist/demo_ticklabel_alignment.py
+++ b/galleries/examples/axisartist/demo_ticklabel_alignment.py
@@ -3,6 +3,11 @@
 Ticklabel alignment
 ===================
 
+Because axisartist groups all ticks into a single object, the global alignment
+of the ticks can be set directly.
+
+See also :doc:`/gallery/ticks/align_ticklabels` for some workarounds that can
+be used when working with standard axes.
 """
 
 

--- a/galleries/examples/ticks/align_ticklabels.py
+++ b/galleries/examples/ticks/align_ticklabels.py
@@ -1,14 +1,24 @@
-"""
-=================
-Align tick labels
-=================
+r"""
+==========================
+Left-aligned y tick labels
+==========================
 
 By default, tick labels are aligned towards the axis. This means the set of
-*y* tick labels appear right-aligned. Because the alignment reference point
-is on the axis, left-aligned tick labels would overlap the plotting area.
-To achieve a good-looking left-alignment, you have to additionally increase
-the padding.
+y tick labels appear right-aligned.
+
+To obtain left-aligned y tick labels, a solution is to force their
+horizontal-alignment to "left".  However, because the alignment reference point
+is on the axis, such labels would overlap the plotting area, so the label
+padding needs to be additionally increased.
+
+An alternate solution is to use the mathtext commands ``\rlap`` and
+``\phantom`` to manipulate the widths of the tick labels as seen by Matplotlib.
+See https://www.tug.org/TUGboat/tb22-4/tb72perlS.pdf for a detailed description
+of this approach.
+
+See also :doc:`/gallery/axisartist/demo_ticklabel_alignment`.
 """
+
 import matplotlib.pyplot as plt
 
 population = {
@@ -20,13 +30,34 @@ population = {
     "Shanghai": 21.9,
 }
 
-fig, ax = plt.subplots(layout="constrained")
+fig, axs = plt.subplots(1, 2, layout="constrained")
+
+# First solution: Force the horizontal-alignment of y tick labels to "left",
+# and increase the padding (to a manually chosen value).
+
+ax = axs[0]
 ax.barh(population.keys(), population.values())
 ax.set_xlabel('Population (in millions)')
-
-# left-align all ticklabels
 for ticklabel in ax.get_yticklabels():
     ticklabel.set_horizontalalignment("left")
-
-# increase padding
 ax.tick_params("y", pad=70)
+
+
+# Second solution: Use mathtext to manipulate the width of ylabels as seen
+# by Matplotlib.  Here, \rlap means "draw this text, but don't advance the
+# cursor", whereas \phantom means "advance the cursor by the width of the
+# enclosed text, but without actually drawing the text".  The end result is
+# that the labels get aligned as if "Mexico City" was written every time, but
+# the real labels are actually drawn.
+
+# Note that the widest label ("Mexico City") is still hard-coded here (it is
+# the widest *rendered* label, which is not necessarily the longest label in
+# characters).
+def left_aligned_label(s):
+    return r"$\rlap{\text{%s}}\phantom{\text{Mexico City}}$" % s
+
+ax = axs[1]
+ax.barh([*map(left_aligned_label, population)], population.values())
+ax.set_xlabel('Population (in millions)')
+
+plt.show()


### PR DESCRIPTION
- Cross-reference the two (standard and mpl_toolkits) ticklabel alignment examples.
- The standard example (align_ticklabels) is specifically about left-aligned yticklabels; update the title accordingly.
- Present an alternative solution for left-aligned yticklabels, which should be more robust in practice (the padding needs to be guessed, whereas one can probably more often see what will be the widest string -- if needed, one can probably actually measure it using get_text_width_height_descent, though that would obscure the example here).

<img width="640" height="480" alt="Figure_1" src="https://github.com/user-attachments/assets/876a3d06-b2c8-481a-bd5f-aeced8f34e1a" />
(the new figure: note how the second axes has tighter alignment)

<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->


## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [ ] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
