### PR TITLE
Reset selector state when callbacks raise

### DIFF
--- a/lib/matplotlib/tests/test_widgets.py
+++ b/lib/matplotlib/tests/test_widgets.py
@@ -681,6 +681,20 @@ def test_span_selector_onselect(ax, interactive):
     onselect.assert_called_once()
 
 
+def test_selector_state_is_reset_when_callback_raises(ax):
+    onselect = mock.Mock(side_effect=[RuntimeError, None])
+    tool = widgets.SpanSelector(ax, onselect, 'horizontal')
+
+    with pytest.raises(RuntimeError):
+        click_and_drag(tool, start=(100, 100), end=(150, 100))
+
+    assert tool._eventpress is None
+    assert tool._eventrelease is None
+
+    click_and_drag(tool, start=(100, 100), end=(150, 100))
+    assert tool._selection_completed
+
+
 @pytest.mark.parametrize('ignore_event_outside', [True, False])
 def test_span_selector_ignore_outside(ax, ignore_event_outside):
     onselect = mock.Mock(spec=noop, return_value=None)

--- a/lib/matplotlib/widgets.py
+++ b/lib/matplotlib/widgets.py
@@ -2502,10 +2502,12 @@ class _SelectorWidget(AxesWidget):
         if not self.ignore(event) and self._eventpress:
             event = self._clean_event(event)
             self._eventrelease = event
-            self._release(event)
-            self._eventpress = None
-            self._eventrelease = None
-            self._state.discard('move')
+            try:
+                self._release(event)
+            finally:
+                self._eventpress = None
+                self._eventrelease = None
+                self._state.discard('move')
             return True
         return False
 


### PR DESCRIPTION
## PR summary

Closes #32327.

Selector release handlers clear their internal press and release events in a `finally` block. This keeps a selector usable after an `onselect` or related callback raises an exception, while preserving the original exception for the caller.

## AI Disclosure

This PR was prepared with Codex. I reviewed the implementation, test, and final description.

## PR quality check

- [x] Use an expressive title
- [x] New and changed code is tested
- [N/A] Plotting related features are demonstrated in an example
- [N/A] New features and API changes have release notes
- [N/A] Documentation complies with general and docstring guidelines
