### PR TITLE
DOC: correct note about PyOS_InputHook

### DIFF
--- a/galleries/users_explain/figure/interactive_guide.rst
+++ b/galleries/users_explain/figure/interactive_guide.rst
@@ -405,17 +405,18 @@ The hook functions typically exhaust all pending events on the GUI
 event queue, run the main loop for a short fixed amount of time, or
 run the event loop until a key is pressed on stdin.
 
-Matplotlib does not currently do any management of :c:data:`PyOS_InputHook` due
-to the wide range of ways that Matplotlib is used.  This management is left to
-downstream libraries -- either user code or the shell.  Interactive figures,
-even with Matplotlib in "interactive mode", may not work in the vanilla python
-repl if an appropriate :c:data:`PyOS_InputHook` is not registered.
+Interactive figures, even with Matplotlib in "interactive mode", may not work
+in REPL if an appropriate :c:data:`PyOS_InputHook` is not registered.  This
+management is left to upstream libraries or downstream code -- either explicit
+user code or shell initialization -- in all backends but the native Mac
+backend.  Input hooks, and helpers to install them, are usually included with
+the Python bindings for GUI toolkits and may be registered on import.  For the
+Mac backend Matplotlib owns the code wrapping the native GUI toolkit and we
+register :c:data:`PyOS_InputHook` on application initialization.
 
-Input hooks, and helpers to install them, are usually included with
-the python bindings for GUI toolkits and may be registered on import.
 IPython also ships input hook functions for all of the GUI frameworks
-Matplotlib supports which can be installed via ``%matplotlib``.  This
-is the recommended method of integrating Matplotlib and a prompt.
+Matplotlib supports which can be installed via ``%matplotlib``.  This is the
+recommended method of integrating Matplotlib and a prompt.
 
 
 IPython / prompt_toolkit

--- a/galleries/users_explain/figure/interactive_guide.rst
+++ b/galleries/users_explain/figure/interactive_guide.rst
@@ -408,11 +408,11 @@ run the event loop until a key is pressed on stdin.
 Interactive figures, even with Matplotlib in "interactive mode", may not work
 in REPL if an appropriate :c:data:`PyOS_InputHook` is not registered.  This
 management is left to upstream libraries or downstream code -- either explicit
-user code or shell initialization -- in all backends but the native Mac
-backend.  Input hooks, and helpers to install them, are usually included with
-the Python bindings for GUI toolkits and may be registered on import.  For the
-Mac backend Matplotlib owns the code wrapping the native GUI toolkit and we
-register :c:data:`PyOS_InputHook` on application initialization.
+user code or shell initialization -- in all toolkits but native macOS.  Input
+hooks, and helpers to install them, are usually included with the Python
+bindings for GUI toolkits and may be registered on import.  For the macOS
+native toolkit Matplotlib owns code that exposes the toolkit to Python and thus
+we register :c:data:`PyOS_InputHook` on GUI application initialization.
 
 IPython also ships input hook functions for all of the GUI frameworks
 Matplotlib supports which can be installed via ``%matplotlib``.  This is the


### PR DESCRIPTION

## PR summary

closes #32314

Tightens up the language and clarifies we own the mac native GUI bindings.

## AI Disclosure

Typed strictly from my 🧠 .  


## PR quality check


- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [/] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [/] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [/] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
