### PR TITLE
ci: Skip Python 3.15 for Pyodide builds

### DIFF
--- a/.github/workflows/wasm.yml
+++ b/.github/workflows/wasm.yml
@@ -47,6 +47,7 @@ jobs:
       - name: Build wheels for wasm
         uses: pypa/cibuildwheel@1828c10ab37f080699c7b81cea34097c684a7074  # v4.2.0
         env:
+          CIBW_SKIP: "cp315-*"
           CIBW_PLATFORM: "pyodide"
           CIBW_TEST_COMMAND: "true"
 


### PR DESCRIPTION
## PR summary

It seems Pyodide no longer ships its own wheels for Python 3.15, presumably because PyPI now supports WASM wheels and it's expected for upstreams to release them.

Unfortunately, our upstreams (at least contourpy and kiwisolver) don't yet have those wheels, so our wasm build fails and we haven't been uploading nightlies for the past few days.

We can revert this when they are available.

## AI Disclosure
None

## PR quality check
- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [n/a] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [n/a] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [n/a] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
