### PR TITLE
Backport PR #32344: TYP: PieContainer does not inherit from Container

### DIFF
--- a/ci/mypy-stubtest-allowlist.txt
+++ b/ci/mypy-stubtest-allowlist.txt
@@ -55,3 +55,6 @@ matplotlib\.animation\.EventSourceProtocol
 # Avoid a regression in NewType handling for stubtest
 # https://github.com/python/mypy/issues/19877
 matplotlib\.ft2font\.GlyphIndexType\.__init__
+
+# getitem method only exists for 3.11 deprecation backcompatability
+matplotlib.container.PieContainer.__getitem__

--- a/lib/matplotlib/container.pyi
+++ b/lib/matplotlib/container.pyi
@@ -53,7 +53,7 @@ class ErrorbarContainer(Container):
         **kwargs
     ) -> None: ...
 
-class PieContainer(Container):
+class PieContainer:
     wedges: list[Wedge]
     def __init__(
         self,
@@ -70,6 +70,7 @@ class PieContainer(Container):
     def add_texts(self,
         texts: list[Text],
     ) -> None: ...
+    def remove(self) -> None: ...
 
 class StemContainer(Container):
     markerline: Line2D


### PR DESCRIPTION
<!-- Thank you for your contribution! -->
<!-- 👉 Please check our development guide https://matplotlib.org/devdocs/devel/index.html -->
<!-- 👉 Tips for pull requests: https://matplotlib.org/devdocs/devel/pr_guide.html#pull-request-guidelines -->


## PR summary
<!-- ✍️ Describe what issue is resolved and why you chose this solution in your own words (no AI please). -->
<!-- 👉 Tip: Use "Closes #0000" to link the related issue -->
Manual backport of #32344.  The conflict was only in the stubtest allowlist, because `main` has an extra entry below the added one.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->
Nope

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [ ] Use an expressive title, e.g. "Fix title font property precedence"
- [ ] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html)
- [ ] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [ ] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [ ] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
