### PR TITLE
ENH: Parse \limits and \nolimits in mathtext

### DIFF
--- a/doc/release/next_whats_new/mathtext_limits.rst
+++ b/doc/release/next_whats_new/mathtext_limits.rst
@@ -1,0 +1,12 @@
+``\limits`` and ``\nolimits`` in mathtext
+-----------------------------------------
+Mathtext now parses the ``\limits`` and ``\nolimits`` commands.  They control
+whether the sub- and superscripts of the preceding operator are placed directly
+above and below it, or to its side:
+
+- ``\limits`` forces over/under placement, e.g. ``$\int\limits_a^b$`` renders
+  the bounds above and below the integral sign.
+- ``\nolimits`` forces side placement, e.g. ``$\sum\nolimits_i^n$`` renders the
+  bounds to the right of the summation sign.
+
+Previously these commands raised a parse error.

--- a/galleries/users_explain/text/mathtext.py
+++ b/galleries/users_explain/text/mathtext.py
@@ -101,6 +101,15 @@ fig.text(.1, .1, r'even: $ \delta $ = $ \$4 $')
 #
 #     \sum_{i=0}^\infty x_i
 #
+# You can override the default placement with ``\limits`` (force under/over) and
+# ``\nolimits`` (force to the side) directly after the operator::
+#
+#     r'$\int\limits_0^\infty x_i \quad \sum\nolimits_{i=0}^\infty x_i$'
+#
+# .. math::
+#
+#     \int\limits_0^\infty x_i \quad \sum\nolimits_{i=0}^\infty x_i
+#
 # Fractions, binomials, and stacked numbers
 # -----------------------------------------
 # Fractions, binomials, and stacked numbers can be created with the

--- a/lib/matplotlib/_mathtext.py
+++ b/lib/matplotlib/_mathtext.py
@@ -2267,12 +2267,18 @@ class Parser:
                                        content=Group(OneOrMore(p.token)) +
                                        ZeroOrMore(Literal("\\\\").suppress()))("parts"))
 
+        # \limits and \nolimits force (resp. forbid) the sub/superscripts of the
+        # preceding operator to be placed above/below rather than to the side.
+        p.limits = Regex(r"\\(?:no)?limits(?![A-Za-z])")("limits")
+
         p.subsuper = (
             (Optional(p.placeable)("nucleus")
+             + Optional(p.limits)
              + OneOrMore(one_of(["_", "^"]) - p.placeable)("subsuper")
              + Regex("'*")("apostrophes"))
             | Regex("'+")("apostrophes")
-            | (p.named_placeable("nucleus") + Regex("'*")("apostrophes"))
+            | (p.named_placeable("nucleus")
+               + Optional(p.limits) + Regex("'*")("apostrophes"))
         )
 
         p.simple = p.space | p.customspace | p.font | p.subsuper
@@ -2627,6 +2633,7 @@ class Parser:
         nucleus = toks.get("nucleus", Hbox(0))
         subsuper = toks.get("subsuper", [])
         napostrophes = len(toks.get("apostrophes", []))
+        limits = toks.get("limits")
 
         if not subsuper and not napostrophes:
             return nucleus
@@ -2662,8 +2669,15 @@ class Parser:
             super.kern()
             super.hpack()
 
-        # Handle over/under symbols, such as sum or prod
-        if self.is_overunder(nucleus):
+        # Handle over/under symbols, such as sum or prod.  \limits and
+        # \nolimits override the default placement for the nucleus.
+        if limits == r"\limits":
+            overunder = True
+        elif limits == r"\nolimits":
+            overunder = False
+        else:
+            overunder = self.is_overunder(nucleus)
+        if overunder:
             vlist = []
             shift = 0.
             width = nucleus.width

--- a/lib/matplotlib/tests/test_mathtext.py
+++ b/lib/matplotlib/tests/test_mathtext.py
@@ -292,6 +292,23 @@ def test_short_long_accents(fig_test, fig_ref):
         0, .5, "$" + "".join(fr"\{l} a" for l in corresponding_long_accs) + "$")
 
 
+@check_figures_equal()
+def test_limits(fig_test, fig_ref):
+    # \limits forces over/under placement, matching the default for \sum;
+    # \nolimits forces side placement, matching the default for \int.
+    fig_test.text(0.5, 0.5, r"$\sum\limits_a^b x \quad \int\nolimits_a^b x$")
+    fig_ref.text(0.5, 0.5, r"$\sum_a^b x \quad \int_a^b x$")
+
+
+def test_limits_parse():
+    # \limits and \nolimits should parse without error, including with no
+    # following sub/superscript (gh-28051).
+    parser = mathtext.MathTextParser("agg")
+    for expr in [r"$\int\limits_a^b$", r"$\sum\nolimits_i x$",
+                 r"$\lim\limits_{x\to 0} f$", r"$\int\limits$"]:
+        parser.parse(expr)
+
+
 def test_fontinfo():
     fontpath = mpl.font_manager.findfont("DejaVu Sans")
     font = mpl.ft2font.FT2Font(fontpath)


### PR DESCRIPTION
## PR summary
Closes #28051.

`\limits` and `\nolimits` are TeX commands that control where an operator's sub- and superscripts go: `\limits` places them directly above and below the operator, `\nolimits` places them to the side. mathtext didn't parse them at all, so `$\int\limits_a^b$` raised `ParseFatalException: Unknown symbol: \limits`.

mathtext already has the over/under layout machinery: it uses it automatically for symbols like `\sum` and `\prod` and for functions like `\lim`. So the missing piece was really just parsing the commands and letting them steer that existing decision. I added `\limits`/`\nolimits` to the `subsuper` grammar rule and made the parse action honor them: `\limits` forces over/under placement of the nucleus, `\nolimits` forces side placement, and otherwise the default (`is_overunder`) behavior is unchanged. Both commands also parse when no sub/superscript follows (e.g. `$\int\limits$`), matching TeX's leniency.

Because the over/under path is reused, the visual results line up with the existing defaults: `\sum\limits_a^b` renders identically to a plain `\sum_a^b`, and `\int\nolimits_a^b` renders identically to a plain `\int_a^b`. I leaned on that for testing: a `check_figures_equal` test asserts both equalities, so no new baseline images are needed. There's also a parse-only test covering the commands, including the no-subscript case.

## AI Disclosure
I used Claude Code to navigate the mathtext parser and locate the `subsuper` grammar rule and its parse action. I decided on the approach, reuse the existing over/under machinery and let `\limits`/`\nolimits` override the placement, and reviewed and directed the edits and tests. My environment can't do a full FreeType build, so instead of running the image-comparison suite I verified behavior by loading the modified parser against an installed matplotlib: I confirmed the issue's example and other cases now parse, that all existing mathtext test expressions still parse (no regression), and that `\sum\limits`/`\int\nolimits` render pixel-identically to their plain-operator equivalents (which is what the new `check_figures_equal` test relies on).

- [x] Use an expressive title
- [x] New and changed code is tested: a new `check_figures_equal` test (`test_limits`) and a parse test (`test_limits_parse`). No new baseline images are required because the test compares against the existing default layouts.
- [ ] N/A: no new plotting feature to demonstrate in a gallery example.
- [x] New feature documented: an entry in the subscripts/superscripts section of the mathtext user guide and a `doc/release/next_whats_new/` note.
- [ ] N/A: no other documentation changes needed.
