### PR TITLE
ENH: AnchoredOffsetbox for (Sub)Figures

### DIFF
--- a/doc/release/next_whats_new/fig_anchored_offsetbox.rst
+++ b/doc/release/next_whats_new/fig_anchored_offsetbox.rst
@@ -1,0 +1,32 @@
+``AnchoredOffsetbox`` and ``AnchoredText`` for ``Figure`` and ``SubFigure``
+---------------------------------------------------------------------------
+
+The `.AnchoredOffsetbox` and `.AnchoredText` artists may now be directly added to a
+`.Figure` or `.SubFigure` and by default will be anchored relative to their parent
+``(Sub)Figure``.
+
+
+.. plot::
+    :include-source: true
+    :alt: The left half of the figure contains two text boxes with black outlines.  One in the top left of the figure reads "Anchored to Figure".  One at the bottom and to the left the vertical center line reads "Anchored to SubFigure".  A third box containing a blue circle is halfway up and to the right of the vertical center line.
+
+    import matplotlib.pyplot as plt
+    import matplotlib.patches as mpatches
+    from matplotlib.offsetbox import AnchoredText, AnchoredOffsetbox, DrawingArea
+
+    fig = plt.figure()
+
+    sfig1, sfig2 = fig.subfigures(ncols=2)
+    sfig1.set_facecolor("lemonchiffon")
+    sfig2.set_facecolor("lightcyan")
+
+    fig_text = AnchoredText("Anchored to Figure", loc="upper left")
+    fig.add_artist(fig_text)
+
+    sfig_text = AnchoredText("Anchored to SubFigure", loc="lower right")
+    sfig1.add_artist(sfig_text)
+
+    area = DrawingArea(width=30, height=30)
+    area.add_artist(mpatches.Circle((15, 15), 15, fc="tab:blue"))
+    box = AnchoredOffsetbox(child=area, loc="center left")
+    sfig2.add_artist(box)

--- a/galleries/examples/misc/anchored_artists.py
+++ b/galleries/examples/misc/anchored_artists.py
@@ -22,12 +22,12 @@ from matplotlib.offsetbox import (AnchoredOffsetbox, AuxTransformBox, DrawingAre
 from matplotlib.patches import Circle, Ellipse
 
 
-def draw_text(ax):
+def draw_text(fig):
     """Draw a text-box anchored to the upper-left corner of the figure."""
     box = AnchoredOffsetbox(child=TextArea("Figure 1a"),
                             loc="upper left", frameon=True)
     box.patch.set_boxstyle("round,pad=0.,rounding_size=0.2")
-    ax.add_artist(box)
+    fig.add_artist(box)
 
 
 def draw_circles(ax):
@@ -68,7 +68,7 @@ def draw_sizebar(ax):
 fig, ax = plt.subplots()
 ax.set_aspect(1)
 
-draw_text(ax)
+draw_text(fig)
 draw_circles(ax)
 draw_ellipse(ax)
 draw_sizebar(ax)

--- a/lib/matplotlib/offsetbox.py
+++ b/lib/matplotlib/offsetbox.py
@@ -909,10 +909,14 @@ class AnchoredOffsetbox(OffsetBox):
     """
     An OffsetBox placed according to location *loc*.
 
-    AnchoredOffsetbox has a single child.  When multiple children are needed,
-    use an extra OffsetBox to enclose them.  By default, the offset box is
-    anchored against its parent Axes. You may explicitly specify the
-    *bbox_to_anchor*.
+    AnchoredOffsetbox has a single child.  When multiple children are needed, use an
+    extra OffsetBox to enclose them.  By default, the offset box is anchored against its
+    parent Axes, SubFigure or Figure. You may explicitly specify the *bbox_to_anchor*.
+
+    .. versionadded:: 3.12
+       `.AnchoredOffsetbox` can now be added directly to a `.Figure` or `.SubFigure`,
+       and will by default be anchored to that parent.
+
     """
     zorder = 5  # zorder of the legend
 
@@ -1024,7 +1028,8 @@ class AnchoredOffsetbox(OffsetBox):
     def get_bbox_to_anchor(self):
         """Return the bbox that the box is anchored to."""
         if self._bbox_to_anchor is None:
-            return self.axes.bbox
+            return (self.axes.bbox if self.axes is not None else
+                    self.get_figure(root=False).bbox)
         else:
             transform = self._bbox_to_anchor_transform
             if transform is None:

--- a/lib/matplotlib/tests/test_offsetbox.py
+++ b/lib/matplotlib/tests/test_offsetbox.py
@@ -507,3 +507,26 @@ def test_anchored_offsetbox_tuple_and_float_borderpad():
     # in the y-direction.
     assert pos_tuple_asym.x0 > pos_float.x0
     assert pos_tuple_asym.y0 < pos_float.y0
+
+
+def test_figure_anchored_offsetbox():
+    fig = plt.figure()
+    sfig1, _ = fig.subfigures(ncols=2)
+
+    box1 = AnchoredText("wibble", loc="upper left", borderpad=0)
+    fig.add_artist(box1)
+
+    box2 = AnchoredText("meep", loc="lower right", borderpad=0)
+    sfig1.add_artist(box2)
+
+    fig.draw_without_rendering()
+
+    # Upper left of figure
+    tight_bb1 = box1.get_tightbbox()
+    assert tight_bb1.x0 == pytest.approx(0)
+    assert tight_bb1.y1 == pytest.approx(480)
+
+    # lower right of lefthand subfigure
+    tight_bb2 = box2.get_tightbbox()
+    assert tight_bb2.x1 == pytest.approx(320)
+    assert tight_bb2.y0 == pytest.approx(0)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->

## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
Closes #32312 following https://github.com/matplotlib/matplotlib/issues/32312#issuecomment-5570974483.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
None used.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [x] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [x] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [x] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [x] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
