### PR TITLE
Simplify embedding webagg example now that WebSocket is widely supported

### DIFF
--- a/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -121,7 +121,6 @@ class MyApplication(tornado.web.Application):
 
         def get(self):
             manager = self.application.manager
-            ws_uri = f"ws://{self.request.host}/"
             content = html_content % {"fig_id": manager.num}
             self.write(content)
 

--- a/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
+++ b/galleries/examples/user_interfaces/embedding_webagg_sgskip.py
@@ -86,8 +86,7 @@ html_content = """<!DOCTYPE html>
              will use to communicate to the server.  This websocket object can
              also be a "fake" websocket that underneath multiplexes messages
              from multiple figures, if necessary. */
-          var websocket_type = mpl.get_websocket_type();
-          var websocket = new websocket_type("%(ws_uri)sws");
+          var websocket = new WebSocket("/ws");
 
           // mpl.figure creates a new figure on the webpage.
           var fig = new mpl.figure(
@@ -123,8 +122,7 @@ class MyApplication(tornado.web.Application):
         def get(self):
             manager = self.application.manager
             ws_uri = f"ws://{self.request.host}/"
-            content = html_content % {
-                "ws_uri": ws_uri, "fig_id": manager.num}
+            content = html_content % {"fig_id": manager.num}
             self.write(content)
 
     class MplJs(tornado.web.RequestHandler):


### PR DESCRIPTION
## PR summary

All major browsers have [supported websockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSocket/WebSocket#browser_compatibility) for over a decade; at this point I think examples should use it directly without a compatibility wrapper.

Perhaps a bit more controversial, websockets can use relative URLs since about 2024, which avoids the need to template the hostname into the HTML. I think it makes sense to simplify this, since keeping browsers up to date is both good advice and the default, not many people are likely to be using a two-year-old browser.

## AI Disclosure
<!-- ✍️ Describe if and how AI is used. See https://matplotlib.org/devdocs/devel/contribute.html#use-of-generative-ai -->

I have not used any AI.

## PR quality check
<!-- ✍️ Please check the relevant boxes below: "x" to indicate completion, "N/A" if the item is not applicable -->

- [x] Use an expressive title, e.g. "Fix title font property precedence"
- [N/A] New and changed code is [tested](https://matplotlib.org/devdocs/devel/testing.html) -- I have run the example manually with these changes
- [N/A] Plotting related features are demonstrated in an [example](https://matplotlib.org/devdocs/devel/document.html#write-examples-and-tutorials)
- [N/A] New features and API changes have  [release notes](https://matplotlib.org/devdocs/devel/api_changes.html#announce-changes-deprecations-and-new-features)
- [N/A] Documentation complies with [general](https://matplotlib.org/devdocs/devel/document.html#write-rest-pages) and [docstring](https://matplotlib.org/devdocs/devel/document.html#write-docstrings) guidelines
