### PR TITLE
Run agentscan if first-contribution left a comment

### DIFF
--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -54,7 +54,7 @@ jobs:
           issue-opened-msg: ""
       - name: Run agentscan if first-contribution left a comment
         if: "${{ steps.first-contribution.outputs.comment-url != '' }}"
-        uses: MatteoGabriele/agentscan-action@c7d61446e7aece6bdd3edcee4558bbfc0392615e  # v2.5.0
+        uses: MatteoGabriele/agentscan-action@8112fb79b33fafb8506159df20129a34209ac410  # v2.5.0
         with:
           mode: labels
           scan-pull-requests: true

--- a/.github/workflows/pr_welcome.yml
+++ b/.github/workflows/pr_welcome.yml
@@ -15,8 +15,10 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
+      contents: read
     steps:
-      - uses: plbstl/first-contribution@2c36bdb58684587f60549a69aaa3ec00b9d5f4fe  # v4.3.3
+      - id: first-contribution
+        uses: plbstl/first-contribution@2c36bdb58684587f60549a69aaa3ec00b9d5f4fe  # v4.3.3
         with:
           labels: first-contribution
           skip-internal-contributors: false
@@ -50,3 +52,16 @@ jobs:
             [Code of
             Conduct](https://github.com/matplotlib/matplotlib/blob/main/CODE_OF_CONDUCT.md).
           issue-opened-msg: ""
+      - name: Run agentscan if first-contribution left a comment
+        if: "${{ steps.first-contribution.outputs.comment-url != '' }}"
+        uses: MatteoGabriele/agentscan-action@c7d61446e7aece6bdd3edcee4558bbfc0392615e  # v2.5.0
+        with:
+          mode: labels
+          scan-pull-requests: true
+          scan-issues: true
+          allowed-users: "meeseeksmachine"
+          label-mixed: "automation: mixed"
+          label-automated: "automation: automated"
+          label-community-flagged: "automation: flagged"
+          auto-close: false
+          honeypot: false


### PR DESCRIPTION
## PR summary

This PR adds an additional step to the "PR Greetings" workflow: if [first-contribution](https://github.com/plbstl/first-contribution) leaves a comment, we then run [agentscan](https://github.com/MatteoGabriele/agentscan-action) and potentially add a label.

| AgentScan Result | Label |
|-|-|
| Organic | *None* |
| Mixed | `automation: mixed` |
| Automated | `automation: automated` |
| Community Flagged | `automation: flagged` |


### What is agentscan?

AgentScan is a [website](https://agentscan.tools), [GitHub action](https://github.com/MatteoGabriele/agentscan-action), and [GitHub app](https://github.com/apps/agentscanapp) that uses [identity](https://github.com/unveil-project/identity) to figure out automation patterns. See [https://agentscan.tools/adopters](https://agentscan.tools/adopters) for a list of other projects using it (notably: [node.js](https://github.com/nodejs/node)).

I found the website a few days ago and have been reviewing previously-closed PRs with it. It seems to do a very good job of detecting automated activity. The website provides graphs of authors' recent history.


### Approach

My first idea was to make a new workflow that would run when the `first-contributor` label was applied. Based on yesterday's meeting comments regarding the PR Template checker, I'm not sure if this will work.

Instead, I check the `comment-url` output of the `first-contribution` action. This should be an empty string if no comment was left. This adds an additional `contents: read` permission to the job that `first-contribution` doesn't need. I'm not sure if there is a better way to isolate permissions.

Only labels are added to help triage. While agentscan has other features, I didn't want it to automatically close PRs or make comments.

This is my first time using GitHub workflows, I probably made mistakes. **Please scrutinize.**

### Open questions for discussion:

- Do we want to do this at all?
- Should we only add a label for "automated" and not "mixed"?
- Should we change the label names?

### Follow-up Work

If this is approved, we will need to add the corresponding GitHub labels prior to merging.


## AI Disclosure

- I used AI to help me figure out the exact YAML syntax to use.
- All of the individual settings were chosen by me after reading through the agentscan documentation.


## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [X] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) *I could not figure out a good way to test this*
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
